### PR TITLE
DC2018 event-128 fixes: seed handoff, invalid draws, PT ladder tooling

### DIFF
--- a/examples/DC2018/dc2018.job
+++ b/examples/DC2018/dc2018.job
@@ -66,6 +66,12 @@ export PATH="$HOME/miniconda3/bin:$PATH:$HOME/.local/bin"
 source $HOME/miniconda3/etc/profile.d/conda.sh
 conda activate exozippy
 
+# PyTensor's C-module compile cache uses fcntl.flock() for its lock file.
+# ~/.pytensor's default location is under NFS-mounted $HOME, and this
+# cluster's NFS client doesn't honor advisory locks reliably (ENOLCK /
+# ESTALE mid-compile). Point it at the job's local-disk scratch dir instead.
+export PYTENSOR_FLAGS="base_compiledir=${TMPDIR:-/tmp}/pytensor"
+
 which python
 
 # Navigate to the workflow directory

--- a/examples/DC2018/run_event.py
+++ b/examples/DC2018/run_event.py
@@ -170,19 +170,22 @@ def build_config(name, files, prefix, mmx_json, args):
 def build_user_params(ra, dec):
     """Fixed-parameter overrides, mirroring examples/DC2018_128.
 
-    Coordinates come from event_info.txt. The radius/teff/feh fixes are the
-    same 'not constrainable without SED data' hack the DC2018_128 example
-    documents; the microlensing start values are deliberately ABSENT so the
-    MMEXOFAST auto-initialization triggers.
+    Coordinates come from event_info.txt. The Lens's radius/teff/feh fixes
+    are the same 'not constrainable without SED data' hack the DC2018_128
+    example documents; the microlensing start values are deliberately
+    ABSENT so the MMEXOFAST auto-initialization triggers. The Source star
+    needs none of this: star.py pins its mass/teff/feh/radius/ra/dec
+    automatically for any star that is purely a microlensing source (never
+    also a lens body), falling back to the Lens's coordinates here.
     """
-    params = {}
-    for star in ("Lens", "Source"):
-        params[f"star.{star}.ra"] = {"initval": ra, "sigma": 0}
-        params[f"star.{star}.dec"] = {"initval": dec, "sigma": 0}
-        params[f"star.{star}.teff"] = {"sigma": 0.0}
-        params[f"star.{star}.feh"] = {"sigma": 0.0}
-        params[f"star.{star}.radius"] = {"sigma": 0.0}
-    params["planet.Companion.radius"] = {"sigma": 0}
+    params = {
+        "star.Lens.ra": {"initval": ra, "sigma": 0},
+        "star.Lens.dec": {"initval": dec, "sigma": 0},
+        "star.Lens.teff": {"sigma": 0.0},
+        "star.Lens.feh": {"sigma": 0.0},
+        "star.Lens.radius": {"sigma": 0.0},
+        "planet.Companion.radius": {"sigma": 0},
+    }
     return params
 
 

--- a/run_tests.job
+++ b/run_tests.job
@@ -1,0 +1,31 @@
+# /bin/sh
+# ----------------Parameters---------------------- #
+#$ -S /bin/sh
+#$ -pe mthread 8
+#$ -q mThC.q
+#$ -cwd
+#$ -j y
+#$ -N exozippy_tests
+#$ -o run_tests.$JOB_ID.log
+#
+# One-off job to run the full pytest suite on a compute node instead of
+# the login node. Submit with: qsub run_tests.job
+
+module purge
+module load tools/python/3.13
+
+export PATH="$HOME/miniconda3/bin:$PATH:$HOME/.local/bin"
+
+source $HOME/miniconda3/etc/profile.d/conda.sh
+conda activate exozippy
+
+# PyTensor's C-module compile cache uses fcntl.flock() for its lock file.
+# ~/.pytensor's default location is under NFS-mounted $HOME, and this
+# cluster's NFS client doesn't honor advisory locks reliably (ENOLCK /
+# ESTALE mid-compile). Point it at the job's local-disk scratch dir instead.
+export PYTENSOR_FLAGS="base_compiledir=${TMPDIR:-/tmp}/pytensor"
+
+cd $HOME/python/EXOZIPPy
+
+which python
+python -m pytest

--- a/src/exozippy/components/mulensing/mulensinstrument.py
+++ b/src/exozippy/components/mulensing/mulensinstrument.py
@@ -175,16 +175,9 @@ class MulensInstrument(Instrument):
         self._resolve_mmexofast(system)
 
         # Source RA/Dec (degrees from resolve → radians for projection math)
-        source_ndx = int(system.lens.source_map[0])
-        n_stars = system.star.n_elements
-        ra_deg = self.config_manager.resolve("star", "ra", shape=(n_stars,))[
-            "initval"
-        ][source_ndx]
-        dec_deg = self.config_manager.resolve("star", "dec", shape=(n_stars,))[
-            "initval"
-        ][source_ndx]
-        ra_rad = float(ra_deg) * np.pi / 180.0
-        dec_rad = float(dec_deg) * np.pi / 180.0
+        ra_deg, dec_deg = self._resolve_source_radec_deg(system)
+        ra_rad = ra_deg * np.pi / 180.0
+        dec_rad = dec_deg * np.pi / 180.0
 
         # Geocentric reference (Skowron+2011 convention): Earth's position and
         # velocity at t_0_par define the inertial frame.  All observer positions
