### PR TITLE
CI: test the Python versions and platforms we claim to support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Dependabot opens PRs for out-of-date dependencies. Since master requires a
+# passing `test` check, an update that breaks the suite cannot merge -- the PR
+# just sits there as a visible warning, which is the useful outcome.
+version: 2
+
+updates:
+  # GitHub Actions. This is the one that has already bitten us: the runner
+  # deprecated the Node 20 runtimes and CI started warning until 2832a56
+  # bumped checkout and setup-python by hand. Dependabot would have opened
+  # that PR unprompted.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # One PR for all action bumps rather than three. Actions move together
+      # and are near-always safe.
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "CI"
+
+  # Python dependencies, read from pyproject.toml (dependabot's "pip"
+  # ecosystem understands poetry projects).
+  #
+  # Monthly, not weekly, and grouped. This is a scientific stack -- pymc,
+  # pytensor, numpy, astropy -- where a minor bump can shift numerical results
+  # rather than fail loudly. A slower cadence with fewer, larger PRs means each
+  # one actually gets looked at instead of rubber-stamped.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    groups:
+      python-dependencies:
+        patterns: ["*"]
+        # Majors stay separate: those are the ones that need a human reading
+        # a changelog, not a grouped bump alongside twelve patch releases.
+        update-types: ["minor", "patch"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,52 @@ jobs:
       - name: Run test suite
         run: poetry run pytest -q -n 2
 
+  # Installs WITHOUT poetry.lock, resolving dependencies fresh the way a user's
+  # `pip install exozippy` does.
+  #
+  # Every other job here installs the lock: one exact, frozen dependency set.
+  # That verifies what we SHIP. It does not verify what users RESOLVE, and
+  # those are different artifacts -- pyproject declares ranges ("jax>=0.5.0,
+  # <1.0.0", "nutpie>=0.13.0") that nothing otherwise exercises. This stack is
+  # unusually sensitive to that gap: a pymc/pytensor/numpy minor release can
+  # shift numerical results rather than fail loudly.
+  #
+  # Dependabot does not cover this. It bumps the lock, so it tells us a new
+  # version works with our pins; it never tests a fresh resolution.
+  #
+  # Deliberately NOT in the `test` gate's needs. An upstream project releasing
+  # something incompatible must not turn the required check red and block
+  # merges for a reason that has nothing to do with the pull request. A
+  # failure here fails the workflow run, which is the alarm we want.
+  pytest-latest-deps:
+    name: pytest-latest-deps
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # No poetry, no lock. pip resolves from pyproject's ranges, exactly as a
+      # user installing from PyPI would. The test harness is installed
+      # separately and unpinned -- it lives in poetry's dev GROUP, which never
+      # reaches published metadata, so `pip install .[gui]` cannot bring it in.
+      - name: Install with a fresh resolution
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[gui]"
+          pip install pytest pytest-timeout pytest-xdist httpx
+
+      - name: Show what actually got resolved
+        run: pip freeze
+
+      - name: Run test suite
+        run: pytest -q -n 2
+
   # The stable name the ruleset requires. It exists only to aggregate the
   # matrix into one pass/fail, so the required check never has to be renamed
   # when the matrix changes.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,19 +11,57 @@ on:
   workflow_call:
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
+  # NOTE ON JOB NAMES -- read before renaming anything here.
+  #
+  # The branch ruleset requires a status check literally named `test`, and
+  # there are no bypass actors, so if nothing ever reports that name then
+  # NOTHING CAN EVER MERGE, including the PR that would fix it.
+  #
+  # A matrix job does not report its own id: it reports one check per
+  # combination, named `pytest (ubuntu-latest, 3.12)` and so on. That is why
+  # the matrix below is called `pytest` and the aggregating gate job at the
+  # bottom is called `test` -- the required name stays stable no matter how
+  # the matrix grows or shrinks.
+  pytest:
+    name: pytest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      # Do not cancel the other combinations when one fails. When a new Python
+      # breaks something, "3.14 failed and everything else was cancelled" tells
+      # you much less than seeing which combinations passed.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.12", "3.13", "3.14"]
+        include:
+          # CONTRIBUTING documents a macOS setup and this history has commits
+          # from a Windows machine, so ubuntu-only coverage was a blind spot
+          # for a stack that compiles C through PyTensor and BLAS. One
+          # combination each catches platform breakage without paying for the
+          # full 3x3 cross product.
+          #
+          # Windows is the one most likely to need work: PyTensor's C backend
+          # wants a compiler it can find, and the usual Windows answer is the
+          # m2w64 toolchain rather than the MSVC the runner ships with. If it
+          # fails, the useful options are to fix the toolchain setup or to drop
+          # Windows from the matrix -- NOT to add continue-on-error, which
+          # turns a real signal into decoration nobody reads.
+          - os: macos-latest
+            python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.12"
+
     steps:
       - uses: actions/checkout@v5
 
       - name: Install Poetry
         run: pipx install poetry
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: poetry
 
       # --extras gui is required, not polish: ruamel-yaml lives in that extra,
@@ -42,3 +80,21 @@ jobs:
       # and vanished entirely on others. That is a memory ceiling, not a bug.
       - name: Run test suite
         run: poetry run pytest -q -n 2
+
+  # The stable name the ruleset requires. It exists only to aggregate the
+  # matrix into one pass/fail, so the required check never has to be renamed
+  # when the matrix changes.
+  #
+  # `if: always()` is load-bearing. Without it this job is skipped when any
+  # matrix combination fails, and a skipped required check reads as neutral
+  # rather than failing -- the PR would look mergeable with a red matrix.
+  test:
+    name: test
+    if: always()
+    needs: [pytest]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any matrix combination did not succeed
+        run: |
+          echo "matrix result: ${{ needs.pytest.result }}"
+          test "${{ needs.pytest.result }}" = "success"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,6 +144,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
+    # Scoped to this job, not the workflow. Only this job files issues; nothing
+    # here needs write access to the repository contents.
+    permissions:
+      contents: read
+      issues: write
+
     steps:
       - uses: actions/checkout@v5
 
@@ -161,11 +167,62 @@ jobs:
           pip install ".[gui]"
           pip install pytest pytest-timeout pytest-xdist httpx
 
-      - name: Show what actually got resolved
-        run: pip freeze
+      # Saved to a file, not just echoed: the failure report below quotes it,
+      # and "which versions did it actually pick" is the first question anyone
+      # asks about a resolution failure.
+      - name: Record what actually got resolved
+        run: pip freeze | tee resolved.txt
 
       - name: Run test suite
         run: pytest -q -n 2
+
+      # Email alone is a weak alarm for this job. A nightly that stays broken
+      # for a week sends seven identical emails, which is how an alarm becomes
+      # noise and then becomes invisible. One issue, updated in place, stays
+      # visible to collaborators and has a state that means something: open =
+      # still broken, closed = fixed.
+      #
+      # Uses the preinstalled gh CLI and the automatic GITHUB_TOKEN, so there
+      # is no marketplace action in the supply chain for this.
+      - name: Open or update the tracking issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Nightly: suite fails against freshly resolved dependencies"
+
+          {
+            echo "The nightly unlocked-resolution job failed."
+            echo
+            echo "This job installs with \`pip install \".[gui]\"\` -- no"
+            echo "poetry.lock -- so it reflects what a user gets from PyPI"
+            echo "rather than what we ship. A failure here usually means an"
+            echo "upstream release is incompatible with our declared ranges,"
+            echo "not that anything in this repository changed."
+            echo
+            echo "Run: $RUN_URL"
+            echo
+            echo "<details><summary>Resolved versions</summary>"
+            echo
+            echo '```'
+            # Key packages first; the full list is in the run's logs.
+            grep -iE '^(pymc|pytensor|numpy|scipy|astropy|jax|jaxlib|numpyro|blackjax|nutpie|celerite2|exoplanet-core)' resolved.txt || true
+            echo '```'
+            echo "</details>"
+          } > body.md
+
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+                       --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --body-file body.md
+          else
+            echo "Opening a new issue"
+            gh issue create --title "$TITLE" --body-file body.md
+          fi
 
   # The stable name the ruleset requires. It exists only to aggregate the
   # matrix into one pass/fail, so the required check never has to be renamed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Nightly, so the slow Windows job still runs regularly without sitting in
+  # front of every pull request.
+  schedule:
+    - cron: "0 7 * * *"
   workflow_dispatch:
   # Callable from publish.yml so a release runs exactly this suite, rather
   # than a copy of it that drifts out of sync.
@@ -22,10 +26,18 @@ jobs:
   # the matrix below is called `pytest` and the aggregating gate job at the
   # bottom is called `test` -- the required name stays stable no matter how
   # the matrix grows or shrinks.
+
+  # Runs on everything, including pull requests.
+  #
+  # These four combinations cost the SAME wall clock as the single 3.12 job
+  # that preceded them, because matrix combinations run concurrently -- a
+  # measured run had all four starting within 6 seconds of each other and
+  # finishing between 12 and 16 minutes. Adding Python versions here is
+  # effectively free; do not trim them to "save time", there is none to save.
   pytest:
     name: pytest
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 45
     strategy:
       # Do not cancel the other combinations when one fails. When a new Python
       # breaks something, "3.14 failed and everything else was cancelled" tells
@@ -35,21 +47,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.12", "3.13", "3.14"]
         include:
-          # CONTRIBUTING documents a macOS setup and this history has commits
-          # from a Windows machine, so ubuntu-only coverage was a blind spot
-          # for a stack that compiles C through PyTensor and BLAS. One
-          # combination each catches platform breakage without paying for the
-          # full 3x3 cross product.
-          #
-          # Windows is the one most likely to need work: PyTensor's C backend
-          # wants a compiler it can find, and the usual Windows answer is the
-          # m2w64 toolchain rather than the MSVC the runner ships with. If it
-          # fails, the useful options are to fix the toolchain setup or to drop
-          # Windows from the matrix -- NOT to add continue-on-error, which
-          # turns a real signal into decoration nobody reads.
+          # CONTRIBUTING documents a macOS setup, and macOS is as fast as Linux
+          # here, so it stays on the pull-request path.
           - os: macos-latest
-            python-version: "3.12"
-          - os: windows-latest
             python-version: "3.12"
 
     steps:
@@ -81,6 +81,46 @@ jobs:
       - name: Run test suite
         run: poetry run pytest -q -n 2
 
+  # Windows is deliberately OFF the pull-request path.
+  #
+  # It is not slightly slower, it is ~4x slower: a measured run was cancelled
+  # still unfinished at the 60-minute cap while every other combination
+  # finished inside 16. Gating pull requests on it would roughly quadruple
+  # merge latency for every one-line change. It runs on pushes to master, on
+  # the nightly schedule, and on releases (publish.yml reaches this through
+  # workflow_call, where github.event_name is the original tag push).
+  #
+  # The trade is explicit: Windows breakage is found AFTER a merge rather than
+  # before it. With no bypass actor and non-fast-forward enforced, the fix is
+  # forward-only. That is accepted because the alternative -- a 60+ minute
+  # blocking check on a platform with known-failing tests -- would block every
+  # PR indefinitely.
+  pytest-windows:
+    name: pytest-windows
+    if: github.event_name != 'pull_request'
+    runs-on: windows-latest
+    # 60 was not enough; the job was cancelled mid-suite. Latency does not
+    # matter off the PR path, so give it room rather than tune it blind.
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: poetry
+
+      - name: Install dependencies
+        run: poetry install --extras gui --no-interaction
+
+      - name: Run test suite
+        run: poetry run pytest -q -n 2
+
   # The stable name the ruleset requires. It exists only to aggregate the
   # matrix into one pass/fail, so the required check never has to be renamed
   # when the matrix changes.
@@ -91,10 +131,21 @@ jobs:
   test:
     name: test
     if: always()
-    needs: [pytest]
+    needs: [pytest, pytest-windows]
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if any matrix combination did not succeed
+      - name: Fail if any required combination did not succeed
         run: |
-          echo "matrix result: ${{ needs.pytest.result }}"
+          echo "pytest:         ${{ needs.pytest.result }}"
+          echo "pytest-windows: ${{ needs.pytest-windows.result }}"
+
+          # The cross-platform matrix must pass everywhere.
           test "${{ needs.pytest.result }}" = "success"
+
+          # Windows is skipped entirely on pull requests, and `skipped` is the
+          # expected result there -- it must NOT be treated as a failure. On
+          # every other event it has actually run and must have succeeded.
+          case "${{ needs.pytest-windows.result }}" in
+            success|skipped) ;;
+            *) echo "Windows job failed"; exit 1 ;;
+          esac

