### PR TITLE
Nightly: auto-close the tracking issue when the suite is green again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -147,6 +147,13 @@ jobs:
       contents: read
       issues: write
 
+    # The open-on-failure and close-on-success steps below both look the
+    # tracking issue up by this exact title. Defined once so they cannot
+    # drift apart -- if they did, a green run would stop closing the issue
+    # a red run opened.
+    env:
+      ISSUE_TITLE: "Nightly: suite fails against freshly resolved dependencies"
+
     steps:
       - uses: actions/checkout@v7
 
@@ -204,7 +211,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          TITLE="Nightly: suite fails against freshly resolved dependencies"
+          TITLE="$ISSUE_TITLE"
 
           {
             echo "The nightly unlocked-resolution job failed."
@@ -235,6 +242,31 @@ jobs:
           else
             echo "Opening a new issue"
             gh issue create --title "$TITLE" --body-file body.md
+          fi
+
+      # The inverse of the step above. Without it the issue only ever opens,
+      # so after a transient failure (a JPL or Zenodo hiccup, run 30620673936)
+      # "open" stops meaning "still broken" until a human triages it. With it
+      # the state is truthful on its own: a real upstream break keeps failing
+      # nightly and the issue stays open; a one-night flake closes itself on
+      # the next green run, with the open/close timestamps recording how long
+      # it lasted. A genuine break is never masked -- this step cannot run
+      # while the suite is failing.
+      - name: Close the tracking issue when the suite is green again
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh issue list --state open --search "$ISSUE_TITLE in:title" \
+                       --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Closing issue #$EXISTING"
+            gh issue close "$EXISTING" \
+              --comment "The nightly unlocked-resolution job passed again: $RUN_URL"
+          else
+            echo "No open tracking issue to close"
           fi
 
   # The stable name the ruleset requires. It exists only to aggregate the


### PR DESCRIPTION
## Summary

Follow-up to #37. The `pytest-latest-deps` job opens (or comments on) a tracking issue on failure, but nothing ever closed it: a transient failure like the JPL timeouts behind #35 left an open issue a human had to notice was stale and close by hand, so the issue's open state stopped meaning "still broken".

This adds the inverse step: when the job succeeds and an open tracking issue exists, close it with a comment linking the passing run. Behavior:

- **Transient flake**: the issue opens overnight and the next green nightly closes it, with the open/close timestamps recording how long it lasted. No human triage.
- **Real upstream break**: the job keeps failing, the failure step keeps commenting in place, and the close step never runs -- the issue stays open until the pins are actually fixed.

The title string both steps search on is hoisted to a job-level `ISSUE_TITLE` env var so the open and close paths cannot drift apart. Uses the same preinstalled `gh` + `GITHUB_TOKEN` approach as the failure step (no marketplace action), and the job already has `issues: write`.

## Test plan

- Workflow-only change; YAML validated locally.
- The step's logic mirrors the existing failure step's issue lookup verbatim; the close path will be exercised by the next scheduled or manually dispatched run that goes green while a tracking issue is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)