### PR TITLE
README: document runtime compiler/header requirements and WSL2 route

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ sampler will not: it builds worker pools with multiprocessing's `fork` start
 method, which does not exist on Windows. See `notes/todo.txt` if you want to
 pick this up -- patches welcome.
 
+The practical route on a Windows machine is WSL2, where an Ubuntu distro is
+simply the supported Linux platform above -- runtime requirements, PTDE
+sampler and all. Open an administrator PowerShell (from the Start menu, type
+"powershell", then click "Run as administrator") and run:
+
+```
+wsl --install -d Ubuntu-24.04
+```
+
+Reboot if prompted, open the Ubuntu app once to create a Unix user, and then
+inside Ubuntu (whose default python3 is 3.12):
+
+```
+sudo apt update
+sudo apt install g++ python3-dev python3-venv
+python3 -m venv ~/exozippy-env
+source ~/exozippy-env/bin/activate
+pip install --pre exozippy
+```
+
+Native Windows would additionally need a GCC-style C++ compiler for PyTensor's
+runtime compilation (MSVC will not do), which we have never tested.
+
 Intel macOS is untested here and needs a C++ compiler: exoplanet-core publishes
 wheels for CPython 3.12-3.14 on Linux (glibc 2.28+), Apple Silicon macOS and
 Windows, but not Intel macOS, so it builds from source there.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ without it pip reports that no matching version exists:
 pip install --pre exozippy
 ```
 
-All dependencies resolve from PyPI, so no compiler is required on the supported
-platforms below. A nightly CI job installs exactly this way, with no lock file,
-to check that a fresh install keeps working as upstream packages move.
+All dependencies resolve from PyPI, so no compiler is required to *install* on
+the supported platforms below (a compiler and the Python headers are still
+needed at *runtime* -- see "Runtime requirements" under Supported platforms). A
+nightly CI job installs exactly this way, with no lock file, to check that a
+fresh install keeps working as upstream packages move.
 
 ### For development
 
@@ -61,8 +63,37 @@ Intel macOS is untested here and needs a C++ compiler: exoplanet-core publishes
 wheels for CPython 3.12-3.14 on Linux (glibc 2.28+), Apple Silicon macOS and
 Windows, but not Intel macOS, so it builds from source there.
 
-If PyTensor cannot find a compiler you can fall back to its slower pure-Python
-mode:
+### Runtime requirements
+
+PyTensor compiles C code at runtime, so running a fit needs a C++ compiler
+*and* the Python development headers -- even though `pip install` itself
+succeeds without them. Missing headers show up as a `CompileError` ending in
+`fatal error: Python.h: No such file or directory` the first time a model is
+built. This is common on RHEL-family systems, where the headers ship in a
+separate package from Python itself. To install both:
+
+```
+# RHEL / Rocky / Alma / CentOS / Fedora (match the -devel version to your Python)
+sudo dnf install gcc-c++ python3.12-devel
+
+# Debian / Ubuntu
+sudo apt install g++ python3.12-dev
+```
+
+macOS's Xcode Command Line Tools (`xcode-select --install`) and any conda
+Python (e.g. the Miniforge setup above) already include the headers. So if you
+lack root on a Linux box, building your environment from a conda Python
+instead of the system one sidesteps the problem entirely (conda can also
+supply the compiler itself if the box has none):
+
+```
+conda create -n exozippy python=3.12
+conda activate exozippy
+pip install --pre exozippy       # or the Poetry development setup above
+```
+
+If you cannot get a compiler or headers at all, PyTensor can fall back to its
+much slower pure-Python mode -- usable as a smoke test, not for a real fit:
 
 ```
 PYTENSOR_FLAGS="blas__ldflags=,cxx="


### PR DESCRIPTION
A collaborator's fresh `pip install --pre exozippy` on a Rocky 8 box died at model build time with `fatal error: Python.h: No such file or directory` -- the install needs no compiler, but PyTensor compiles C at runtime, and RHEL-family systems ship the Python headers in a separate `-devel` package.

- Line 17's "no compiler is required" now distinguishes install from runtime and points at the new section.
- New **Runtime requirements** subsection: names the exact error, gives `dnf`/`apt` install commands for g++ + headers, spells out the no-root conda alternative (conda Pythons ship headers, and conda-forge can supply the compiler too), and keeps the pure-Python `PYTENSOR_FLAGS` fallback framed as a smoke test only.
- Windows: recommend WSL2 with explicit setup steps (admin PowerShell `wsl --install -d Ubuntu-24.04`, then apt + venv + pip inside Ubuntu), since an Ubuntu WSL2 distro is just the supported Linux platform -- PTDE sampler included -- rather than untested native-Windows compiler advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)