### PR TITLE
Fix and extend the transit component

### DIFF
--- a/examples/kelt4rvonly/kelt4.params.yaml
+++ b/examples/kelt4rvonly/kelt4.params.yaml
@@ -19,14 +19,13 @@ star.0.feh:
 orbit.0.period:
   initval: 2.9895933
 orbit.0.tc:
-  initval: 2456190.302013
+  #initval: 2456190.302013
+  initval: 2459634.3
   #init_scale: 0.0055082686
 orbit.0.cosi:
   initval: 0.11996
-  sigma: 0
 planet.0.radius:
   initval: 1.706
-  sigma: 0.0
 rvinstrument.EXPERT.gamma:
   #init_scale: 11.1130411925
 rvinstrument.FIES.gamma:

--- a/examples/kelt4rvonly/kelt4.yaml
+++ b/examples/kelt4rvonly/kelt4.yaml
@@ -1,7 +1,7 @@
 run:
   name: "kelt4"
 
-prefix: "fitresults/KELT-4A"
+prefix: "fitresults2/KELT-4A"
 logger_level: INFO   # DEBUG, INFO, or WARNING
 
 # the order of the components here is the order they are output in the table
@@ -18,14 +18,14 @@ orbit:
   - name: "b"
     bodies : "b" # must match "name" of planets/stars. can be list for heirarchical orbits
 
-#transit:
-#  - name: "TESS S48"
-#    file: "n20220130.TESS.TESS.TIC165297570.S48.0120.SPOC.dat"
-#    filter: "TESS"
-#    exptime: 2.0 # exposure time in minutes
-#    ninterp: 1.0 # number of model points to compute for each data point to account for long cadence smearing. Defaults to 1 point/3 minutes
-#    fitspline: False
-#    splinespace: 0.75
+transit:
+ - name: "TESS_S48"
+   file: "n20220130.TESS.TESS.TIC165297570.S48.0120.SPOC.dat"
+   filter: "TESS"
+   exptime: 2.0 # exposure time in minutes
+   ninterp: 1.0 # number of model points to compute for each data point to account for long cadence smearing. Defaults to 1 point/3 minutes
+   fitspline: False
+   splinespace: 0.75
 
 
 rvinstrument:
@@ -44,13 +44,13 @@ sampler:
   backend: "pymc" # TODO: "affine_invariant", "differential_evolution", "parallel_tempering", "multinest"
   pymc:
     tune: 2000
-    draws: 4000
+    draws: 2000
     chains: 4
     cores: 4
     init: "adapt_diag"
-    target_accept: 0.95
+    target_accept: 0.99
     #nuts_sampler: "pymc" # "numpyro", "blackjax", "nutpie"
     nuts_sampler: "numpyro"
-    check_curvatures: True
+    check_curvatures: False
     recompute_trace: True # if False and an existing prefix.nc file exists, it will load that rather than re-sample
     profile: False

--- a/src/exozippy/components/transit/defaults.yaml
+++ b/src/exozippy/components/transit/defaults.yaml
@@ -10,6 +10,7 @@ transit:
   jitter_variance:
     lower: -1000.0
     upper: 100000.0
+    initval: 0.0
     init_scale: 0.000001
     unit: ""
     internal_unit: ""

--- a/src/exozippy/components/transit/symbolic_physics.py
+++ b/src/exozippy/components/transit/symbolic_physics.py
@@ -1,0 +1,19 @@
+import sympy as sp
+
+baseline = sp.symbols('baseline', real=True)
+jitter = sp.symbols('jitter', real=True)
+jitter_variance = sp.symbols('jittervar', real=True)
+
+def get_symbol_map(config):
+    return {
+        "baseline": "baseline",
+        "jitter": "jitter",
+        "jitter_variance": "jitter_variance",
+    }
+
+RELATIONS = [
+    sp.Eq(jitter_variance, jitter**2)
+]
+
+def get_solver_paths():
+    return RELATIONS

--- a/src/exozippy/components/transit/transit.py
+++ b/src/exozippy/components/transit/transit.py
@@ -1,4 +1,3 @@
-# note, this is an untested, AI generated placeholder
 
 import logging
 import numpy as np
@@ -89,14 +88,65 @@ class Transit(Component):
         # 1. Start with the photometric baseline
         lc_model = self.baseline.value[self.inst_map_tensor]
 
