### PR TITLE
Stop the JPL ephemeris download from flaking CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,19 @@ jobs:
           path: src/exozippy/components/sed/models/NextGen
           key: nextgen-spectra-7a2b81333f6a5bfccd4cbc07bdea6648
 
+      # The mulensing component sets astropy's solar-system ephemeris to
+      # "jpl", which downloads the ~115 MB de430 kernel into ~/.astropy/cache
+      # on first use. Same failure mode as the Zenodo spectra above: a slow
+      # JPL server turned into URLError failures across the suite (nightlies
+      # of 2026-07-29 and 2026-07-31). The kernel file never changes, so a
+      # static key is correct; bump it only if the ephemeris name in
+      # ephemeris.py / mulensing/op.py ever moves off de430.
+      - name: Cache the astropy ephemeris kernel
+        uses: actions/cache@v6
+        with:
+          path: ~/.astropy/cache
+          key: astropy-cache-de430
+
       # -n 2 overrides the -n 6 in pyproject's addopts. Six workers suit a
       # workstation but oversubscribe a GitHub runner: each peaks ~1-2 GB
       # building a System and compiling PyTensor graphs. The symptom was never
@@ -158,6 +171,14 @@ jobs:
         with:
           path: src/exozippy/components/sed/models/NextGen
           key: nextgen-spectra-7a2b81333f6a5bfccd4cbc07bdea6648
+
+      # Same astropy ephemeris-kernel cache as the matrix job -- see the
+      # comment there.
+      - name: Cache the astropy ephemeris kernel
+        uses: actions/cache@v6
+        with:
+          path: ~/.astropy/cache
+          key: astropy-cache-de430
 
       # Saved to a file, not just echoed: the failure report below quotes it,
       # and "which versions did it actually pick" is the first question anyone

--- a/src/exozippy/components/mulensing/op.py
+++ b/src/exozippy/components/mulensing/op.py
@@ -12,8 +12,6 @@ from astropy.time import Time
 from pytensor.gradient import DisconnectedType
 from pytensor.graph import Apply, Op
 
-solar_system_ephemeris.set("jpl")
-
 # Cache Earth positions keyed on sorted unique times (immutable between MCMC steps).
 _earth_pos_cache = {}
 
@@ -23,6 +21,11 @@ def _earth_xyz_at(times_np):
     times_np = np.asarray(times_np)
     key = hash(times_np.tobytes())
     if key not in _earth_pos_cache:
+        # Set lazily, not at import: the first set downloads the ~115 MB
+        # de430 kernel, and doing that at import time made `import exozippy`
+        # itself require network (and fail suite-wide when JPL was slow).
+        # Same pattern as ephemeris.get_observer_position.
+        solar_system_ephemeris.set("jpl")
         t = Time(times_np, format="jd", scale="tdb")
         _earth_pos_cache[key] = (
             get_body_barycentric("earth", t).xyz.to("au").value.T


### PR DESCRIPTION
## Summary

The nightlies of 2026-07-29 and 2026-07-31 failed with `urllib.error.URLError: <urlopen error timed out>` across dozens of tests (see #35). Root cause: `mulensing/op.py` set astropy's solar-system ephemeris to `"jpl"` at module import, which downloads the ~115 MB de430 kernel from JPL during test collection on every fresh runner. Every push/PR run has been making the same download and simply winning the dice roll; the nightlies hit JPL at the same hour every day and lost twice.

Not a dependency problem: in the 7/31 run the fresh resolution (pymc 6.2.0, pytensor 3.1.3, numpy 2.5.1, jax 0.11.0) installed fine and 577 tests passed before the network errors.

Two fixes:
- `op.py` sets the ephemeris lazily inside `_earth_xyz_at`, the same pattern `ephemeris.get_observer_position` already uses. `import exozippy` no longer requires network access, and a JPL outage can only fail the tests that actually compute Earth positions instead of collection of the whole suite.
- Both CI jobs cache `~/.astropy/cache` with a static key (the de430 kernel never changes), mirroring the existing Zenodo spectra cache. After the first green run populates the cache, CI never talks to JPL at all.

## Test plan

- Full suite run locally against this branch: 739 passed, 6 skipped.
- `import exozippy...mulensing.op` verified to trigger no download; `_earth_xyz_at` verified to return correct shapes with the lazy set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)