### PR TITLE
Fix fifth-order Mann mass relation coefficient

### DIFF
--- a/src/exozippy/evolutionary_model/massradius_mann.py
+++ b/src/exozippy/evolutionary_model/massradius_mann.py
@@ -26,14 +26,14 @@ def massradius_mann(ks0, feh=None, distance=None):
         bi = [-0.642, -0.208, -8.43e-4, 7.87e-3, 1.42e-4, -2.13e-4]
         mstar = 10 ** (bi[0] + bi[1] * (ks - zp) + bi[2] * (ks - zp) ** 2 +
                        bi[3] * (ks - zp) ** 3 + bi[4] * (ks - zp) ** 4 + 
-                       bi[4] * (ks - zp) ** 5)
+                       bi[5] * (ks - zp) ** 5)
         sigma_mstar = mstar * 0.020
     else:
         # eq 5, table 6 (n=5)
         bi = [-0.647, -0.207, -6.53e-4, 7.13e-3, 1.84e-4, -1.6e-4, -0.0035]
         mstar = (1.0+feh*bi[6])*10**(bi[0] + bi[1]*(ks - zp) + bi[2]*(ks - zp)**2 +
                                      bi[3]*(ks - zp)**3 + bi[4]*(ks-zp)**4 +
-                                     bi[4]*(ks - zp)**5)
+                                     bi[5]*(ks - zp)**5)
         sigma_mstar = mstar * 0.021
     
     return mstar, rstar, sigma_mstar, sigma_rstar


### PR DESCRIPTION
Hi, this PR fixes the fifth-order coefficient in the Mann et al. 2019 mass relation.

The coefficient array defines `bi[5]` for the fifth-order term, but the current implementation uses `bi[4]` twice:

    ... + bi[4]*(ks-zp)**4 + bi[4]*(ks-zp)**5

This mistake (I presume it's just a typo and not intentional?) occurs at two locations in this particular file. 

I noticed the same bug in the corresponding EXOFASTv2 IDL file. If you want, I can also do a PR there. Just let me know!