@@ -350,9 +343,23 @@ class MulensInstrument(Instrument):
         want_rho = bool(any(lens.finite_source))
 
         if isinstance(spec, str) and spec != "auto":
-            # Explicit JSON: masks + error factors only (Lens pushes seeds).
+            # Explicit JSON: masks + error factors, and the seed hints too.
+            # Lens re-pushes the same seeds at stage 2 (harmless, identical
+            # content); pushing them HERE as well makes them visible to this
+            # component's flux bootstrap (_estimate_flux_components), which
+            # runs later in this same load_data call -- stage 2 would be too
+            # late and the per-band flux decomposition would silently fall
+            # back to median-flux / q_source=0.95.
             self._reject_time_spec_with_mmexofast(spec)
             data = mmexofast_support.load_json(spec)
+            if data is not None:
+                mmexofast_support.push_seed_hints(
+                    data,
+                    self.config_manager,
+                    want_rho=want_rho,
+                    is_binary=is_binary,
+                    source=spec,
+                )
         else:
             if spec != "auto" and mmexofast_support.user_hints_sufficient(
                 self.config_manager.user_params, is_binary, want_rho
@@ -390,6 +397,44 @@ class MulensInstrument(Instrument):
             data, self.files, self.prefix, self.config_manager
         )
 
+    def _resolve_source_radec_deg(self, system):
+        """Source star's sky position in degrees.
+
+        Falls back to the (primary) lens star's ra/dec when the user never
+        explicitly set the source's own -- source and lens are angularly
+        coincident by construction, so params.yaml only needs to state the
+        target coordinates once, on the lens.
+        """
+        source_ndx = int(system.lens.source_map[0])
+        n_stars = system.star.n_elements
+        ra_all = self.config_manager.resolve("star", "ra", shape=(n_stars,))[
+            "initval"
+        ]
+        dec_all = self.config_manager.resolve("star", "dec", shape=(n_stars,))[
+            "initval"
+        ]
+
+        star_names = getattr(system.star, "names", None)
+        keys = [f"star.{source_ndx}.ra", "star.ra"]
+        if star_names:
+            keys.append(f"star.{star_names[source_ndx]}.ra")
+        user_set_source = any(k in self.config_manager.user_params for k in keys)
+
+        ndx = source_ndx
+        if not user_set_source:
+            primary_lens_idx = next(
+                (
+                    idx
+                    for (ctype, idx) in system.lens.lens_bodies[0]
+                    if ctype == "star"
+                ),
+                None,
+            )
+            if primary_lens_idx is not None:
+                ndx = primary_lens_idx
+
+        return float(ra_all[ndx]), float(dec_all[ndx])
+
     def _mmexofast_coords(self, system):
         """Source-star coordinates as an 'hh:mm:ss dd:mm:ss' string, or None.
 
@@ -400,17 +445,10 @@ class MulensInstrument(Instrument):
         try:
             from astropy.coordinates import SkyCoord
 
-            source_ndx = int(system.lens.source_map[0])
-            n_stars = system.star.n_elements
-            ra_deg = self.config_manager.resolve(
-                "star", "ra", shape=(n_stars,)
-            )["initval"][source_ndx]
-            dec_deg = self.config_manager.resolve(
-                "star", "dec", shape=(n_stars,)
-            )["initval"][source_ndx]
-            return SkyCoord(
-                float(ra_deg), float(dec_deg), unit="deg"
-            ).to_string(style="hmsdms")
+            ra_deg, dec_deg = self._resolve_source_radec_deg(system)
+            return SkyCoord(ra_deg, dec_deg, unit="deg").to_string(
+                style="hmsdms"
+            )
         except Exception as e:
             logger.warning(
                 f"Could not resolve source coordinates for MMEXOFAST: {e}; "
@@ -524,6 +562,11 @@ class MulensInstrument(Instrument):
         Parallax is intentionally ignored (flux scales only).
         """
         s_val = _get("lens.0.s")
+        if s_val is None:
+            # MMEXOFAST seeds carry log_s (the sampled coordinate), not s.
+            log_s = _get("lens.0.log_s")
+            if log_s is not None:
+                s_val = 10.0 ** float(log_s)
         q_val = _get("lens.0.q")
         alpha = _get("lens.0.alpha")
         if s_val is None or q_val is None or alpha is None:
@@ -593,7 +636,16 @@ class MulensInstrument(Instrument):
         n_src = getattr(self, "_n_sources", 1)
 
         def _get(key, default=None):
-            return _raw_initval(cm.user_params.get(key), default)
+            # User params first (they outrank everything), then the seed-0
+            # MMEXOFAST hints in user units. Without the seed fallback the
+            # automated workflow -- whose params file deliberately omits the
+            # microlensing start values -- never sees a geometry here and
+            # every band degrades to the median-flux / q_source=0.95 guess,
+            # which badly mis-normalizes multi-band fits.
+            val = _raw_initval(cm.user_params.get(key), None)
+            if val is None:
+                val = cm.seed_start_value(key)
+            return default if val is None else val
 
         def _get_flux(param):
             # user_params keys are normalized to index form by standardize_param_names

--- a/src/exozippy/components/parameter.py
+++ b/src/exozippy/components/parameter.py
@@ -48,6 +48,36 @@ Number = Union[int, float, np.floating]
 # numerical time bomb.
 _RAW_CANCELLATION_CLIP = 1.0e4
 
