### PR TITLE
Fix startup failure that would have broken the next release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,20 @@ jobs:
   # same suite CI runs and the two cannot drift.
   tests:
     uses: ./.github/workflows/tests.yml
+    # REQUIRED, not tidiness. A called workflow cannot request more permission
+    # than its caller grants, and this repository's default workflow token is
+    # read-only. tests.yml's pytest-latest-deps job asks for `issues: write`
+    # (it files a tracking issue when the nightly unlocked-resolution run
+    # fails), so without this line the whole workflow dies at STARTUP with a
+    # permissions error -- before a single job runs, and regardless of whether
+    # that job would have been skipped by its own `if:`.
+    #
+    # This was found by dispatching publish.yml as a release rehearsal, which
+    # returned `startup_failure`. It would otherwise have surfaced the first
+    # time a version tag was pushed, i.e. during a real release.
+    permissions:
+      contents: read
+      issues: write
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
publish.yml calls tests.yml via workflow_call. A called workflow cannot
request more permission than its caller grants, and this repository's
default workflow token is read-only. tests.yml's pytest-latest-deps job
asks for `issues: write` so it can file a tracking issue when the nightly
unlocked-resolution run fails -- added in #26 -- and publish.yml's `tests`
job granted nothing.

The result is a STARTUP failure: the entire workflow dies before any job
runs, and the `if:` that would have skipped pytest-latest-deps on a push
does not save it, because the permissions check happens first.

Found by dispatching publish.yml as a release rehearsal (intended to test
an artifact action bump, which it never got far enough to reach). The
alternative discovery path was pushing a v0.1.0 tag and watching the
release fail.

Honest scope: the startup failure is confirmed for workflow_dispatch. I did
not prove it for a tag push, which would need an actual tag. The permission
subset check is static, so it should behave identically, and granting the
permission is correct either way.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013x7LE4HS2HFJbSrD5tKFvu