+        # 1b. Per-planet transit/occultation geometry (impact parameter & durations),
+        # exposed as Deterministics for diagnostics and plotting (e.g. phased-plot xlim).
+        ecc_p = orbits.ecc.value[planets.orbit_map]  # (N_planets,)
+        esinw_p = orbits.esinw.value[planets.orbit_map]
+        inc_p = orbits.inc.value[planets.orbit_map]
+        period_p = orbits.period.value[planets.orbit_map]
+        ar_p = planets.ar.value
+        p_p = planets.p.value
+
+        # Numerical-stability floor for the geometry below. Keeps arcsin arguments
+        # strictly inside (-1, 1) (where its derivative is finite) and denominators
+        # away from 0, so a transient excursion during NUTS leapfrog steps (e.g.
+        # inc away from 90 deg, or ecc/esinw near 1) can't produce a NaN/inf
+        # gradient. Values at the actual posterior mode are far from these floors,
+        # so the reported b/t14/tau are unaffected.
+        _GEOM_EPS = 1e-6
+
+        sini_p = pt.sin(inc_p)
+        cosi_p = pt.cos(inc_p)
+        ecc_factor = pt.sqrt(pt.clip(1.0 - pt.sqr(ecc_p), _GEOM_EPS, 1.0))
+
+        denom_minus = pt.clip(1.0 - esinw_p, _GEOM_EPS, np.inf)
+        denom_plus = pt.clip(1.0 + esinw_p, _GEOM_EPS, np.inf)
+        sini_ar = pt.clip(pt.abs(sini_p * ar_p), _GEOM_EPS, np.inf)
+
+        dur_b = ar_p * cosi_p * (1.0 - pt.sqr(ecc_p)) / denom_minus
+        dur_bs = ar_p * cosi_p * (1.0 - pt.sqr(ecc_p)) / denom_plus
+
+        def _arcsin_term(p_offset_sq, dur_bx):
+            radicand = pt.clip(p_offset_sq - pt.sqr(dur_bx), 0.0, np.inf)
+            arg = pt.clip(pt.sqrt(radicand) / sini_ar, -1.0 + _GEOM_EPS, 1.0 - _GEOM_EPS)
+            return pt.arcsin(arg)
+
+        dur_t14 = (period_p / np.pi) * _arcsin_term(pt.sqr(1.0 + p_p), dur_b) * ecc_factor / denom_minus
+        dur_t14s = (period_p / np.pi) * _arcsin_term(pt.sqr(1.0 + p_p), dur_bs) * ecc_factor / denom_plus
+
+        dur_tfwhm = (period_p / np.pi) * _arcsin_term(pt.sqr(1.0 - p_p), dur_b) * ecc_factor / denom_minus
+        dur_tfwhms = (period_p / np.pi) * _arcsin_term(pt.sqr(1.0 - p_p), dur_bs) * ecc_factor / denom_plus
+
+        dur_tau = (dur_t14 - dur_tfwhm) / 2.0
+        dur_taus = (dur_t14s - dur_tfwhms) / 2.0
+
+        pm.Deterministic(f"{self.prefix}.b", dur_b)
+        pm.Deterministic(f"{self.prefix}.bs", dur_bs)
+        pm.Deterministic(f"{self.prefix}.t14", dur_t14)
+        pm.Deterministic(f"{self.prefix}.t14s", dur_t14s)
+        pm.Deterministic(f"{self.prefix}.tfwhm", dur_tfwhm)
+        pm.Deterministic(f"{self.prefix}.tfwhms", dur_tfwhms)
+        pm.Deterministic(f"{self.prefix}.tau", dur_tau)
+        pm.Deterministic(f"{self.prefix}.taus", dur_taus)
+
         # 2. Orbital Geometry Broadcast
         t_grid = time[:, None]  # (N_obs, 1)
         tp = orbits.tp.value[planets.orbit_map][None, :]  # (1, N_planets)
         n = orbits.n.value[planets.orbit_map][None, :]
-        ecc = orbits.ecc.value[planets.orbit_map][None, :]
+        ecc = ecc_p[None, :]
         cosw = orbits.cosw.value[planets.orbit_map][None, :]
         sinw = orbits.sinw.value[planets.orbit_map][None, :]
-        inc = orbits.inc.value[planets.orbit_map][None, :]
+        inc = inc_p[None, :]
 
         M = (t_grid - tp) * n
         sinf, cosf = ops.kepler(M, ecc + pt.zeros_like(M))
