### PR TITLE
Add the ruff-format reformat to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,10 @@
 
 # Apply black and isort across the tree (176 files).
 536c2da893368f42094cdcf5e4ca940abdd5de89
+
+# Apply ruff format across the tree (49 files), after ruff replaced black and
+# isort. Verified AST-identical across all 192 Python files, and it touches
+# nothing but .py -- the config and docs changes that came with the switch are
+# separate commits, which is why this PR was merged with a merge commit rather
+# than squashed.
+e62f639b71937121772e2a1ae5287faf968b8665


### PR DESCRIPTION
e62f639 reformatted 49 files when ruff replaced black. Without this entry
it becomes the last author of every line it rewrapped.

It qualifies under this file's own rule: it touches only .py files and was
verified AST-identical across all 192 Python files in the tree, so there is
no logic hidden inside it. The config and documentation changes that came
with the switch are separate commits, which is why PR #24 was merged with a
merge commit instead of being squashed -- squashing would have fused them
and made the combined commit ineligible.

Measured effect (git blame --no-ignore-revs vs with):
  config.py     670 -> 46 lines of 2481
  parameter.py  425 -> 56 lines of 1698
  component.py   90 ->  8 lines of 546

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013x7LE4HS2HFJbSrD5tKFvu
