### PR TITLE
README: it is pip-installable now, and say which platforms are tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,82 @@
 # EXOZIPPy
 [DeepWiki](https://www.deepwiki.com/jdeast/EXOZIPPy)
 
-This will eventually be a python successor to EXOFASTv2, but it is not officially released yet. Many features are missing, not tested, or not functional. If you'd like to help with development, please contact me at jason.eastman@cfa.harvard.edu
+This will eventually be a python successor to EXOFASTv2, but it is not officially
+released yet. Many features are missing, not tested, or not functional. If you'd
+like to help with development, please contact me at jason.eastman@cfa.harvard.edu
 
-When we officially release the code, it'll be a pip installable package. For now,
-install it from a git clone. All dependencies (including exoplanet-core, which now
-ships binary wheels) resolve from PyPI, so no compiler is required:
+## Installing
+
+EXOZIPPy is on PyPI. Only pre-releases exist so far, so `--pre` is required --
+without it pip reports that no matching version exists:
+
+```
+pip install --pre exozippy
+```
+
+All dependencies resolve from PyPI, so no compiler is required on the supported
+platforms below. A nightly CI job installs exactly this way, with no lock file,
+to check that a fresh install keeps working as upstream packages move.
+
+### For development
+
+Use Poetry, which installs the pinned `poetry.lock` and so reproduces a known
+good dependency set:
 
 ```
 conda create -n exozippy python=3.12
 conda activate exozippy
-mkdir -p ~/python
-cd ~/python
 git clone https://github.com/jdeast/EXOZIPPy.git
 cd EXOZIPPy
-pip install -e .
+poetry install --extras gui
+poetry run pre-commit install
 ```
 
-If you have Poetry, `poetry install` (which uses the pinned `poetry.lock`) is the
-most reliable path.
+`--extras gui` is worth taking even if you never open the GUI: ruamel-yaml lives
+in that extra, and without it roughly 30 tests fail at import.
 
-Note: exoplanet-core provides wheels for CPython 3.12-3.14 on Linux (glibc 2.28+),
-Apple Silicon macOS, and Windows. Intel macOS has no wheel and builds from source,
-which needs a C++ compiler.
+See CONTRIBUTING.md for the workflow (`master` is protected; changes go through
+a pull request with a passing test suite).
 
-# Windows (powershell)
-good luck! If you manage to install it and run it on windows, please send instructions.
+## Supported platforms
 
-skips compiler (slow!) Installation via Conda recommended!
+Every push and pull request runs the full test suite on:
 
-This might be relevant:
-setx PYTENSOR_FLAGS "blas__ldflags=,cxx="
+| OS | Python |
+|----|--------|
+| Linux (ubuntu-latest) | 3.12, 3.13, 3.14 |
+| macOS (arm64) | 3.12 |
+
+Windows is **not currently tested and not supported.** It is not merely
+unverified -- the test suite takes over 90 minutes there against ~16 minutes on
+Linux and has never completed a CI run, so the job was removed rather than left
+producing no signal. Three real Windows bugs were found and fixed along the way
+(an unsatisfiable mkl pin, a POSIX-only `SIGALRM` in the symbolic solver, and
+the GUI's cross-process stop signal), so basic use may well work. But the PTDE
+sampler will not: it builds worker pools with multiprocessing's `fork` start
+method, which does not exist on Windows. See `notes/todo.txt` if you want to
+pick this up -- patches welcome.
+
+Intel macOS is untested here and needs a C++ compiler: exoplanet-core publishes
+wheels for CPython 3.12-3.14 on Linux (glibc 2.28+), Apple Silicon macOS and
+Windows, but not Intel macOS, so it builds from source there.
+
+If PyTensor cannot find a compiler you can fall back to its slower pure-Python
+mode:
+
+```
+PYTENSOR_FLAGS="blas__ldflags=,cxx="
+```
+
+## Running a fit
+
+```
+cd examples/ob140939
+exozippy ob140939.yaml
+```
+
+The optional browser GUI (installed by the `gui` extra) starts with:
+
+```
+exozippy-gui
+```


### PR DESCRIPTION
The install section was actively wrong. It said "When we officially
release the code, it'll be a pip installable package. For now, install it
from a git clone" -- but exozippy 0.1.0rc1 is on PyPI and installs fine.

The important detail is that only a pre-release exists, so plain
`pip install exozippy` FAILS with "no matching distribution"; it needs
`--pre`. Anyone following the old README would have cloned unnecessarily,
and anyone guessing the obvious command would have hit a confusing error.

Adds a supported-platforms table taken from what CI actually runs (Linux
on 3.12/3.13/3.14, macOS arm64 on 3.12) rather than from intent.

Replaces the Windows section. "good luck!" was honest but is now
out of date in both directions: three real Windows bugs were found and
fixed (an unsatisfiable mkl pin, a POSIX-only SIGALRM in the symbolic
solver, the GUI's cross-process stop signal), so basic use may work -- but
the PTDE sampler cannot, because it builds worker pools with
multiprocessing's fork start method, which does not exist there. The
section now says that, and points at notes/todo.txt.

Keeps the exoplanet-core wheel note, re-verified against PyPI: 0.4.0
publishes cp312-cp314 wheels for manylinux_2_28 x86_64, macosx_11_0_arm64
and win_amd64, so Intel macOS really does still build from source.

Also documents the dev setup (poetry install --extras gui, pre-commit
install) and points at CONTRIBUTING.md for the protected-branch workflow.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013x7LE4HS2HFJbSrD5tKFvu