@@ -223,7 +273,7 @@ class Transit(Component):
 
     def plot(self, system, points, filename_prefix="debug"):
         self.plot_unphased(system, points, filename_prefix=filename_prefix)
-        # Add a call to self.plot_phased(...) here when you are ready
+        self.plot_phased(system, points, filename_prefix=filename_prefix)
 
     def plot_unphased(self, system, points, filename_prefix="debug"):
         if isinstance(points, dict): points = [points]
@@ -265,3 +315,79 @@ class Transit(Component):
             plt.tight_layout()
             plt.savefig(f"{filename_prefix}_LC_unphased_{self.names[i]}.pdf")
             plt.close()
+
+    def plot_phased(self, system, points, filename_prefix="debug"):
+        planets = system.planet
+        if isinstance(points, dict): points = [points]
+
+        for p_idx in range(planets.n_elements):
+
+            for i in range(self.n_elements):
+                plt.figure(figsize=(10, 6))
+
+                # 1. Spaghetti models
+                for point in points:
+                    ref_point = point
+                    P_ref = float(np.atleast_1d(ref_point.get(system.orbit.period.label))[p_idx])
+                    tc_ref = float(np.atleast_1d(ref_point.get(system.orbit.tc.label))[p_idx])
+
+                    # One-period model grid; phase in [-0.5, 0.5] with transit centred at 0
+                    t_model = np.linspace(tc_ref - 0.5 * P_ref, tc_ref + 0.5 * P_ref, 1000).astype(np.float64)
+                    phase_model = ((t_model - tc_ref) / P_ref + 0.5) % 1.0 - 0.5
+                    time_from_center_model = phase_model * P_ref
+                    sort_m = np.argsort(phase_model)
+
+                    param_values = [
+                        float(np.squeeze(np.asarray(point.get(p.label, p.initval)))) if getattr(p.value, "ndim", 0) == 0
+                        else np.atleast_1d(point.get(p.label, p.initval)) for p in system.plot_params
+                    ]
+                    try:
+                        lc_matrix = self._compiled_lc_matrix(t_model, i, *param_values)
+                        y_planet = lc_matrix[:, p_idx]
+                        alpha = 0.8 if len(points) == 1 else 0.1
+                        plt.plot(time_from_center_model[sort_m], y_planet[sort_m], 'r-', alpha=alpha, lw=1, zorder=2)
+                    except Exception as e:
+                        logger.warning(f"LC phased model eval failed: {e}")
+                        continue
+
+                # 2. Clean and phase the data
+                mask = (self.inst_map == i)
+                clean_params = [
+                    float(np.squeeze(np.asarray(ref_point.get(p.label, p.initval)))) if getattr(p.value, "ndim", 0) == 0
+                    else np.atleast_1d(ref_point.get(p.label, p.initval)) for p in system.plot_params
+                ]
+                try:
+                    data_lc_matrix = self._compiled_lc_matrix(self.time[mask], i, *clean_params)
+                except Exception as e:
+                    logger.warning(f"LC phased data eval failed: {e}")
+                    plt.close()
+                    continue
+
+                base_vals = np.atleast_1d(ref_point.get(self.baseline.label, 1.0))
+                baseline = float(base_vals[i])
+
+                # Subtract baseline and other planets' contributions to isolate p_idx
+                other_mask = np.ones(planets.n_elements, dtype=bool)
+                other_mask[p_idx] = False
+                other_decrements = np.sum(data_lc_matrix[:, other_mask], axis=1)
+
+                cleaned_flux = self.flux[mask] - baseline - other_decrements
+                data_phases = ((self.time[mask] - tc_ref) / P_ref + 0.5) % 1.0 - 0.5
+                time_from_center_data = data_phases * P_ref
+
+                plt.errorbar(time_from_center_data, cleaned_flux, yerr=self.err[mask],
+                             fmt='k.', alpha=0.5, zorder=1, label=self.names[i])
+
+                t14_raw = ref_point.get(f"{self.prefix}.t14")
+                if t14_raw is not None:
+                    t14_ref = float(np.atleast_1d(t14_raw)[p_idx])
+                    plt.xlim(-t14_ref, t14_ref)
+
+                plt.axhline(0, color='gray', linestyle=':', alpha=0.5)
+                plt.xlabel(f"Time from Mid-Transit [d] (P = {P_ref:.5f} d)")
+                plt.ylabel("Flux − Baseline")
+                plt.title(f"Phased LC: {planets.names[p_idx]} — {self.names[i]}")
+                plt.legend(loc='best', fontsize='small')
+                plt.tight_layout()
+                plt.savefig(f"{filename_prefix}_LC_phased_{self.names[i]}_{planets.names[p_idx]}.pdf")
+                plt.close()