+# phys_logit clips the sigmoid's argument to +/-30: sigmoid(30) = 1 - 9.4e-14,
+# closer to 1.0 than float64 can distinguish for any practical downstream use.
+# Every raw value that pushes |lq| past this is therefore physically identical
+# to the boundary value already -- no additional posterior mass lives out
+# there that isn't already accounted for at the boundary itself. Section C
+# adds a penalty beyond this same threshold (_LOGIT_SATURATION_PENALTY_K
+# below) so a data-unconstrained direction's chain can't wander arbitrarily
+# far into that degenerate, numerically-unsafe plateau -- without touching
+# the exact-uniform correction anywhere inside it.
+_LOGIT_SATURATION_LQ = 30.0
+
+# Quadratic-in-excess coefficient for the above penalty: -k*(|lq|-30)**2.
+# Picked to bite gently (a few nats) just past the threshold -- consistent
+# with ordinary sampling noise -- and overwhelmingly (thousands of nats) by
+# |lq| ~ 100, so it stops a runaway without shifting probability mass on
+# the representable [-30, 30] interior it leaves untouched.
+#
+# Tempering note: PTDE tempers the FULL logp (ptde.py accepts on
+# dlogp / T), so a rung at temperature T sees this wall softened to a
+# Gaussian of width sigma_lq = sqrt(T / (2k)) past the clip. The quadratic
+# (not linear) growth is what makes the guard survive tempering at all --
+# a bounded-slope penalty just rescales under 1/T. With k = 0.5 the
+# hottest default rung (T_max = 200) stays within |lq| ~ 70, comparable to
+# the +/-30 interior; if T_max is ever pushed to O(10^4), scale k with it
+# (k ~ T_max / 400 keeps the 3-sigma excursion at the interior width).
+# Raising k costs nothing statistically -- the posterior-invariance
+# argument is k-independent (the wall lives entirely where phys is the
+# same clipped value) -- so when in doubt, larger is safe.
+_LOGIT_SATURATION_PENALTY_K = 0.5
+
 # Preliminary whitening scale for a sampled bounded element whose
 # defaults.yaml provides no init_scale: this fraction of (upper - lower).
 # It only needs to land within the whitening probe's dynamic range -- the
@@ -819,7 +849,9 @@ class Parameter:
             lq = sv_logit_q_inits + sv_scale_logits * raw_vector
             phys_logit = pt.as_tensor_variable(lowers) + pt.as_tensor_variable(
                 uppers - lowers
-            ) * pt.sigmoid(pt.clip(lq, -30.0, 30.0))
+            ) * pt.sigmoid(
+                pt.clip(lq, -_LOGIT_SATURATION_LQ, _LOGIT_SATURATION_LQ)
+            )
 
             # Gaussian / linear branch: mu + sigma * raw  (or initval + scale * raw)
             phys_linear = (
@@ -881,7 +913,11 @@ class Parameter:
                     else pt.constant(uppers[i])
                 )
                 span_t = pt.maximum(up_t - lo_t, 1e-12)
-                q_i = pt.sigmoid(pt.clip(lq[i], -30.0, 30.0))
+                q_i = pt.sigmoid(
+                    pt.clip(
+                        lq[i], -_LOGIT_SATURATION_LQ, _LOGIT_SATURATION_LQ
+                    )
+                )
                 phys_val = pt.set_subtensor(phys_val[i], lo_t + span_t * q_i)
                 if is_sampled[i]:
                     # Normalize the conditional uniform: p(val | bounds) = 1/span.
@@ -1076,9 +1112,29 @@ class Parameter:
             raw_cancel_safe = pt.clip(
                 raw_vector, -_RAW_CANCELLATION_CLIP, _RAW_CANCELLATION_CLIP
             )
+            # Saturation guard: log_jac's restoring slope approaches a
+            # constant (not a growing one) as |lq| -> infinity, so a
+            # data-unconstrained direction (whitening sets a large scale_logit
+            # for it) can push |lq| far past _LOGIT_SATURATION_LQ before
+            # feeling much resistance -- even though phys_logit has already
+            # clipped there, so no distinguishable physical state, and no
+            # posterior mass, lives beyond it. This adds a quadratic-in-excess
+            # penalty only past that threshold: exactly zero (and the
+            # correction above stays an exact uniform prior) on the
+            # representable interior, growing sharply beyond it so the raw
+            # coordinate can't wander into that degenerate, numerically
+            # unsafe plateau. Independent of scale_logit and of any
+            # component's physics -- keyed on lq, the same coordinate
+            # phys_logit's clip already uses.
+            saturation_excess = pt.maximum(
+                pt.abs(lq) - _LOGIT_SATURATION_LQ, 0.0
+            )
+            saturation_penalty = -_LOGIT_SATURATION_PENALTY_K * pt.sqr(
+                saturation_excess
+            )
             correction = pt.where(
                 logit_mask,
-                log_jac + 0.5 * pt.sqr(raw_cancel_safe),
+                log_jac + 0.5 * pt.sqr(raw_cancel_safe) + saturation_penalty,
                 pt.zeros_like(raw_vector),
             )
             pm.Potential(
@@ -1541,7 +1597,16 @@ class Parameter:
                     tf["logit_q_inits"][i]
                     + tf["init_scale_logits"][i] * raw[j]
                 )