--- a/poetry.lock
+++ b/poetry.lock
@@ -2108,19 +2108,36 @@ files = [
 ]
 
 [[package]]
-name = "intel-openmp"
-version = "2023.2.4"
-description = "Intel® OpenMP* Runtime Library"
+name = "intel-cmplr-lib-ur"
+version = "2026.1.0"
+description = "Intel® oneAPI Unified Runtime Libraries package"
 optional = false
 python-versions = "*"
 groups = ["main"]
 markers = "sys_platform == \"win32\""
 files = [
-    {file = "intel_openmp-2023.2.4-py2.py3-none-manylinux1_i686.whl", hash = "sha256:7724dd133c3889a0659abe9ca47bed84f92796292787a791506ea0e455cc2da4"},
-    {file = "intel_openmp-2023.2.4-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:15c601fce77757142fdbda700ca158895ceaf972230dc27c89ee4aa90b26f79f"},
-    {file = "intel_openmp-2023.2.4-py2.py3-none-win32.whl", hash = "sha256:24cca6bd0f2903abf4f91fd0503699b89e4c9eb5957cad6cad73bee1e464435b"},
-    {file = "intel_openmp-2023.2.4-py2.py3-none-win_amd64.whl", hash = "sha256:2d1e9696b3692fdf47e1a90067cdb72afc2e128f2d8e6934b1b0db638d03dc33"},
+    {file = "intel_cmplr_lib_ur-2026.1.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:74b64ace8277b031aa36328dc8f87f7f959a6ca4da5b68c69923d37283e01664"},
+    {file = "intel_cmplr_lib_ur-2026.1.0-py2.py3-none-win_amd64.whl", hash = "sha256:538e1135ee1801fb19fa1a580838a1f666f05534d35350d82736d959373d3b15"},
 ]