--- a/src/exozippy/components/transit/transit.py
+++ b/src/exozippy/components/transit/transit.py
@@ -4,6 +4,8 @@ import logging
 import numpy as np
 import pandas as pd
 import pymc as pm
+import pytensor
+import matplotlib.pyplot as plt
 
 logger = logging.getLogger(__name__)
 import pytensor.tensor as pt
@@ -89,12 +91,12 @@ class Transit(Component):
 
         # 2. Orbital Geometry Broadcast
         t_grid = time[:, None]  # (N_obs, 1)
-        tp = orbits.tp.value[system.orbit_map][None, :]  # (1, N_planets)
-        n = orbits.n.value[system.orbit_map][None, :]
-        ecc = orbits.ecc.value[system.orbit_map][None, :]
-        cosw = orbits.cosw.value[system.orbit_map][None, :]
-        sinw = orbits.sinw.value[system.orbit_map][None, :]
-        inc = orbits.inc.value[system.orbit_map][None, :]
+        tp = orbits.tp.value[planets.orbit_map][None, :]  # (1, N_planets)
+        n = orbits.n.value[planets.orbit_map][None, :]
+        ecc = orbits.ecc.value[planets.orbit_map][None, :]
+        cosw = orbits.cosw.value[planets.orbit_map][None, :]
+        sinw = orbits.sinw.value[planets.orbit_map][None, :]
+        inc = orbits.inc.value[planets.orbit_map][None, :]
 
         M = (t_grid - tp) * n
         sinf, cosf = ops.kepler(M, ecc + pt.zeros_like(M))
@@ -112,20 +114,38 @@ class Transit(Component):
         b = pt.sqrt(pt.sqr(r_norm * cos_wf) + pt.sqr(r_norm * sin_wf * cos_i))
         Z = r_norm * sin_wf * sin_i
 
-        # 3. Limb Darkening Setup
-        u1_mapped = self.u1.value[self.inst_map_tensor]
-        u2_mapped = self.u2.value[self.inst_map_tensor]
-        u_stack = pt.stack([u1_mapped, u2_mapped], axis=0)  # Shape (2, N_obs)
+        # 3. Limb Darkening Setup (per observation, mapped from per-instrument values)
+        u1_mapped = self.u1.value[self.inst_map_tensor]  # (N_obs,)
+        u2_mapped = self.u2.value[self.inst_map_tensor]  # (N_obs,)
+        # Normalisation: integral of the quadratic LD law over the projected stellar disk.
+        # With basis c = [1-u1-u2, u1, u2] and s_off = [π, 2π/3, 0]:
+        #   norm = dot(s_off, c) = π*(1-u1-u2) + (2π/3)*u1
+        ld_norm = np.pi * (1.0 - u1_mapped - u2_mapped) + (2.0 * np.pi / 3.0) * u1_mapped
 
         # 4. Exoplanet-core Transit Model
         for p_idx in range(planets.n_elements):
-            b_p = b[:, p_idx]
-            p_ratio_p = p_ratio[:, p_idx]
-            Z_p = Z[:, p_idx]
+            b_p = b[:, p_idx]  # (N_obs,) sky-plane separation in units of R_*
+            Z_p = Z[:, p_idx]  # (N_obs,) line-of-sight coord (+ = planet in front of star)
+            r_p = planets.p.value[p_idx]  # scalar R_p/R_*
 