-                q = 1.0 / (1.0 + np.exp(-np.clip(lq, -30.0, 30.0)))
+                q = 1.0 / (
+                    1.0
+                    + np.exp(
+                        -np.clip(
+                            lq,
+                            -_LOGIT_SATURATION_LQ,
+                            _LOGIT_SATURATION_LQ,
+                        )
+                    )
+                )
                 out[i] = (
                     tf["lowers"][i] + (tf["uppers"][i] - tf["lowers"][i]) * q
                 )

--- a/src/exozippy/components/star/star.py
+++ b/src/exozippy/components/star/star.py
@@ -1,6 +1,37 @@
+import numpy as np
+
 from exozippy.components.component import Component
 
 from . import physics
+
+
+def _microlensing_only_star_indices(system):
+    """Star indices that are exclusively a microlensing source body.
+
+    Nothing in the mulensing physics reads a source star's mass/teff/feh/
+    radius (only the lens-side bodies' masses feed t_E; see
+    mulensing/symbolic_physics.py's dead `source_mass`/`source_radius`
+    symbol-map entries -- declared, never used in a RELATIONS equation), so
+    these are dynamically irrelevant whenever a star is a source and never
+    also a lens body.
+    """
+    lens = getattr(system, "lens", None)
+    if lens is None or not getattr(lens, "source_bodies", None):
+        return set()
+
+    source_idx = {
+        idx
+        for event in lens.source_bodies
+        for (ctype, idx) in event
+        if ctype == "star"
+    }
+    lens_idx = {
+        idx
+        for event in lens.lens_bodies
+        for (ctype, idx) in event
+        if ctype == "star"
+    }
+    return source_idx - lens_idx
 
 
 class Star(Component):
@@ -124,6 +155,56 @@ class Star(Component):
 
         if "distance" in self.manifest:
             self.manifest.update({"parallax": "default", "fbol": "default"})
+
+        # Pure microlensing-source stars: pin the parameters nothing in this
+        # topology consumes, instead of requiring every microlensing
+        # params.yaml to fix them by hand (see run_event.py's old
+        # build_user_params, which did exactly this per-event).
+        ml_source_idx = _microlensing_only_star_indices(system)
+        if ml_source_idx:
+            relation_idx = set()
+            for relation in ("mann", "torres"):
+                comp = getattr(system, relation, None)
+                if comp is not None:
+                    relation_idx |= set(comp.star_indices)
+
+            sed_idx = set()
+            sed = getattr(system, "sed", None)
+            blend_matrix = getattr(sed, "blend_matrix", None)
+            if blend_matrix is not None:
+                sed_idx = set(np.nonzero((blend_matrix != 0).any(axis=0))[0])
+
+            abs_astrom_idx = set()
+            astrom = getattr(system, "astrometryinstrument", None)
+            if astrom is not None:
+                modes = getattr(astrom, "modes", None)
+                star_map = getattr(astrom, "star_map", None)
+                if modes is not None and star_map is not None:
+                    abs_astrom_idx = {
+                        int(star_map[i])
+                        for i, m in enumerate(modes)
+                        if m in ("gaia", "abs")
+                    }
+
+            def _pin_sigma(param_name, skip_idx):
+                idx_list = sorted(ml_source_idx - skip_idx)
+                if not idx_list or param_name not in self.manifest:
+                    return
+                entry = self.manifest[param_name]
+                entry = dict(entry) if isinstance(entry, dict) else {}
+                pin = np.full(self.n_elements, np.nan)
+                pin[idx_list] = 0.0
+                overrides = dict(entry.get("overrides", {}))
+                overrides["sigma"] = pin.tolist()
+                entry["overrides"] = overrides
+                self.manifest[param_name] = entry
+
+            _pin_sigma("logmass", relation_idx)
+            _pin_sigma("teff", relation_idx | sed_idx)
+            _pin_sigma("feh", relation_idx | sed_idx)
+            _pin_sigma("radius", relation_idx | sed_idx)
+            _pin_sigma("ra", abs_astrom_idx)
+            _pin_sigma("dec", abs_astrom_idx)
 
     def build_likelihood(self, model, system):
         # Explicit pass-through!

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -505,6 +505,29 @@ class ConfigManager:
         if rank is not None:
             self.seed_hint_rank = rank
 