+
+[package.dependencies]
+umf = "==1.1.*"
+
+[[package]]
+name = "intel-openmp"
+version = "2026.1.0"
+description = "Intel OpenMP* Runtime Library"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "intel_openmp-2026.1.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:e6887f701b7d2323ed147008893b9af22e511aaa97e0fc9c37eb8be24a5366b0"},
+    {file = "intel_openmp-2026.1.0-py2.py3-none-win_amd64.whl", hash = "sha256:8f9f86d93da9d549eec7bae26d65d6188ed748792ce655b5cdbc2e1a15cb7206"},
+]
+
+[package.dependencies]
+intel-cmplr-lib-ur = "2026.1.0"
 
 [[package]]
 name = "ipdb"
@@ -3147,31 +3164,37 @@ typing_extensions = "*"
 
 [[package]]
 name = "mkl"
-version = "2023.2.2"
+version = "2026.1.0"
 description = "Intel® oneAPI Math Kernel Library"
 optional = false
 python-versions = "*"
 groups = ["main"]
 markers = "sys_platform == \"win32\""
 files = [
-    {file = "mkl-2023.2.2-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:d13bbffd3315d135d1584cb33ddba76ed3130201963d1efcfb9fbe3a631fb956"},
+    {file = "mkl-2026.1.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:4d5a26449818a8aebd4b2aaf6b291831e691f9cf74b152df49b99cf48bbd5360"},
+    {file = "mkl-2026.1.0-py2.py3-none-win_amd64.whl", hash = "sha256:8194a8270d70622eff00eec84c793efc382b14848b98c3ace6bacdda42170a80"},
 ]
 
 [package.dependencies]
