### PR TITLE
Auto-detect broken PyTensor C toolchain, fall back to pure-Python mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,13 @@ conda activate exozippy
 pip install --pre exozippy       # or the Poetry development setup above
 ```
 
-If you cannot get a compiler or headers at all, PyTensor can fall back to its
-much slower pure-Python mode -- usable as a smoke test, not for a real fit:
-
-```
-PYTENSOR_FLAGS="blas__ldflags=,cxx="
-```
+If the toolchain is broken anyway (no g++, or g++ without `Python.h`),
+`exozippy` detects it at startup, prints a warning naming the fix, and falls
+back automatically to PyTensor's much slower pure-Python mode -- usable as a
+smoke test, not for a real fit. (Setting `PYTENSOR_FLAGS="cxx="` by hand is
+not enough: models with more than ~31 likelihood terms then die on numpy's
+32-operand ufunc limit; the automatic fallback also installs the graph
+rewrite that works around it.)
 
 ## Running a fit
 

--- a/src/exozippy/pytensor_fallback.py
+++ b/src/exozippy/pytensor_fallback.py
@@ -1,0 +1,168 @@
+"""Detect a broken PyTensor C toolchain at startup and fall back gracefully.
+
+PyTensor compiles C code at runtime, so ``pip install`` succeeds on a machine
+that cannot actually run a fit: a missing g++ or missing Python development
+headers (the RHEL-family ``python3.12-devel`` package) only surfaces as a
+``CompileError`` deep inside the first ``pytensor.function`` call, long after
+the model has been built. ``ensure_usable_backend()`` probes the C backend
+with a trivial compile up front and, when it is broken, prints a loud banner
+naming the fix and switches PyTensor to its pure-Python backend in-process.
+
+The pure-Python backend alone is not enough: PyMC joins the model's logp
+factors with a single variadic ``add`` node, and a model with more than ~31
+factors exceeds numpy's 32-operand ufunc limit (``NPY_MAXARGS``), which
+``Elemwise.perform`` refuses (inputs + outputs > 32; the C backend has no such
+limit). The fallback therefore also registers a graph rewrite that splits any
+too-wide variadic ``Add``/``Mul`` into a tree of narrower ones. PyTensor's own
+fusion pass already self-caps at the same limit, so pre-existing variadic
+nodes are the only offenders.
+"""
+
+import logging
+import textwrap
+
+logger = logging.getLogger(__name__)
+
+# numpy ufuncs segfault or raise above 32 operands, where operands means
+# inputs + outputs. Add/Mul have one output, so at most 31 inputs per node.
+_MAX_UFUNC_OPERANDS = 32
+_MAX_FANIN = _MAX_UFUNC_OPERANDS - 1
+
+_REWRITE_REGISTERED = False
+
+
+def _split_variadic(fn, inputs):
+    """Rebuild fn(*inputs) as a tree of fn nodes with fan-in <= _MAX_FANIN."""
+    while len(inputs) > _MAX_FANIN:
+        inputs = [
+            fn(*chunk) if len(chunk) > 1 else chunk[0]
+            for chunk in (
+                inputs[i : i + _MAX_FANIN]
+                for i in range(0, len(inputs), _MAX_FANIN)
+            )
+        ]
+    return fn(*inputs)
+
+
+def register_wide_elemwise_split():
+    """Register the >32-operand Add/Mul splitting rewrite (idempotent).
+
+    Registered under the standard fast_run/fast_compile tags so every mode
+    picks it up. It fires only on nodes the Python backend cannot execute at
+    all, and the split tree is numerically identical (same pairwise-upcast
+    rules), so registering it is harmless when the C backend works -- but we
+    only bother when falling back, to leave healthy setups byte-for-byte
+    untouched.
+    """
+    global _REWRITE_REGISTERED
+    if _REWRITE_REGISTERED:
+        return
+
+    import pytensor.scalar as ps
+    import pytensor.tensor as pt
+    from pytensor.compile import optdb
+    from pytensor.graph.rewriting.basic import node_rewriter, out2in
+    from pytensor.tensor.elemwise import Elemwise
+
+    @node_rewriter([Elemwise])
+    def local_split_wide_variadic(fgraph, node):
+        if len(node.inputs) + len(node.outputs) <= _MAX_UFUNC_OPERANDS:
+            return None
+        if isinstance(node.op.scalar_op, ps.Add):
+            fn = pt.add
+        elif isinstance(node.op.scalar_op, ps.Mul):
+            fn = pt.mul
+        else:
+            return None
+        return [_split_variadic(fn, list(node.inputs))]
+
+    # Position 48.5: after add_mul_fusion (48), which flattens nested adds and
+    # so can itself create wide nodes, and before elemwise_fusion (49), which
+    # self-caps at the operand limit and creates no new offenders.
+    optdb.register(
+        "exozippy_split_wide_variadic",
+        out2in(local_split_wide_variadic, ignore_newtrees=False),
+        "fast_run",
+        "fast_compile",
+        position=48.5,
+    )
+    _REWRITE_REGISTERED = True
+
+
+def check_c_backend():
+    """Try a trivial C-backend compile; return None if it works, else the error.
+
+    On a healthy machine the probe module is in PyTensor's compile cache after
+    the first ever run, so this costs milliseconds. When the toolchain is
+    broken (no g++, or g++ without Python.h) the compile fails fast.
+    """
+    import pytensor
+    import pytensor.tensor as pt
+
+    if not pytensor.config.cxx:
+        # PyTensor already found no compiler at import (it warns and clears
+        # cxx itself), or the user forced the Python backend via
+        # PYTENSOR_FLAGS. Either way there is nothing to probe.
+        return "PyTensor has no C compiler configured (config.cxx is empty)"
+    try:
+        x = pt.dscalar("exozippy_c_backend_probe")
+        probe = pytensor.function([x], x + 1.0)
+        probe(0.0)
+    except Exception as exc:
+        return str(exc)
+    return None
+
+
+def activate_python_fallback(reason):
+    """Switch PyTensor to the pure-Python backend and make it usable."""
+    import pytensor
+
+    pytensor.config.cxx = ""
+    try:
+        pytensor.config.blas__ldflags = ""
+    except Exception:
+        pass  # only relevant to C-code BLAS probing; never fatal
+    register_wide_elemwise_split()
+
+    hint = ""
+    if "Python.h" in reason:
+        hint = (
+            "\nThe Python development headers are missing. To install them:\n"
+            "  RHEL / Rocky / Alma / Fedora:  sudo dnf install gcc-c++ python3.X-devel\n"
+            "  Debian / Ubuntu:               sudo apt install g++ python3.X-dev\n"
+            "  no root:                       use a conda Python (headers included)\n"
+            "(match the package version to your Python; see README 'Runtime\n"
+            "requirements')"
+        )
+    banner = textwrap.dedent(
+        """
+        {sep}
+        WARNING: PyTensor's C backend is unusable on this machine:
+
+        {reason}
+        {hint}
+        Falling back to PyTensor's pure-Python backend. This works, but it is
+        ORDERS OF MAGNITUDE slower -- fine as a smoke test, hopeless for a
+        real fit. Fix the toolchain above before fitting anything real.
+        {sep}
+        """
+    ).format(
+        sep="!" * 75, reason=textwrap.indent(reason.strip(), "    "), hint=hint
+    )
+    print(banner, flush=True)
+    logger.warning(
+        "PyTensor C backend unusable; using pure-Python fallback: %s", reason
+    )
+
+
+def ensure_usable_backend():
+    """Probe the C backend; fall back to pure Python (loudly) if broken.
+
+    Called once at the top of ``run_fit``, before anything compiles. Returns
+    True when the C backend works, False when the fallback was activated.
+    """
+    reason = check_c_backend()
+    if reason is None:
+        return True
+    activate_python_fallback(reason)
+    return False

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -112,6 +112,13 @@ def run_fit(config, user_params=None):
     extra.
     """
     from exozippy.gui.status import GuiReporter
+    from exozippy.pytensor_fallback import ensure_usable_backend
+
+    # Probe the C toolchain before anything compiles: a missing g++ or
+    # missing Python.h otherwise surfaces as a CompileError deep inside the
+    # first pytensor.function call. Falls back to the (much slower)
+    # pure-Python backend with a loud banner naming the fix.
+    ensure_usable_backend()
 
     gui = GuiReporter.from_config(config)
     gui.phase("preparing")

--- a/tests/test_pytensor_fallback.py
+++ b/tests/test_pytensor_fallback.py
@@ -1,0 +1,122 @@
+"""Tests for the PyTensor pure-Python backend fallback (pytensor_fallback.py)."""
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+from pytensor.compile.mode import Mode
+
+from exozippy import pytensor_fallback
+from exozippy.pytensor_fallback import (
+    _split_variadic,
+    activate_python_fallback,
+    check_c_backend,
+    ensure_usable_backend,
+    register_wide_elemwise_split,
+)
+
+
+@pytest.fixture
+def restore_pytensor_config():
+    """Save and restore the global PyTensor config the fallback mutates."""
+    cxx = pytensor.config.cxx
+    blas = pytensor.config.blas__ldflags
+    yield
+    pytensor.config.cxx = cxx
+    pytensor.config.blas__ldflags = blas
+
+
+def test_split_variadic_builds_legal_tree():
+    """Given many more inputs than the operand limit, when _split_variadic
+    rebuilds the sum, then every node in the result is narrow enough for the
+    Python backend and the value is unchanged."""
+    # Arrange: two levels of splitting required (1000 > 31*31 is false, but
+    # 1000 inputs -> 33 chunks -> a second pass is still needed).
+    n = 1000
+    xs = [pt.constant(float(i), dtype="float64") for i in range(n)]
+
+    # Act
+    out = _split_variadic(pt.add, xs)
+
+    # Assert: correct value, and no apply node anywhere exceeds the limit.
+    assert out.eval() == pytest.approx(n * (n - 1) / 2.0)
+    from pytensor.graph.traversal import ancestors
+
+    for var in ancestors([out]):
+        node = var.owner
+        if node is not None:
+            assert len(node.inputs) + len(node.outputs) <= 32
+
+
+@pytest.mark.parametrize("fn,np_fn", [(pt.add, np.sum), (pt.mul, np.prod)])
+def test_wide_variadic_runs_in_python_mode(fn, np_fn, restore_pytensor_config):
+    """Given a variadic Add/Mul wider than numpy's 32-operand ufunc limit,
+    when the splitting rewrite is registered and the graph runs on the
+    pure-Python linker, then it evaluates instead of raising
+    NotImplementedError and matches numpy."""
+    # Arrange. cxx="" mirrors the real fallback environment; with cxx set,
+    # pytensor's fusion pass assumes the C backend (1024-operand cap) and
+    # would fuse the split tree back into one too-wide Composite.
+    pytensor.config.cxx = ""
+    register_wide_elemwise_split()
+    n = 46  # what PyMC's joint logp produced for examples/ob140939
+    xs = [pt.dscalar(f"x{i}") for i in range(n)]
+    vals = 1.0 + np.arange(n) / float(n)
+
+    # Act
+    f = pytensor.function(
+        xs, fn(*xs), mode=Mode(linker="py", optimizer="fast_run")
+    )
+
+    # Assert
+    assert f(*vals) == pytest.approx(np_fn(vals))
+
+
+def test_check_c_backend_passes_on_healthy_toolchain():
+    """Given the CI/dev toolchain (which compiles C fine), when the probe
+    runs, then it reports no error."""
+    assert check_c_backend() is None
+
+
+def test_check_c_backend_reports_missing_cxx(restore_pytensor_config):
+    """Given PyTensor configured with no C compiler, when the probe runs,
+    then it returns a reason instead of raising."""
+    # Arrange
+    pytensor.config.cxx = ""
+
+    # Act
+    reason = check_c_backend()
+
+    # Assert
+    assert reason is not None
+    assert "no C compiler" in reason
+
+
+def test_activate_python_fallback_sets_config_and_warns(
+    restore_pytensor_config, capsys
+):
+    """Given a Python.h-flavored compile error, when the fallback activates,
+    then the C backend is disabled in-process, the split rewrite is
+    registered, and the banner names both the slowdown and the header fix."""
+    # Act
+    activate_python_fallback(
+        "fatal error: Python.h: No such file or directory"
+    )
+
+    # Assert
+    out = capsys.readouterr().out
+    assert pytensor.config.cxx == ""
+    assert pytensor_fallback._REWRITE_REGISTERED
+    assert "ORDERS OF MAGNITUDE slower" in out
+    assert "python3.X-devel" in out
+
+
+def test_ensure_usable_backend_is_silent_when_healthy(capsys):
+    """Given a working C toolchain, when ensure_usable_backend runs, then it
+    returns True and prints nothing."""
+    # Act
+    ok = ensure_usable_backend()
+
+    # Assert
+    assert ok is True
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
Follow-up to #50 (stacked on it; retargets to master when it merges). A collaborator's box with g++ but no Python.h only fails deep inside the first `pytensor.function` call — and it turned out the manual `PYTENSOR_FLAGS` fallback #50 documents never worked for real models anyway.

**Probe**: `run_fit` now compiles a trivial C-backend function before anything else compiles (milliseconds when healthy — compile cache; fails fast when broken). On failure it prints a loud banner quoting the compiler error, naming the fix for the `Python.h` case (`dnf install gcc-c++ python3.X-devel` / `apt install g++ python3.X-dev` / conda), and warning the fallback is orders of magnitude slower.

**Fallback**: sets `config.cxx = ""` in-process — but that alone is insufficient. PyMC joins the logp factors with one variadic `add` (46 inputs on examples/ob140939), and Python-mode `Elemwise.perform` refuses nodes with inputs+outputs > 32 (numpy's `NPY_MAXARGS`; the C backend has no such limit). The fallback therefore also registers a rewrite at optdb position 48.5 — after `add_mul_fusion` (which can create wide nodes), before `elemwise_fusion` (which self-caps at the same limit when `cxx` is empty) — splitting wide variadic `Add`/`Mul` into trees with fan-in <= 31.

**Verified**: ob140939 with `PYTENSOR_FLAGS=cxx=` previously crashed at the whitening probe under every flag combination tried (`optimizer_excluding=fusion`, `fusion:add_mul_fusion` — the wide node predates all rewrites); it now prints the banner, whitens, and samples. New `tests/test_pytensor_fallback.py` covers the tree splitter, Python-mode execution of 46-input Add/Mul, the probe, and the banner. README's manual-flags recipe replaced with the automatic behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)