+    def seed_start_value(self, path, seed=0):
+        """Seed-hint start value for ``path`` in USER units, or None.
+
+        ``add_seed_hints`` stores values in index-form paths and INTERNAL
+        units (via ``_translate_and_scale``).  Stage-1 consumers that read
+        raw ``user_params`` entries -- which are still in user units before
+        ``finalize_user_params`` runs -- use this as the matching-unit
+        fallback (e.g. the mulens flux bootstrap needs alpha in degrees,
+        the MulensModel convention, not the internal radians).
+        """
+        sets = self.seed_hint_sets or []
+        if seed >= len(sets):
+            return None
+        tpath, _ = self._translate_and_scale(path, 0.0)
+        if tpath not in sets[seed]:
+            return None
+        parts = tpath.split(".")
+        factor = self.get_conversion_factor(
+            parts[0], parts[-1], full_path=path
+        )
+        val = float(sets[seed][tpath])
+        return val / factor if factor else val
+
     def add_scale_hint(self, path, scale):
         """
         Register a context-appropriate PRELIMINARY init_scale for a parameter.

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -168,7 +168,14 @@ def _run_fit(config, gui, user_params=None):
     method = sampler_cfg.get(
         "method", None
     )  # None → auto-select after system is built
-    n_temps = int(sampler_cfg.get("n_temps", 8))
+    # "auto" passes through to the sampler, which sizes the ladder from the
+    # parameter count once the model is built (ptde.resolve_n_temps).
+    _n_temps_raw = sampler_cfg.get("n_temps", 8)
+    n_temps = (
+        _n_temps_raw
+        if isinstance(_n_temps_raw, str)
+        else int(_n_temps_raw)
+    )
     T_max = float(sampler_cfg.get("T_max", 200.0))
     _n_chains_raw = sampler_cfg.get("n_chains", None)
     n_chains = int(_n_chains_raw) if _n_chains_raw is not None else None

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -111,6 +111,66 @@ def _geometric_ladder(n_temps, T_max):
     return T_max ** (np.arange(n_temps) / (n_temps - 1))
 
 
+def resolve_n_temps(n_temps, n_params, T_max):
+    """Resolve the sampler-config ``n_temps``, including ``"auto"``.
+
+    ``auto`` sizes the ladder a priori for adjacent-rung energy overlap on
+    a D-dimensional target: between rungs the mean logp shifts by
+    ~(D/2)*ln(r) while fluctuating ~sqrt(D/2), so geometric spacing wants
+    ln(r) ~ sqrt(2/D), i.e. n = ceil(sqrt(D/2) * ln(T_max)) rungs (floored
+    at the historical EXOFASTv2-parity 8). This is an a priori estimate;
+    the definitive, problem-specific check is the measured communication
+    barrier logged by ladder_health_report at the end of every run -- the
+    DEO schedule tolerates ladders leaner than this formula, and heavy
+    tails or multimodality can demand more than it.
+    """
+    if isinstance(n_temps, str):
+        if n_temps.strip().lower() != "auto":
+            raise ValueError(
+                f"n_temps must be an integer or 'auto', got {n_temps!r}"
+            )
+        n = max(8, int(np.ceil(np.sqrt(n_params / 2.0) * np.log(T_max))))
+        logger.info(
+            f"n_temps: auto -> {n} rungs "
+            f"(D={n_params}, T_max={T_max:g}, sqrt(D/2)*ln(T_max))"
+        )
+        return n
+    return int(n_temps)
+
+
+def ladder_health_report(temperatures, n_swap_accept, n_swap_propose):
+    """Log the measured communication barrier; warn if the ladder chokes.
+
+    Lambda = sum over adjacent-rung pairs of their swap REJECTION rates --
+    the empirical global communication barrier of Syed et al. 2022 (JRSS-B).
+    Under the non-reversible DEO schedule the T_max<->T=1 round-trip rate
+    approaches 1/(2 + 2*Lambda) once n_temps is comfortably above Lambda;
+    with n_temps - 1 < ~2*Lambda the ladder itself is the mixing
+    bottleneck, and the fix is more rungs (sampler config n_temps -- or
+    n_temps: auto), not more draws.
+    """
+    n_temps = len(temperatures)
+    prop = np.asarray(n_swap_propose, dtype=float)
+    if n_temps < 2 or prop.sum() <= 0:
+        return None
+    rej = 1.0 - np.asarray(n_swap_accept, dtype=float) / np.maximum(prop, 1.0)
+    lam = float(np.sum(np.clip(rej, 0.0, 1.0)))
+    logger.info(
+        f"PT ladder health: communication barrier Lambda={lam:.2f} with "
+        f"n_temps={n_temps} (DEO round-trip ceiling ~ 1/(2+2*Lambda) = "
+        f"{1.0 / (2.0 + 2.0 * lam):.3f} per swap round)"
+    )
+    recommended = int(np.ceil(2.0 * lam)) + 1
+    if (n_temps - 1) < 2.0 * lam:
+        logger.warning(
+            f"PT ladder is communication-limited: n_temps={n_temps} is "
+            f"below ~2*Lambda+1 = {recommended}. Round trips between T_max "
+            f"and T=1 -- not draws -- are the mixing bottleneck; raise "
+            f"n_temps to ~{recommended} (or set n_temps: auto) and rerun."
+        )
+    return lam
+
+
 # The chain-initialization probe lives in exozippy.whitening now (it is also
 # the engine behind the data-driven whitening rescale done at model setup);
 # PTDE re-probes the already-whitened model, where every scale is ~1, so the
@@ -622,7 +682,12 @@ def ptde_sample(
     model : PyMC model (from system.build_model())
     system : EXOZIPPy System (MAP start + raw→physical conversion)
     draws, tune : int
-    n_temps : int   — temperature rungs (default 8, EXOFASTv2 parity)
+    n_temps : int | "auto"  — temperature rungs (default 8, EXOFASTv2
+               parity); "auto" → max(8, ceil(sqrt(D/2)·ln(T_max))), sized
+               for adjacent-rung energy overlap (see resolve_n_temps).
+               Every run also logs the measured communication barrier and
+               warns when the ladder is the mixing bottleneck
+               (ladder_health_report).
     T_max : float   — hottest temperature (default 200, EXOFASTv2 parity)
     n_chains : int | None  — chains per temperature rung;
                None → 2 × n_params (standard DE minimum for good mixing)
@@ -715,6 +780,13 @@ def ptde_sample(
         )
 
     rng = np.random.default_rng(seed)
+
+    # parameter bookkeeping -- before the ladder, since n_temps may be
+    # "auto" (sized from the parameter count; see resolve_n_temps).
+    raw_start = system.get_raw_start(model)
+    model_keys = list(raw_start.keys())
+    n_params = sum(v.size for v in raw_start.values())
+    n_temps = resolve_n_temps(n_temps, n_params, T_max)
     temperatures = _geometric_ladder(n_temps, T_max)
 
     _rung_thin_factor = max(1, int(rung_thin_factor))
@@ -771,10 +843,6 @@ def ptde_sample(
     raw_var_names = [v.name for v in model.free_RVs]  # ordered input names
     out_var_names = [v.name for v in output_vars]  # ordered output names
 
-    # parameter bookkeeping
-    raw_start = system.get_raw_start(model)
-    model_keys = list(raw_start.keys())
-    n_params = sum(v.size for v in raw_start.values())
     if n_chains is None:
         n_chains = 2 * n_params  # standard DE minimum for good mixing
     if gamma is None:
@@ -1420,6 +1488,9 @@ def ptde_sample(
             else ""
         )
     )
+    # Post-tune swap counters (window resets stop when tuning ends), so this
+    # measures the FINAL ladder's communication barrier.
+    ladder_health_report(temperatures, n_swap_accept, n_swap_propose)
 
     if collect_rung_timing:
         logger.info("PTDE per-rung logp timing (seconds):")

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -75,6 +75,8 @@ from exozippy.samplers.ptde import (
     _record_round_trips,
     _safe_progress,
     _worker_init,
+    ladder_health_report,
+    resolve_n_temps,
 )
 
 logger = logging.getLogger(__name__)
@@ -152,6 +154,13 @@ def ptde_async_sample(
     _ptde._PTDE_COLLECT_TIMING = collect_rung_timing
 
     rng = np.random.default_rng(seed)
+
+    # parameter bookkeeping -- before the ladder, since n_temps may be
+    # "auto" (sized from the parameter count; see ptde.resolve_n_temps).
+    raw_start = system.get_raw_start(model)
+    model_keys = list(raw_start.keys())
+    n_params = sum(v.size for v in raw_start.values())
+    n_temps = resolve_n_temps(n_temps, n_params, T_max)
     temperatures = _geometric_ladder(n_temps, T_max)
 
     # compile logp ONCE; store in ptde.py's module global BEFORE forking
@@ -187,10 +196,6 @@ def ptde_async_sample(
     raw_var_names = [v.name for v in model.free_RVs]
     out_var_names = [v.name for v in output_vars]
 
-    # parameter bookkeeping
-    raw_start = system.get_raw_start(model)
-    model_keys = list(raw_start.keys())
-    n_params = sum(v.size for v in raw_start.values())
     if n_chains is None:
         n_chains = 2 * n_params
     if gamma is None:
@@ -748,6 +753,9 @@ def ptde_async_sample(
             else ""
         )
     )
+    # Async never resets the swap counters, so these stats span tune+draw;
+    # still the right order of magnitude for the barrier check.
+    ladder_health_report(temperatures, n_swap_accept, n_swap_propose)
 
     if collect_rung_timing:
         logger.info("PTDE-async per-rung logp timing (seconds):")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,11 @@ class _DummyConfigManager:
     def add_scale_hint(self, *args, **kwargs):
         pass
 
+    def seed_start_value(self, path, seed=0):
+        # No seed hints in the stub (the real ConfigManager returns None for
+        # a path no seed set carries).
+        return None
+
 
 class _DummyComponent:
     """Stub component whose only observable property is n_elements."""

--- a/tests/test_mmexofast_support.py
+++ b/tests/test_mmexofast_support.py
@@ -319,3 +319,45 @@ def test_run_or_load_uses_cached_json(tmp_path):
     cached.write_text('{"fits": [], "errfacs": {}}')
     data = mmx.run_or_load(cached, ["a.txt"])
     assert data == {"fits": [], "errfacs": {}}
+
+
+# ---------------------------------------------------------------------------
+# ConfigManager.seed_start_value: user-unit view of the seed hints
+# ---------------------------------------------------------------------------
+
+
+def test_seed_start_value_returns_user_units():
+    """
+    Given seed hints pushed through the real ConfigManager (which stores
+    internal units -- alpha in radians),
+    When seed_start_value reads them back,
+    Then the values come back in USER units (alpha in degrees), matching what
+    a raw user_params entry would hold, so stage-1 consumers (the mulens flux
+    bootstrap) can use either source interchangeably.
+    """
+    from exozippy.config import ConfigManager
+
+    cm = ConfigManager({}, system_config={"lens": [{"name": "Lens"}]})
+    cm.add_seed_hints(
+        [
+            {
+                "lens.0.t_0": 2458554.82,
+                "lens.0.u_0": 0.131,
+                "lens.0.t_E": 19.16,
+                "lens.0.log_s": -0.066,
+                "lens.0.alpha": -50.37,
+                "lens.0.q": 9.26e-4,
+            },
+            {"lens.0.alpha": -50.47},
+        ]
+    )
+
+    stored = cm.seed_hint_sets[0]["lens.0.alpha"]
+    assert np.isclose(stored, np.deg2rad(-50.37))  # internal storage: rad
+
+    assert np.isclose(cm.seed_start_value("lens.0.alpha"), -50.37)
+    assert np.isclose(cm.seed_start_value("lens.0.t_0"), 2458554.82)
+    assert np.isclose(cm.seed_start_value("lens.0.log_s"), -0.066)
+    assert np.isclose(cm.seed_start_value("lens.0.alpha", seed=1), -50.47)
+    assert cm.seed_start_value("lens.0.rho") is None  # never pushed
+    assert cm.seed_start_value("lens.0.t_0", seed=5) is None  # no such seed

--- a/tests/test_parameter_logic.py
+++ b/tests/test_parameter_logic.py
@@ -670,6 +670,72 @@ def test_logit_prior_is_flat_in_physical_space():
     )
 
 
+def test_logit_saturation_guard_is_inert_inside_and_quadratic_outside():
+    """
+    Given a bounded sampled parameter with no sigma,
+    When the logp is evaluated at raw values mapping inside and beyond the
+    sigmoid's +/-30 saturation clip,
+    Then inside the clip the logp exactly matches the analytic flat-prior
+      pushforward (the guard contributes nothing -- posterior unchanged),
+      and beyond it the logp additionally falls by k*(|lq|-30)^2 (the
+      confinement that keeps unconstrained directions off the degenerate
+      plateau, where every raw maps to the identical clipped physical value).
+    """
+    from exozippy.components.parameter import (
+        _LOGIT_SATURATION_LQ,
+        _LOGIT_SATURATION_PENALTY_K,
+    )
+
+    # ARRANGE: q0 = 0.5, span = 10, init_scale = 1 -> lq = 0.4 * raw,
+    # so raw = 75 sits exactly at the clip and raw = 100 well beyond it.
+    initval, lower, upper, init_scale = 5.0, 0.0, 10.0, 1.0
+    with pm.Model() as model:
+        p = Parameter(
+            label="p",
+            initval=initval,
+            init_scale=init_scale,
+            lower=lower,
+            upper=upper,
+        )
+        p.build_pymc()
+        logp_fn = model.compile_logp()
+
+    span = upper - lower
+    q0 = (initval - lower) / span
+    c = init_scale / (q0 * (1 - q0) * span)  # d(lq)/d(raw) = 0.4
+
+    def expected_shape(raw):
+        # logp up to a raw-independent constant: the exact log-Jacobian
+        # (softplus form, matching build_pymc) plus the saturation guard.
+        # The N(0,1) prior is cancelled by the +raw^2/2 correction term.
+        lq = c * raw
+        log_jac = -np.logaddexp(0.0, lq) - np.logaddexp(0.0, -lq)
+        excess = max(abs(lq) - _LOGIT_SATURATION_LQ, 0.0)
+        return log_jac - _LOGIT_SATURATION_PENALTY_K * excess**2
+
+    # ACT: measure logp differences against raw = 0 (constant drops out)
+    lp0 = float(logp_fn({"p_raw": np.array([0.0])}))
+    raws = [-100.0, -80.0, -74.0, -3.0, 3.0, 74.0, 80.0, 100.0]
+    measured = [
+        float(logp_fn({"p_raw": np.array([r])})) - lp0 for r in raws
+    ]
+    predicted = [expected_shape(r) - expected_shape(0.0) for r in raws]
+
+    # ASSERT
+    assert np.allclose(measured, predicted, atol=1e-6), (
+        f"logp shape deviates from analytic flat-prior + saturation guard:\n"
+        f"raws      = {raws}\nmeasured  = {measured}\npredicted = {predicted}"
+    )
+    # And the guard is strictly confining: logp decreases monotonically
+    # outward beyond the clip.
+    lp_74, lp_80, lp_100 = (
+        measured[raws.index(74.0)],
+        measured[raws.index(80.0)],
+        measured[raws.index(100.0)],
+    )
+    assert lp_74 > lp_80 > lp_100
+
+
 def test_bounded_sigma_param_logp_matches_truncated_normal():
     """
     Given a bounded sampled parameter with mu/sigma,