-intel-openmp = "==2023.*"
-tbb = "==2021.*"
+intel-openmp = ">=2025,<2027"
+onemkl-license = "2026.1.0"
+tbb = "==2023.*"
 
 [[package]]
 name = "mkl-include"
-version = "2023.2.2"
+version = "2026.1.0"
 description = "Intel® oneAPI Math Kernel Library"
 optional = false
 python-versions = "*"
 groups = ["main"]
 markers = "sys_platform == \"win32\""
 files = [
-    {file = "mkl_include-2023.2.2-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:20ead2d598ed2e2c7053a99ce83c4a4459e4d667191bf32860c072c269113d0f"},
+    {file = "mkl_include-2026.1.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:e64b260e67284b8a696343d58c339ad9d990cc985077dab1269d1c6d2a2e2b1b"},
+    {file = "mkl_include-2026.1.0-py2.py3-none-win_amd64.whl", hash = "sha256:d933db23875da7d145a8897fa0cab1014228af3c387972f25b65472b49b23c94"},
 ]
+
+[package.dependencies]
+onemkl-license = "2026.1.0"
 
 [[package]]
 name = "ml-dtypes"
@@ -3878,6 +3901,19 @@ files = [
 
 [package.dependencies]
 typing-extensions = {version = "*", markers = "python_full_version < \"3.13.0\""}
+
+[[package]]
+name = "onemkl-license"
+version = "2026.1.0"
+description = "Intel® oneAPI Math Kernel Library"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "onemkl_license-2026.1.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:39fd829648af92c9e03c22ba228f07174d829aaa2fe3c5f6cd7073b8eb8a9805"},
+    {file = "onemkl_license-2026.1.0-py2.py3-none-win_amd64.whl", hash = "sha256:425b599af279e6bc03e27319d75aa156ca7dd8645dbcd0c324ef894d3fae6be3"},
+]
 
 [[package]]
 name = "opt-einsum"
@@ -5839,17 +5875,31 @@ dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
 
 [[package]]
 name = "tbb"
-version = "2021.13.1"
+version = "2023.1.0"
 description = "Intel® oneAPI Threading Building Blocks (oneTBB)"
 optional = false
 python-versions = "*"
 groups = ["main"]
 markers = "sys_platform == \"win32\""
 files = [
-    {file = "tbb-2021.13.1-py2.py3-none-manylinux1_i686.whl", hash = "sha256:bb5bdea0c0e9e6ad0739e7a8796c2635ce9eccca86dd48c426cd8027ac70fb1d"},
-    {file = "tbb-2021.13.1-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:d916359dc685579d09e4b344241550afc1cc034f7f5ec7234c258b6680912d70"},
-    {file = "tbb-2021.13.1-py3-none-win32.whl", hash = "sha256:00f5e5a70051650ddd0ab6247c0549521968339ec21002e475cd23b1cbf46d66"},
-    {file = "tbb-2021.13.1-py3-none-win_amd64.whl", hash = "sha256:cbf024b2463fdab3ebe3fa6ff453026358e6b903839c80d647e08ad6d0796ee9"},
+    {file = "tbb-2023.1.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:64ad35241c736a595498f5343abec8eaaa203e9fe0dbdbf4b86d37c5a3ab1d9c"},
+    {file = "tbb-2023.1.0-py3-none-win_amd64.whl", hash = "sha256:27df1315202defc67a73800c667ba4fbd03cf8924f73949373d4a34d1443fca2"},
+]
+
+[package.dependencies]
+tcmlib = "==1.*"
+
+[[package]]
+name = "tcmlib"
+version = "1.5.0"
+description = "Thread Composability Manager"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "tcmlib-1.5.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9d7c01cff35aae9bf5390b620680ebdf10a7d211c22d6488a27a029502e7d0aa"},
+    {file = "tcmlib-1.5.0-py2.py3-none-win_amd64.whl", hash = "sha256:f7b62787214083d490b39d7650f1e477eeacc875e7f86799feb9aa1fd34460d4"},
 ]
 
 [[package]]
@@ -5973,6 +6023,22 @@ files = [
     {file = "tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931"},
     {file = "tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415"},
 ]
+
+[[package]]
+name = "umf"
+version = "1.1.0"
+description = "Unified Memory Framework"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "umf-1.1.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:567152c5ee6b8e16cc56b29a8a9a6b918de1febf89877f71ea2e8247ef39fc32"},
+    {file = "umf-1.1.0-py2.py3-none-win_amd64.whl", hash = "sha256:a8c5ff84901fe6348715b6c1c85de4d195a6c69185d99ce4ebf7449b5d04011c"},
+]
+
+[package.dependencies]
+tcmlib = ">=1.5"
 
 [[package]]
 name = "uncertainties"
