### PR TITLE
GUI: record the error cause in the run status file

### DIFF
--- a/src/exozippy/gui/status.py
+++ b/src/exozippy/gui/status.py
@@ -122,7 +122,7 @@ class GuiReporter:
 
     # -- status.json ------------------------------------------------------
 
-    def _write_status(self, phase, state):
+    def _write_status(self, phase, state, error=None):
         doc = {
             "phase": phase,
             "pid": os.getpid(),
@@ -130,11 +130,13 @@ class GuiReporter:
             "started_at": self._t_start,
             "updated_at": time.time(),
         }
+        if error is not None:
+            doc["error"] = str(error)
         _atomic_write_text(
             self.status_path, json.dumps(doc, default=_json_default, indent=2)
         )
 
-    def phase(self, phase, state=None):
+    def phase(self, phase, state=None, error=None):
         """Write status.json at a phase transition.
 
         `state` defaults to the last progress state seen, so a phase change
@@ -148,7 +150,7 @@ class GuiReporter:
         else:
             self._last_state = {k: state.get(k) for k in _SUMMARY_KEYS}
         try:
-            self._write_status(phase, state)
+            self._write_status(phase, state, error=error)
         except Exception:
             logger.warning(
                 "GuiReporter: failed to write status file %s",
@@ -156,17 +158,20 @@ class GuiReporter:
                 exc_info=True,
             )
 
-    def terminal(self, phase):
+    def terminal(self, phase, error=None):
         """Force a terminal phase (done/stopped/error), reusing the last state.
 
         Called on every exit path from run_fit so a reader never finds the
-        file stuck on a non-terminal phase after the process is gone.
+        file stuck on a non-terminal phase after the process is gone. `error`
+        (a string, typically the formatted traceback) is recorded in the
+        document so a monitor can report WHY a run ended in "error" -- the
+        process is usually gone by the time anyone looks.
         """
         if phase not in TERMINAL_PHASES:
             raise ValueError(
                 f"terminal phase must be one of {sorted(TERMINAL_PHASES)}"
             )
-        self.phase(phase, self._last_state)
+        self.phase(phase, self._last_state, error=error)
 
     # -- progress callback (passed to the samplers) -----------------------
 

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 import os
 import signal
 import time
+import traceback
 from pathlib import Path
 
 import arviz as az
@@ -123,7 +124,10 @@ def run_fit(config, user_params=None):
         gui.terminal("stopped")
         raise
     except BaseException:
-        gui.terminal("error")
+        # Record the traceback in the status file: the interpreter is gone by
+        # the time a monitor sees phase "error", so this is the only place the
+        # cause survives (e.g. a wrap-up crash after a graceful stop).
+        gui.terminal("error", error=traceback.format_exc())
         raise
     gui.terminal("done")
     return result

--- a/tests/test_run_endpoints.py
+++ b/tests/test_run_endpoints.py
@@ -341,7 +341,8 @@ def test_endpoint_run_lifecycle_start_sampling_stop(kelt4_workdir, tmp_path):
             )
 
         assert _poll_until(_sampling_with_progress, REACH_SAMPLING_TIMEOUT), (
-            "run never reported n_draws>=100 during sampling"
+            "run never reported n_draws>=100 during sampling; last status: "
+            f"{client.get('/api/run/status').json()}"
         )
 
         status = client.get("/api/run/status").json()
@@ -355,8 +356,14 @@ def test_endpoint_run_lifecycle_start_sampling_stop(kelt4_workdir, tmp_path):
         stopped = client.post("/api/run/stop", json={"force": False})
         assert stopped.status_code == 200
 
+        # Keep the last full status doc so a failure message carries the
+        # child's recorded error/traceback, not just the bare phase name.
+        final_status = {}
+
         def _terminal():
             st = client.get("/api/run/status").json()
+            final_status.clear()
+            final_status.update(st)
             return st["phase"] if st.get("phase") in TERMINAL_PHASES else None
 
         final_phase = _poll_until(_terminal, timeout=600.0)
@@ -369,4 +376,4 @@ def test_endpoint_run_lifecycle_start_sampling_stop(kelt4_workdir, tmp_path):
     assert final_phase in {
         "stopped",
         "done",
-    }, f"non-terminal end: {final_phase}"
+    }, f"non-terminal end: {final_phase}; status: {final_status}"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -133,6 +133,28 @@ def test_disabled_reporter_writes_nothing(tmp_path):
     assert not os.path.exists(str(prefix) + "_gui_snapshot")
 
 
+def test_terminal_error_records_cause(tmp_path):
+    """
+    Given an enabled GuiReporter,
+    When terminal("error", error=<traceback text>) is written,
+    Then status.json carries the cause in its "error" field (and a plain
+    terminal("done") writes no such field).
+    """
+    prefix = tmp_path / "run" / "planet"
+    reporter = GuiReporter(prefix, enabled=True)
+
+    reporter.terminal("error", error="Traceback: boom in wrap-up")
+
+    doc = json.load(open(str(prefix) + "_gui_status.json"))
+    assert doc["phase"] == "error"
+    assert doc["error"] == "Traceback: boom in wrap-up"
+
+    reporter.terminal("done")
+    doc = json.load(open(str(prefix) + "_gui_status.json"))
+    assert doc["phase"] == "done"
+    assert "error" not in doc
+
+
 def test_snapshot_is_thinned_and_atomic(tmp_path):
     """
     Given 500 stored draws/chain and a 200-draw snapshot cap,


### PR DESCRIPTION
## Why

`test_endpoint_run_lifecycle_start_sampling_stop` flaked on CI (Python 3.14): a graceful stop ended in phase `error`, and the only diagnostic anywhere was the assert message `non-terminal end: error`. The child interpreter is gone by the time a monitor sees the terminal phase, so the cause of the failure was unrecoverable. The assertion itself is right to be strict (a graceful stop should never end in `error`), so this PR adds diagnostics rather than loosening it.

## What

- `GuiReporter.terminal()` / `phase()` accept an optional `error=` string, written into `<prefix>_gui_status.json`
- `run_fit`'s `except BaseException` path records `traceback.format_exc()` there before re-raising
- the endpoint lifecycle test keeps the last full status doc and includes it in both failure messages, so the next flake shows the child's actual traceback
- fast unit test (`test_terminal_error_records_cause`) pins the new field

`/api/run/status` already forwarded an `error` field, so the GUI Run tab displays the cause with no endpoint change.

## Testing

- 13 fast runner/endpoint tests pass
- the slow end-to-end lifecycle test passes (84s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)