--- a/tests/test_ptde.py
+++ b/tests/test_ptde.py
@@ -689,3 +689,67 @@ def test_shutdown_pool_kills_workers_that_ignore_sigterm():
         assert pool2.apply_async(abs, (-3,)).get(timeout=10) == 3
     finally:
         _shutdown_pool(pool2)
+
+
+# ---------------------------------------------------------------------------
+# n_temps: "auto" resolution and ladder-health reporting
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_n_temps_auto_scales_with_dimension():
+    """
+    Given the "auto" n_temps mode,
+    When resolved for targets of increasing dimension,
+    Then the ladder size follows max(8, ceil(sqrt(D/2)*ln(T_max))) -- the
+      adjacent-rung energy-overlap rule -- and an explicit integer passes
+      through untouched.
+    """
+    from exozippy.samplers.ptde import resolve_n_temps
+
+    assert resolve_n_temps("auto", 5, 200.0) == 9
+    assert resolve_n_temps("auto", 27, 200.0) == 20
+    # tiny problems keep the EXOFASTv2-parity floor of 8
+    assert resolve_n_temps("auto", 2, 200.0) == 8
+    # explicit values (int or numeric string) are honored verbatim
+    assert resolve_n_temps(8, 27, 200.0) == 8
+    assert resolve_n_temps(12, 5, 200.0) == 12
+    with pytest.raises(ValueError, match="auto"):
+        resolve_n_temps("automagic", 27, 200.0)
+
+
+def test_ladder_health_report_warns_only_when_communication_limited(caplog):
+    """
+    Given end-of-run swap statistics,
+    When the ladder health report runs,
+    Then Lambda equals the summed adjacent-pair rejection rates, a healthy
+      ladder logs no warning, a choked one warns with the ~2*Lambda+1
+      recommendation, and degenerate inputs (no swaps) return None.
+    """
+    import logging
+
+    from exozippy.samplers.ptde import ladder_health_report
+
+    temps = _geometric_ladder(8, 200.0)
+
+    with caplog.at_level(logging.WARNING, logger="exozippy.samplers.ptde"):
+        lam = ladder_health_report(
+            temps, np.full(7, 90.0), np.full(7, 100.0)
+        )
+        assert np.isclose(lam, 0.7)
+        assert not caplog.records
+
+        lam = ladder_health_report(
+            temps, np.full(7, 20.0), np.full(7, 100.0)
+        )
+        assert np.isclose(lam, 5.6)
+        assert any(
+            "communication-limited" in r.message for r in caplog.records
+        )
+        # recommendation is ceil(2*Lambda)+1
+        assert any("~13" in r.message for r in caplog.records)
+
+    assert ladder_health_report(temps, np.zeros(7), np.zeros(7)) is None
+    assert (
+        ladder_health_report(np.array([1.0]), np.zeros(1), np.zeros(1))
+        is None
+    )