-            decrement = ops.quad_limb_dark(u_stack, b_p, p_ratio_p)
-            decrement = pt.where(Z_p > 0, decrement, 0.0)  # Hide secondary eclipses
-            lc_model += decrement
+            # quad_solution_vector(b, r) -> (N_obs, 3) solution vector s.
+            # Broadcast scalar r_p to (N_obs,) following the ops.kepler() pattern.
+            sol = ops.quad_solution_vector(b_p, r_p + pt.zeros_like(b_p))
+
+            # Limb-darkened flux fraction: 1.0 off-disk, <1.0 during transit.
+            # Formula verified numerically: lc = dot(s, c) / dot(s_off, c)
+            flux_frac = (
+                sol[:, 0] * (1.0 - u1_mapped - u2_mapped) +
+                sol[:, 1] * u1_mapped +
+                sol[:, 2] * u2_mapped
+            ) / ld_norm
+
+            # Fraction of stellar flux blocked (0 off-disk, ≈ r² at disk centre)
+            blocked = 1.0 - flux_frac
+
+            # Primary transit only; secondary eclipse (planet behind star) has Z < 0
+            blocked = pt.where(Z_p > 0.0, blocked, 0.0)
+            lc_model = lc_model - blocked
 
         if self.total_detrend_cols > 0:
             detrend = pm.Data("transit_detrend", self.detrend_matrix)
@@ -146,12 +166,12 @@ class Transit(Component):
 
         if planets is not None and orbits is not None:
             t_grid = t_input[:, None]
-            tp = orbits.tp.value[system.orbit_map][None, :]
-            n = orbits.n.value[system.orbit_map][None, :]
-            ecc = orbits.ecc.value[system.orbit_map][None, :]
-            cosw = orbits.cosw.value[system.orbit_map][None, :]
-            sinw = orbits.sinw.value[system.orbit_map][None, :]
-            inc = orbits.inc.value[system.orbit_map][None, :]
+            tp = orbits.tp.value[planets.orbit_map][None, :]
+            n = orbits.n.value[planets.orbit_map][None, :]
+            ecc = orbits.ecc.value[planets.orbit_map][None, :]
+            cosw = orbits.cosw.value[planets.orbit_map][None, :]
+            sinw = orbits.sinw.value[planets.orbit_map][None, :]
+            inc = orbits.inc.value[planets.orbit_map][None, :]
 
             M = (t_grid - tp) * n
             sinf, cosf = ops.kepler(M, ecc + pt.zeros_like(M))
@@ -168,19 +188,25 @@ class Transit(Component):
             b = pt.sqrt(pt.sqr(r_norm * cos_wf) + pt.sqr(r_norm * sin_wf * cos_i))
             Z = r_norm * sin_wf * sin_i
 
-            # Broadcast limb darkening to (2, 1) to match (N_times,) impact parameters
-            u1_inst = self.u1.value[inst_idx]
+            u1_inst = self.u1.value[inst_idx]  # scalar for this instrument
             u2_inst = self.u2.value[inst_idx]
-            u_stack = pt.stack([u1_inst, u2_inst], axis=0)[:, None]
+            ld_norm_inst = np.pi * (1.0 - u1_inst - u2_inst) + (2.0 * np.pi / 3.0) * u1_inst
 
             decrement_matrix_list = []
             for p_idx in range(planets.n_elements):
-                b_p = b[:, p_idx]
-                p_ratio_p = p_ratio[:, p_idx]
+                b_p = b[:, p_idx]   # (N_times,)
                 Z_p = Z[:, p_idx]
-                decrement = ops.quad_limb_dark(u_stack, b_p, p_ratio_p)
-                decrement = pt.where(Z_p > 0, decrement, 0.0)
-                decrement_matrix_list.append(decrement)
+                r_p = planets.p.value[p_idx]
+
+                sol = ops.quad_solution_vector(b_p, r_p + pt.zeros_like(b_p))
+                flux_frac = (
+                    sol[:, 0] * (1.0 - u1_inst - u2_inst) +
+                    sol[:, 1] * u1_inst +
+                    sol[:, 2] * u2_inst
+                ) / ld_norm_inst
+                # Negative so that _compiled_full_lc output + baseline gives a transit dip
+                blocked = pt.where(Z_p > 0.0, 1.0 - flux_frac, 0.0)
+                decrement_matrix_list.append(-blocked)
 
             lc_matrix = pt.stack(decrement_matrix_list, axis=1)  # (N_times, N_planets)
 


### PR DESCRIPTION
Fixed the transit component; replaced the removed `ops.quad_limb_dark` call with `quad_solution_vector` and fixed a sign error; added a photometric jitter variance term, transit duration Deterministics (t14, tau, b, tfwhm + secondary-eclipse counterparts), and phased light-curve plotting. The fitted values match the published values within ~1.2σ.

Note: orbit.0.cosi is now free (the transit measures it directly), and the kelt4 example carries some local testing settings.