### PR TITLE
CI: bump checkout/setup-python to Node 24 runtimes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Poetry
         run: pipx install poetry
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: poetry


### PR DESCRIPTION
## Summary

CI was warning that the Node.js 20 runtime is deprecated. The two JS-based actions in `tests.yml` run on Node 20:

- `actions/checkout@v4` -> `@v5`
- `actions/setup-python@v5` -> `@v6`

Both bumped major versions run on Node 24, clearing the deprecation warning. No other workflow steps use JS-based actions.

## Test plan

- CI runs on this PR; the deprecation warning should no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G53QppCnhaYZqbJu9yiDX