--- a/tests/test_runaway_logp_regression.py
+++ b/tests/test_runaway_logp_regression.py
@@ -73,7 +73,10 @@ RUNAWAY_RAW = {
     "mulensinstrument.q_source_raw": [-101671.55477455864],
     "planet.mass_raw": [195576323.76112023],
     "star.distance_raw": [-5303.75771384, -8672.6901092],
-    "star.logmass_raw": [3950.28058978, -76714.41614803],
+    # star.1 (Source) is a pure microlensing source: star.py now pins its
+    # mass (nothing in mulensing physics consumes a source's mass), so only
+    # star.0 (Lens)'s historical raw value remains sampled.
+    "star.logmass_raw": [3950.28058978],
     "star.pm_dec_raw": [3.12510181e05, 1.57096079e08],
     "star.pm_ra_raw": [-3.34082488e08, -4.12501179e07],
     "star.rv_raw": [2201.98526294, -691.32034664],
@@ -95,7 +98,8 @@ GOOD_RAW = {
     "mulensinstrument.q_source_raw": [-0.31134542581872854],
     "planet.mass_raw": [-0.9441505502539654],
     "star.distance_raw": [-345.90821049, 91.83850293],
-    "star.logmass_raw": [87.18591661, 0.50417452],
+    # star.1 (Source)'s mass is now pinned (see RUNAWAY_RAW's comment above).
+    "star.logmass_raw": [87.18591661],
     "star.pm_dec_raw": [-5.27994699, 0.40483486],
     "star.pm_ra_raw": [2.99778494, 1.37559868],
     "star.rv_raw": [2.36402842, -1.05406419],


### PR DESCRIPTION
Root-causes and fixes from the DC2018 event 128 investigation, where the fit converged confidently to a different wrong PSPL-like mode on every run.

## Fixes

- **Jobs / NFS**: PyTensor's compile-cache flock() lock lives under NFS-mounted $HOME and the cluster's NFS client drops advisory locks (ENOLCK/ESTALE mid-compile). Both job scripts now point base_compiledir at the job's local-disk $TMPDIR; new run_tests.job runs the suite on a compute node.

- **Star**: parameters of pure microlensing-source stars (mass/teff/feh/radius/ra/dec) are auto-pinned via the manifest `overrides` channel -- nothing in the mulensing physics consumes them, and the source's free logmass (constrained only by the weak IMF potential) was the dominant contributor to 33.5% of draws being rejected as numerically invalid. Exact: a zero-consumer parameter's posterior factorizes. Source ra/dec falls back to the lens star's coordinates.

- **Parameter**: quadratic penalty -k(|lq|-30)^2 beyond the logit saturation clip, where every raw value already maps to the bit-identical boundary value. Kills the remaining invalid draws (unconstrained hogg out_scale/out_frac directions random-walking the degenerate plateau under tempered acceptance). Statistically exact -- the only posterior change is reweighting an unreachable ~9e-14 boundary point mass. Event 128: 0 of 2,025,000 draws invalid after this.

- **MMEXOFAST seed handoff**: the per-band flux bootstrap read t_0/u_0/t_E from raw user_params only, which the automated workflow deliberately omits -- so the NNLS flux decomposition never ran and every band fell back to q_source=0.95 / median baseline, badly mis-normalizing multi-band fits (this is what let the hogg mixture eat the caustic anomaly and produce the wrong-mode fits). The bootstrap now falls back to the seed hints (new unit-aware ConfigManager.seed_start_value), and explicit-JSON seeds are pushed at stage 1a where the bootstrap can see them.

- **PTDE**: `n_temps: auto` (max(8, ceil(sqrt(D/2) ln T_max)), opt-in; explicit ints and the EXOFASTv2-parity default unchanged) and an end-of-run ladder-health report: measured communication barrier Lambda (Syed et al. 2022) logged every run, with a warning and concrete recommended rung count when the ladder is the mixing bottleneck.

## Tests
- New: saturation-guard logp shape pinned against closed form on both sides of the threshold; seed_start_value unit round-trip; resolve_n_temps / ladder_health_report behaviors.
- Updated: runaway-logp regression point drops the now-pinned source-mass element.
- Full suite green on the cluster before the final PTDE/n_temps commit; a post-rebase suite run is queued.

Verification on DC2018 event 128: invalid draws 33.5% -> 20.6% -> 0; start models now co-normalized across both bands (full re-fit in progress, ~8h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)