@@ -6722,4 +6788,4 @@ gui = ["fastapi", "pyqt6", "pyqt6-webengine", "pywebview", "qtpy", "ruamel-yaml"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "d4c755863654291352d0dda1b195658899e3fdbdc3ac80f1502aaada89132489"
+content-hash = "a65d31b6077d9e3b7932255501382ff0108f73afbdd23f1555ebe77afb50538b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,9 +99,18 @@ dependencies = [
     "numpyro>=0.21.0,<1.0.0",
     "blackjax>=0.8.0,<2.0.0",
     "nutpie>=0.13.0",
-    # OS specific dependencies
-    "mkl>=2023.0,<2024.0; sys_platform == 'win32'",
-    "mkl-include>=2023.0,<2024.0; sys_platform == 'win32'",
+    # OS specific dependencies -- PyTensor's BLAS on Windows.
+    #
+    # The floor is 2024.2 for a concrete reason: Intel stopped shipping Windows
+    # wheels partway through the 2023 series. 2023.1.0 and 2023.2.0 have them,
+    # 2023.2.1 and 2023.2.2 are macOS-only. The old `<2024.0` cap (poetry's
+    # `^2023.0`, carried verbatim through the PEP 621 migration and never a
+    # deliberate compatibility bound) therefore resolved to 2023.2.2 and made
+    # `poetry install` IMPOSSIBLE on Windows -- "Unable to find installation
+    # candidates for mkl (2023.2.2)". Every release from 2024.2.1 to 2026.1.0
+    # ships win_amd64. Do not re-cap below 2024.2 without checking PyPI first.
+    "mkl>=2024.2,<2027.0; sys_platform == 'win32'",
+    "mkl-include>=2024.2,<2027.0; sys_platform == 'win32'",
     # NetCDF write backend for idata.to_netcdf(); arviz/xarray no longer pull
     # one in by default (it's an optional "io" extra), but we need it to save
     # traces.

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -23,6 +23,36 @@ class SymbolicTimeout(Exception):
 
 import contextlib
 
+# SIGALRM is POSIX-only -- Windows has no such signal, and touching
+# signal.SIGALRM there raises AttributeError at import-adjacent call time.
+# Guarding on the attribute rather than on sys.platform keeps this honest on
+# any other platform that lacks it.
+#
+# The consequence on Windows is real and worth stating: the symbolic solver
+# runs WITHOUT a wall-clock timeout. A pathological equation/target pair that
+# would be abandoned after 2s on Linux can hang instead. The alternative --
+# a thread-based timeout -- cannot actually interrupt sympy once it is down
+# in C, so it would provide the appearance of a limit rather than a limit.
+_HAS_SIGALRM = hasattr(signal, "SIGALRM")
+
+
+def _arm_alarm(seconds, handler):
+    """Arm a SIGALRM timeout. No-op (returns None) where SIGALRM is absent."""
+    if not _HAS_SIGALRM:
+        return None
+    old_handler = signal.signal(signal.SIGALRM, handler)
+    signal.alarm(seconds)
+    return old_handler
+
+
+def _disarm_alarm(old_handler=None):
+    """Cancel a pending SIGALRM and optionally restore the prior handler."""
+    if not _HAS_SIGALRM:
+        return
+    signal.alarm(0)
+    if old_handler is not None:
+        signal.signal(signal.SIGALRM, old_handler)
+
 
 @contextlib.contextmanager
 def _sympy_time_limit(seconds=2):
@@ -44,13 +74,11 @@ def _sympy_time_limit(seconds=2):
         signal.alarm(1)
         raise SymbolicTimeout()
 
-    old_handler = signal.signal(signal.SIGALRM, handler)
-    signal.alarm(seconds)
+    old_handler = _arm_alarm(seconds, handler)
     try:
         yield
     finally:
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, old_handler)
+        _disarm_alarm(old_handler)
 
 
 # Instance names appear as the middle part of dotted parameter paths
@@ -2111,8 +2139,7 @@ class ConfigManager:
         def handler(signum, frame):
             raise TimeoutError("Symbolic solver timed out!")
 
-        signal.signal(signal.SIGALRM, handler)
-        signal.alarm(2)  # 2-second hard limit
+        _arm_alarm(2, handler)  # 2-second hard limit (POSIX only)
 
         solutions = []
         used_nsolve = False
@@ -2141,14 +2168,14 @@ class ConfigManager:
                 f"sp.solve timed out for {target_str} — blacklisting."
             )
             self.symbolic_blacklist.add(target_str)
-            signal.alarm(0)
+            _disarm_alarm()
             return False
         except Exception as e:
             logger.debug(f"sp.solve exception for {target_str}: {e}")
-            signal.alarm(0)
+            _disarm_alarm()
             return False
         finally:
-            signal.alarm(0)
+            _disarm_alarm()
 
         # 3. Fallback to nsolve if analytical failed
         if not solutions:

--- a/src/exozippy/gui/runner.py
+++ b/src/exozippy/gui/runner.py
@@ -167,6 +167,18 @@ class RunHandle:
         return self.proc.wait(timeout=timeout)
 
     def _signal(self, sig):
