### PR TITLE
Examples: default to ptde_async instead of ptde

### DIFF
--- a/examples/DC2018/run_event.py
+++ b/examples/DC2018/run_event.py
@@ -206,7 +206,9 @@ def main(argv=None):
     ap.add_argument("--tune", type=int, default=5000)
     ap.add_argument("--draws", type=int, default=50000)
     ap.add_argument(
-        "--sampler", default="ptde", help="Sampler method (default ptde)"
+        "--sampler",
+        default="ptde_async",
+        help="Sampler method (default ptde_async)",
     )
     ap.add_argument(
         "--finite-source",

--- a/examples/DC2018_128/DC2018_128.yaml
+++ b/examples/DC2018_128/DC2018_128.yaml
@@ -53,7 +53,7 @@ parameter_file: "DC2018_128.params.yaml"
 #parameter_file: "DC2018_128.params.2.yaml"
 
 sampler:
-  method: ptde            # Differential Evolution + Parallel Tempering (standard for EXOFASTv2)
+  method: ptde_async      # Differential Evolution + Parallel Tempering (async worker pool)
   n_temps: 8              # temperature rungs (EXOFASTv2 parity)
   T_max: 200              # hottest temperature (EXOFASTv2 parity)
   # n_chains: defaults to 2*n_params

--- a/examples/DC2018_128/DC2018_128_hpc.yaml
+++ b/examples/DC2018_128/DC2018_128_hpc.yaml
@@ -64,7 +64,7 @@ parameter_file: "DC2018_128.params.yaml"
 #parameter_file: "DC2018_128.params.2.yaml"
 
 sampler:
-  method: ptde            # Differential Evolution + Parallel Tempering (standard for EXOFASTv2)
+  method: ptde_async      # Differential Evolution + Parallel Tempering (async worker pool)
   n_temps: 8              # temperature rungs (EXOFASTv2 parity)
   T_max: 200              # hottest temperature (EXOFASTv2 parity)
   # n_chains: defaults to 2*n_params

--- a/examples/KMT-2019-BLG-1806/KMT-2019-BLG-1806.yaml
+++ b/examples/KMT-2019-BLG-1806/KMT-2019-BLG-1806.yaml
@@ -58,7 +58,7 @@ mulensinstrument:
 parameter_file: "KMT-2019-BLG-1806.params.yaml"
 
 sampler:
-  method: ptde            # Differential Evolution + Parallel Tempering (standard for EXOFASTv2)
+  method: ptde_async      # Differential Evolution + Parallel Tempering (async worker pool)
   n_temps: 8           # temperature rungs (EXOFASTv2 parity)
   T_max: 200           # hottest temperature (EXOFASTv2 parity)
   # n_chains: defaults to 2 × n_params

--- a/examples/ob161003/ob161003.yaml
+++ b/examples/ob161003/ob161003.yaml
@@ -68,7 +68,7 @@ mulensinstrument:
 parameter_file: "ob161003.params.yaml"
 
 sampler:
-  method: ptde            # Differential Evolution + Parallel Tempering (standard for EXOFASTv2)
+  method: ptde_async      # Differential Evolution + Parallel Tempering (async worker pool)
   n_temps: 8              # temperature rungs (EXOFASTv2 parity)
   T_max: 200              # hottest temperature (EXOFASTv2 parity)
   # n_chains: defaults to 2 × n_params


### PR DESCRIPTION
The async worker pool avoids ptde's synchronous barrier (every chain waits for the slowest of n_temps*n_chains proposals each step), which production DC2018 runs showed stalling behind rare, expensive near-caustic evaluations concentrated in the hottest rungs.

Switches run_event.py's --sampler default plus the ptde/KMT-2019-BLG-1806/ob161003 example configs that were still pinned to the synchronous sampler.