+        # Windows cannot deliver SIGINT to another process: send_signal raises
+        # `ValueError: Unsupported signal: 2`. The only cross-process interrupts
+        # it accepts are CTRL_C_EVENT and CTRL_BREAK_EVENT, and CTRL_C_EVENT
+        # cannot be aimed -- it goes to every process sharing the console,
+        # including the GUI itself. CTRL_BREAK_EVENT can be aimed, which is why
+        # start_run gives the child its own process group.
+        #
+        # Python delivers CTRL_BREAK_EVENT to the child as SIGBREAK rather than
+        # SIGINT, so the samplers register _stop_handler for SIGBREAK too. Both
+        # halves are required; either alone leaves stop silently doing nothing.
+        if sys.platform == "win32" and sig == signal.SIGINT:
+            sig = signal.CTRL_BREAK_EVENT
         try:
             self.proc.send_signal(sig)
         except ProcessLookupError:
@@ -196,10 +208,18 @@ def start_run(config_path, cwd=None):
 
     # A fresh interpreter via -m avoids any dependence on the console-script
     # entry point being on PATH and gives the child a clean PyTensor/pymc state.
+    # On Windows the child needs its own process group, or CTRL_BREAK_EVENT
+    # cannot be aimed at it (see RunHandle._signal). Harmless elsewhere, but
+    # the flag only exists on Windows, so it is added conditionally.
+    popen_kwargs = {}
+    if sys.platform == "win32":
+        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+
     proc = subprocess.Popen(
         [sys.executable, "-m", "exozippy.cli", config_path],
         cwd=cwd,
         env=env,
+        **popen_kwargs,
     )
     return RunHandle(proc, prefix, cwd, config_path)
 

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -1061,6 +1061,14 @@ def ptde_sample(
     # discarding whatever draws were already collected).
     old_sigint = signal.signal(signal.SIGINT, _stop_handler)
     old_sigterm = signal.signal(signal.SIGTERM, _stop_handler)
+    # Windows delivers the GUI's stop request as CTRL_BREAK_EVENT, which
+    # arrives here as SIGBREAK rather than SIGINT (see gui/runner.py).
+    # Without this the request is received and silently ignored.
+    old_sigbreak = (
+        signal.signal(signal.SIGBREAK, _stop_handler)
+        if hasattr(signal, "SIGBREAK")
+        else None
+    )
     try:
         # initial logp evaluations
         flat_starts = [
@@ -1405,6 +1413,8 @@ def ptde_sample(
     finally:
         signal.signal(signal.SIGINT, old_sigint)
         signal.signal(signal.SIGTERM, old_sigterm)
+        if old_sigbreak is not None:
+            signal.signal(signal.SIGBREAK, old_sigbreak)
         if pool is not None:
             pool.close()
             pool.join()

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -338,6 +338,13 @@ def ptde_async_sample(
 
     old_sigint = signal.signal(signal.SIGINT, _stop_handler)
     old_sigterm = signal.signal(signal.SIGTERM, _stop_handler)
+    # Windows delivers the GUI's stop request as CTRL_BREAK_EVENT, which
+    # arrives here as SIGBREAK rather than SIGINT (see gui/runner.py).
+    old_sigbreak = (
+        signal.signal(signal.SIGBREAK, _stop_handler)
+        if hasattr(signal, "SIGBREAK")
+        else None
+    )
 
     result_q = queue.Queue()
     submitted_at = {}  # (k, i) -> submission time, only while in flight
@@ -648,6 +655,8 @@ def ptde_async_sample(
     finally:
         signal.signal(signal.SIGINT, old_sigint)
         signal.signal(signal.SIGTERM, old_sigterm)
+        if old_sigbreak is not None:
+            signal.signal(signal.SIGBREAK, old_sigbreak)
         if pool is not None:
             # terminate() (not close()) at shutdown: close() waits for any
             # in-flight eval to finish, so a worker still stuck on a slow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,32 @@ Plain classes (not fixtures) — imported explicitly by test files that need the
 Pytest adds the tests/ directory to sys.path, so ``from conftest import ...`` works.
 """
 
+import os
+
+import pytest
+
 from exozippy.components.parameter import Parameter
 from exozippy.config import ConfigManager
+
+# The PTDE samplers build their worker pools with
+# multiprocessing.get_context("fork"), which raises
+# `ValueError: cannot find context for 'fork'` on Windows -- fork simply does
+# not exist there, and the only alternative, "spawn", re-imports the module in
+# each worker and requires all worker state to be picklable. Converting them is
+# a real piece of work, not a portability tweak, so these tests are skipped
+# rather than left permanently red.
+#
+# This is not only a Windows concern: Python 3.14 deprecates fork in
+# multi-threaded processes, and the ubuntu CI logs already emit
+# "DeprecationWarning: This process is multi-threaded, use of fork() may lead
+# to deadlocks in the child". The eventual fix is fork -> spawn everywhere.
+requires_fork = pytest.mark.skipif(
+    not hasattr(os, "fork"),
+    reason=(
+        "PTDE uses multiprocessing's fork start method, which does not exist "
+        "on this platform (see conftest.requires_fork)"
+    ),
+)
 
 
 class _DummyConfigManager:

--- a/tests/test_config_healing.py
+++ b/tests/test_config_healing.py
@@ -41,3 +41,61 @@ def test_config_derives_te_from_physical_input():
     # theta_E = sqrt(8.144 * 0.5 * 0.125) = 0.7134
     # t_E = (0.7134 / 5.0) * 365.25 = 52.12
     assert np.isclose(derived_te, 52.12, atol=0.1)
+
+
+def test_symbolic_time_limit_is_inert_where_sigalrm_is_absent(monkeypatch):
+    """
+    Given a platform whose signal module has no SIGALRM (Windows),
+    When the symbolic solver's timeout guard is armed and disarmed,
+    Then it degrades to a no-op instead of raising AttributeError.
+
+    Regression: config.py called signal.signal(signal.SIGALRM, ...) and
+    signal.alarm() unguarded, so every Windows run died with
+    `AttributeError: module 'signal' has no attribute 'SIGALRM'` before the
+    solver could do any work. Caught by adding Windows to the CI matrix.
+    """
+    # ARRANGE
+    import exozippy.config as cfg
+
+    monkeypatch.setattr(cfg, "_HAS_SIGALRM", False)
+    calls = []
+    monkeypatch.setattr(
+        cfg.signal, "alarm", lambda *a: calls.append(a), raising=False
+    )
+
+    def boom(*args, **kwargs):  # must never be reached
+        raise AssertionError("signal.signal called without SIGALRM support")
+
+    monkeypatch.setattr(cfg.signal, "signal", boom)
+
+    # ACT
+    old = cfg._arm_alarm(2, lambda *a: None)
+    cfg._disarm_alarm(old)
+    with cfg._sympy_time_limit(2):
+        result = 1 + 1
+
+    # ASSERT
+    assert old is None
+    assert calls == [], "signal.alarm must not be called without SIGALRM"
+    assert result == 2, "the guarded block must still execute"
+
+
+def test_symbolic_time_limit_still_arms_where_sigalrm_exists():
+    """
+    Given a POSIX platform,
+    When _sympy_time_limit guards a block that overruns its limit,
+    Then SymbolicTimeout is still raised -- the Windows guard must not have
+    disabled the timeout everywhere.
+    """
+    # ARRANGE
+    import time
+
+    import exozippy.config as cfg
+
+    if not cfg._HAS_SIGALRM:
+        pytest.skip("platform has no SIGALRM")
+
+    # ACT / ASSERT
+    with pytest.raises(cfg.SymbolicTimeout):
+        with cfg._sympy_time_limit(1):
+            time.sleep(5)

--- a/tests/test_mmexofast_to_params.py
+++ b/tests/test_mmexofast_to_params.py
@@ -1,0 +1,109 @@
+# tests/test_mmexofast_to_params.py
+"""Tests for the MMEXOFAST -> params.yaml converter.
+
+The interface between MMEXOFAST and EXOZIPPy is a JSON file, not an import,
+so these tests pin the parts of that contract the converter relies on. Per-fit
+``sigmas`` are optional: MMEXOFAST omits them for solutions that are initial
+estimates rather than optimized fits, and is expected to stop emitting them
+altogether.
+"""
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from exozippy.utilities.mmexofast_to_params import mmexofast_to_params
+
+MMX_PATH = (
+    Path(__file__).parent.parent / "examples" / "DC2018_128" / "mmexofast.json"
+)
+
+PARAM_PATHS = [
+    "lens.Lens.t_0",
+    "lens.Lens.u_0",
+    "lens.Lens.t_E",
+    "lens.Lens.s",
+    "lens.Lens.alpha",
+    "lens.Lens.rho",
+    "lens.Lens.q",
+]
+
+
+def _write_without_sigmas(tmp_path, keep=None):
+    """Copy the example file, dropping every per-fit sigma except ``keep``."""
+    data = json.loads(MMX_PATH.read_text())
+    stripped = copy.deepcopy(data)
+    for fit in stripped["fits"]:
+        if keep is None:
+            fit.pop("sigmas", None)
+        else:
+            fit["sigmas"] = {k: fit["sigmas"][k] for k in keep}
+
+    path = tmp_path / "mmexofast_no_sigmas.json"
+    path.write_text(json.dumps(stripped))
+
+    return path
+
+
+def test_sigmas_present_emit_init_scale(tmp_path):
+    """Given a file with sigmas, every parameter block carries an
+    init_scale alongside its initval."""
+    parsed = yaml.safe_load(
+        mmexofast_to_params(MMX_PATH, out_path=tmp_path / "out.yaml")
+    )
+
+    assert sorted(parsed) == sorted(PARAM_PATHS)
+    for path in PARAM_PATHS:
+        assert "initval" in parsed[path], path
+        assert "init_scale" in parsed[path], path
+
+
+def test_missing_sigmas_still_converts(tmp_path):
+    """Given a file whose fits have no sigmas at all -- what MMEXOFAST emits
+    when it has only initial estimates -- conversion succeeds and yields
+    initvals with no init_scale, rather than raising KeyError."""
+    path = _write_without_sigmas(tmp_path)
+
+    parsed = yaml.safe_load(
+        mmexofast_to_params(path, out_path=tmp_path / "out.yaml")
+    )
+
+    assert sorted(parsed) == sorted(PARAM_PATHS)
+    for name, entry in parsed.items():
+        assert "initval" in entry, name
+        assert "init_scale" not in entry, name
+
+
+def test_partial_sigmas_emit_init_scale_only_where_known(tmp_path):
+    """A sigma present for some parameters and absent for others is not
+    all-or-nothing: each block is decided independently."""
+    path = _write_without_sigmas(tmp_path, keep=["t_0", "log_q"])
+
+    parsed = yaml.safe_load(
+        mmexofast_to_params(path, out_path=tmp_path / "out.yaml")
+    )
+
+    with_scale = {
+        name for name, entry in parsed.items() if "init_scale" in entry
+    }
+    assert with_scale == {"lens.Lens.t_0", "lens.Lens.q"}
+
+
+@pytest.mark.parametrize("solution_index", [None, 0, 1])
+def test_output_is_valid_yaml_without_sigmas(tmp_path, solution_index):
+    """Both the multi-seed (None) and single-solution paths stay parseable
+    when sigmas are absent."""
+    path = _write_without_sigmas(tmp_path)
+
+    text = mmexofast_to_params(
+        path,
+        solution_index=solution_index,
+        out_path=tmp_path / "out.yaml",
+    )
+
+    parsed = yaml.safe_load(text)
+    assert parsed
+    assert all("initval" in entry for entry in parsed.values())

--- a/tests/test_mode_evidence.py
+++ b/tests/test_mode_evidence.py
@@ -30,6 +30,7 @@ import pymc as pm
 import pytensor.tensor as pt
 import pytest
 
+from conftest import requires_fork
 from exozippy.outputs.evidence import (
     EvidenceResult,
     apply_evidence_weighting,
@@ -161,6 +162,7 @@ def _mixture_lp(x, mu0, mu1, w0, w1):
     return np.logaddexp(lp0, lp1)
 
 
+@requires_fork
 def test_evidence_weights_recover_true_mixture_weights():
     """
     Given a well-separated two-mode mixture with equal draw occupancy (~50/50)
@@ -261,6 +263,7 @@ def test_apply_evidence_weighting_falls_back_on_refusal():
     assert "refused" in report.provenance
 
 
+@requires_fork
 def test_evidence_refuses_heavy_tailed_mode():
     """
     Given a single mode whose raw-space target is heavy-tailed (Cauchy) so a

--- a/tests/test_ptde.py
+++ b/tests/test_ptde.py
@@ -11,6 +11,7 @@ import pytest
 import xarray as xr
 from scipy.stats import kstest
 
+from conftest import requires_fork
 from exozippy.components.parameter import Parameter
 from exozippy.samplers.ptde import (
     _PROBE_FLAT_SCALE,
@@ -644,6 +645,7 @@ def test_make_starts_falls_back_when_system_has_no_jitter():
     assert all(np.isfinite(float(logp_fn(s))) for s in starts)
 
 
+@requires_fork
 def test_shutdown_pool_kills_workers_that_ignore_sigterm():
     """
     Given a fork Pool whose workers ignore SIGTERM (as _worker_init sets up)

--- a/tests/test_ptde_async.py
+++ b/tests/test_ptde_async.py
@@ -15,6 +15,7 @@ import pymc as pm
 import pytest
 import xarray as xr
 
+from conftest import requires_fork
 from exozippy.samplers.ptde_async import ptde_async_sample
 
 # ---------------------------------------------------------------------------
@@ -105,6 +106,7 @@ def test_ptde_async_returns_inferencedata_with_expected_structure():
     assert "lp" in idata.sample_stats.data_vars
 
 
+@requires_fork
 def test_ptde_async_runs_with_multiple_cores():
     """
     Given cores>1 (a real fork Pool, not the serial fallback),
@@ -174,6 +176,7 @@ def test_ptde_async_collect_rung_timing_runs_end_to_end(caplog):
 # ---------------------------------------------------------------------------
 
 
+@requires_fork
 def test_ptde_async_with_eval_timeout_runs_end_to_end():
     """
     Given eval_timeout set on a model whose logp always evaluates quickly,


### PR DESCRIPTION
pyproject advertises requires-python = ">=3.12,<3.15" and CI tested 3.12
only, so two of the three versions we publish to PyPI were never run. A
user pip-installing on 3.13 hit code we had not executed. Same shape for
platforms: CONTRIBUTING documents a macOS setup and this history has
commits from a Windows machine, but CI was ubuntu-only -- a real blind spot
for a stack that compiles C through PyTensor and BLAS.

The matrix is now 5 combinations: ubuntu on 3.12/3.13/3.14, plus macOS and
Windows on 3.12. One combination each for the non-Linux platforms catches
platform breakage without paying for the full cross product. fail-fast is
off so a failure on one Python does not cancel the evidence from the rest.

JOB NAMING IS LOAD-BEARING. The branch ruleset requires a check named
`test` and has no bypass actors. A matrix job reports one check per
combination -- `pytest (ubuntu-latest, 3.12)` -- and never its own id, so
converting the old `test` job into a matrix would have meant nothing ever
reported `test` again and NOTHING COULD EVER MERGE, including the fix. So
the matrix is named `pytest` and a tiny aggregating job keeps the name
`test`. Its `if: always()` is equally load-bearing: without it the gate is
skipped when the matrix fails, and a skipped required check reads as
neutral rather than failing.

Also adds Dependabot: weekly grouped Actions bumps and monthly grouped
Python bumps. The Actions half has already proven necessary -- 2832a56
bumped checkout and setup-python by hand after the Node 20 runtimes were
deprecated. Majors are excluded from the Python group so they arrive as
separate PRs a human reads a changelog for.

Expect this to go red somewhere on the first run. That is the point: it is
reporting a gap that already existed rather than creating one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013x7LE4HS2HFJbSrD5tKFvu
