### PR TITLE
Multi-seed restarts: mode-aware seeding, seed polish, minority-mode reporting

### DIFF
--- a/examples/DC2018/run_event.py
+++ b/examples/DC2018/run_event.py
@@ -154,7 +154,11 @@ def build_config(name, files, prefix, mmx_json, args):
         ],
         "sampler": {
             "method": args.sampler,
-            "n_temps": 8,
+            "n_temps": (
+                args.n_temps
+                if str(args.n_temps).lower() == "auto"
+                else int(args.n_temps)
+            ),
             "T_max": 200,
             "cores": args.cores,
             "tune": args.tune,
@@ -163,6 +167,12 @@ def build_config(name, files, prefix, mmx_json, args):
             "recompute_trace": bool(args.recompute),
             "eval_timeout": 10,
         },
+        # Degenerate events routinely leave chains split across solution
+        # branches with no inter-mode mixing; occupancy weights then reflect
+        # initialization, not posterior mass (event 128: 52/54 chains in a
+        # branch 500 nats WORSE than the one the other 2 found). Per-mode
+        # bridge-sampling evidence weights are the designed remedy.
+        "modes": {"weights": "evidence"},
     }
     return config
 
@@ -230,6 +240,13 @@ def main(argv=None):
         "--finite-source",
         action="store_true",
         help="Model finite-source effects (default off, as in DC2018_128)",
+    )
+    ap.add_argument(
+        "--n-temps",
+        default="8",
+        help="PT temperature rungs: an integer or 'auto' "
+        "(max(8, ceil(sqrt(D/2)*ln(T_max))); use when the ladder-health "
+        "warning reports a communication-limited ladder)",
     )
     ap.add_argument(
         "--recompute",

--- a/src/exozippy/mkparam.py
+++ b/src/exozippy/mkparam.py
@@ -72,19 +72,51 @@ def _next_versioned_path(param_path):
     return p.parent / f"{base}.{n + 1}{suffix}"
 
 
+def _mode_seed_quotas(weights, n):
+    """Allocate ``n`` seeds across modes: every mode gets at least one seed
+    (a restart must never erase a discovered mode), the rest go by weight
+    (largest remainder). With more modes than seeds, the top-n by weight
+    get one each."""
+    order = np.argsort(weights)[::-1]
+    if n <= len(weights):
+        quotas = np.zeros(len(weights), dtype=int)
+        quotas[order[:n]] = 1
+        return quotas
+    w = np.asarray(weights, dtype=float)
+    w = w / w.sum()
+    remaining = n - len(w)
+    ideal = w * remaining
+    quotas = np.ones(len(w), dtype=int) + np.floor(ideal).astype(int)
+    shortfall = n - int(quotas.sum())
+    if shortfall > 0:
+        frac_order = np.argsort(ideal - np.floor(ideal))[::-1]
+        quotas[frac_order[:shortfall]] += 1
+    return quotas
+
+
 def _sample_seed_draws(idata, n, exclude, rng_seed=0):
     """Pick ``n`` random JOINT (chain, draw) index pairs for multi-seed starts.
 
-    Draws are taken from the GOOD chains and the POST-BURN-IN region only
-    (samplers.convergence.find_burnin drops the initial transient and any
-    stuck chain), so every seed is a real point in the equilibrated posterior
-    and the set spans the true covariance. Whole draws are returned (a chain
-    and draw index), never per-parameter marginals, so a downstream consumer
-    that reads all parameters at (chain, draw) gets one self-consistent point.
+    When the trace is multimodal (outputs.modes.identify_modes finds more
+    than one mode), the draws are STRATIFIED BY MODE -- every mode gets at
+    least one seed and the rest are allocated by mode weight -- so a restart
+    can never launder a multimodal posterior into a single-basin start set.
+    (The old good-chain pooling did exactly that: good_chain_mask is a
+    stuck-chain detector, and against a multimodal trace it classifies mode
+    membership as sickness -- on DC2018 event 128 it flagged the 52
+    majority-branch chains as bad because the 2 true-branch chains' lp was
+    582 nats higher.)
 
-    Returns (pairs, good_mask, burnin) where ``good_mask`` and ``burnin`` also
-    describe the pool used, so a caller can compute statistics over exactly
-    the same post-burn-in good draws.
+    Within a mode (and in the unimodal fall-back path) draws are taken from
+    the POST-BURN-IN region of the good chains, so every seed is a real
+    point in the equilibrated posterior. Whole draws are returned (a chain
+    and draw index), never per-parameter marginals, so a downstream consumer
+    that reads all parameters at (chain, draw) gets one self-consistent
+    point.
+
+    Returns (pairs, good_mask, burnin) where ``good_mask`` and ``burnin``
+    also describe the pool used, so a caller can compute statistics over
+    exactly the same post-burn-in good draws.
     """
     post = idata["posterior"]
     var_names = convergence.default_var_names(post)
@@ -98,9 +130,53 @@ def _sample_seed_draws(idata, n, exclude, rng_seed=0):
     burnin, good_mask = diag["burnin"], diag["good_mask"]
     good_chains = np.nonzero(good_mask)[0]
     n_draws = int(post.sizes["draw"])
-
     rng = np.random.default_rng(rng_seed)
     draw_lo = min(burnin, max(0, n_draws - 1))
+
+    # ---- mode-stratified path -------------------------------------------
+    labels = None
+    try:
+        from exozippy.outputs.modes import identify_modes
+
+        report = identify_modes(idata, attach=False)
+        if report.n_modes > 1:
+            labels = report.labels  # (chain, draw); -1 = invalid/unassigned
+            weights = [m.weight for m in report.modes]
+    except Exception as e:  # never let mode analysis break seed emission
+        logger.warning(
+            f"mkprior: mode identification failed ({e}); falling back to "
+            f"unstratified seed draws."
+        )
+
+    if labels is not None:
+        quotas = _mode_seed_quotas(weights, n)
+        logger.info(
+            "mkprior: multimodal trace -- stratifying %d seeds across %d "
+            "modes (quotas %s, weights %s)",
+            n,
+            len(quotas),
+            quotas.tolist(),
+            [f"{w:.3f}" for w in weights],
+        )
+        pairs, seen = [], {tuple(exclude)}
+        for m, quota in enumerate(quotas):
+            cs, ds = np.nonzero(labels == m)
+            post_burn = ds >= draw_lo
+            if post_burn.sum() >= quota:  # prefer equilibrated draws
+                cs, ds = cs[post_burn], ds[post_burn]
+            idx = rng.permutation(len(cs))
+            taken = 0
+            for j in idx:
+                if taken >= quota:
+                    break
+                pair = (int(cs[j]), int(ds[j]))
+                if pair not in seen:
+                    seen.add(pair)
+                    pairs.append(pair)
+                    taken += 1
+        return pairs, good_mask, burnin
+
+    # ---- unimodal / fallback path ---------------------------------------
     pairs, seen = [], {tuple(exclude)}
     attempts = 0
     while len(pairs) < n and attempts < 50 * max(n, 1):

--- a/src/exozippy/outputs/modes.py
+++ b/src/exozippy/outputs/modes.py
@@ -50,6 +50,19 @@ DEFAULT_LP_ABS_MAX = 1e12
 # runaways pinned at bounds (observed values: 1e3..1e27 vs bulk ~1e2).
 DEFAULT_Z_MAX = 50.0
 
+# lp exemption from the raw-z filter: a draw far outside the bulk in raw
+# space but with lp this close to (or better than) the z-passing bulk's
+# median is a CANDIDATE MODE, not a runaway, and is routed into clustering
+# instead of being invalidated.  Every genuine runaway population observed
+# to date sat >~1000 nats below the bulk (saturated-plateau states;
+# lp-insane states are caught by DEFAULT_LP_ABS_MAX separately), while a
+# real minority mode can sit ABOVE the bulk -- DC2018 event 128's true
+# s~0.98 branch was found by 2/54 chains at +500 nats and was discarded as
+# 'raw-z invalid', reporting the wrong branch as a clean unimodal fit.  A
+# genuinely-real mode more than this many nats BELOW the dominant one
+# carries e^-50 of its mass and loses nothing by staying flagged.
+DEFAULT_LP_EXEMPT_MARGIN = 50.0
+
 # With the runaway-lp cancellation bug fixed, ONLY a model or sampler bug
 # should produce invalid draws.  Above this fraction of the trace, run.py
 # refuses to emit final tables (evidence -- trace + mode report -- is written
@@ -401,6 +414,7 @@ def identify_modes(
     max_modes: int = 8,
     z_max: float = DEFAULT_Z_MAX,
     lp_abs_max: float = DEFAULT_LP_ABS_MAX,
+    lp_exempt_margin: float = DEFAULT_LP_EXEMPT_MARGIN,
     merge_ratio: float = 0.5,
     subsample: int = 20000,
     seed: int = 20260711,
@@ -420,6 +434,9 @@ def identify_modes(
     max_modes : upper limit for the BIC scan.
     z_max : robust z-score threshold for the invalid-draw filter.
     lp_abs_max : |lp| above this marks a draw invalid (numerically broken).
+    lp_exempt_margin : a draw beyond z_max whose lp is within this many
+        nats of the z-passing bulk's median (or better) is exempted from
+        raw-z invalidation and clustered as a candidate mode.
     merge_ratio : density-dip merge threshold; higher merges more eagerly.
     subsample : cluster on at most this many draws (assignment of the rest
         is by nearest center); keeps k selection fast on huge traces.
@@ -486,6 +503,29 @@ def identify_modes(
         scale = np.where(mad > 0, mad, 1.0)
         z = np.abs((X - med) / scale)
         z_ok = np.nan_to_num(z, nan=np.inf).max(axis=1) <= z_max
+        # lp exemption: a z-failing draw whose lp is within
+        # lp_exempt_margin of the z-PASSING bulk's median (or better) is a
+        # candidate mode, not a runaway -- route it into clustering.  Real
+        # runaways (saturated-plateau states) sit >~1000 nats below the
+        # bulk; a true minority mode can sit ABOVE it (see
+        # DEFAULT_LP_EXEMPT_MARGIN).  Skipped when lp is unavailable.
+        if has_lp and (valid & z_ok).any():
+            lp_bulk_med = np.median(lp[valid & z_ok])
+            exempt = (
+                valid
+                & ~z_ok
+                & np.nan_to_num(lp >= lp_bulk_med - lp_exempt_margin)
+            )
+            n_exempt = int(exempt.sum())
+            if n_exempt:
+                notes.append(
+                    f"{n_exempt} draws beyond raw-z {z_max:g} kept as "
+                    f"candidate modes: their lp is within "
+                    f"{lp_exempt_margin:g} nats of the in-bulk median "
+                    f"({lp_bulk_med:.2f}) or better -- a displaced basin, "
+                    f"not a runaway."
+                )
+                z_ok |= exempt
         valid &= z_ok
         reasons[(reasons == "") & ~z_ok] = "raw-z"
 

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -89,6 +89,7 @@ KNOWN_SAMPLER_KEYS = {
     "rung_thin_start",
     "collect_rung_timing",
     "swap_schedule",
+    "seed_polish",
 }
 
 
@@ -303,6 +304,28 @@ def _run_fit(config, gui, user_params=None):
         # get_raw_starts returns just [raw_start], [0] for the ordinary case.
         raw_starts, seed_indices = system.get_raw_starts(model)
 
+        # Per-seed T=1 DE polish (sampler-config `seed_polish`): "auto"
+        # (default) polishes SOLUTION-ESTIMATE seeds -- MMEXOFAST fits,
+        # which can start hundreds of nats below their own basin's optimum
+        # and lose their chains to better-looking basins during tuning --
+        # but never posterior-draw seed sets (params.2 initval lists),
+        # which are already at equilibrium and would all polish to the
+        # same point per basin. `on`/`off`/int force it; int = step count.
+        _polish_raw = sampler_cfg.get("seed_polish", "auto")
+        _DEFAULT_POLISH_STEPS = 150
+        if isinstance(_polish_raw, str) and _polish_raw.lower() == "auto":
+            seed_polish_steps = (
+                _DEFAULT_POLISH_STEPS
+                if getattr(system.config_manager, "seed_hint_sets", None)
+                else 0
+            )
+        elif _polish_raw in (True, "on"):
+            seed_polish_steps = _DEFAULT_POLISH_STEPS
+        elif _polish_raw in (False, None, "off"):
+            seed_polish_steps = 0
+        else:
+            seed_polish_steps = max(0, int(_polish_raw))
+
         # convert raw starting point to the internal starting point
         internal_start = system.get_internal_point(model, raw_start)
 
@@ -353,6 +376,7 @@ def _run_fit(config, gui, user_params=None):
                     raw_scales=(
                         whiten_report["raw_scales"] if whiten_report else None
                     ),
+                    seed_polish_steps=seed_polish_steps,
                     plot_prefix=str(prefix),
                     min_ess=min_ess,
                     max_rhat=max_rhat,
@@ -387,6 +411,7 @@ def _run_fit(config, gui, user_params=None):
                     raw_scales=(
                         whiten_report["raw_scales"] if whiten_report else None
                     ),
+                    seed_polish_steps=seed_polish_steps,
                     plot_prefix=str(prefix),
                     min_ess=min_ess,
                     max_rhat=max_rhat,

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -190,6 +190,93 @@ from exozippy.whitening import (
 )
 
 
+def polish_seed_starts(
+    raw_starts,
+    logp_fn,
+    rng,
+    scales,
+    n_steps=150,
+    pop_size=None,
+    gamma=None,
+):
+    """T=1 differential-evolution polish of each seed's raw start.
+
+    For each seed: spawn a small population jittered at ONE scale unit
+    around the seed (staying inside its own basin -- this is a local
+    refiner, not a search), run ``n_steps`` of DE-MC at T=1 (Metropolis
+    acceptance on difference-vector proposals, the same move the sampler
+    itself uses), and return the best-lp point visited as the new seed.
+
+    Rationale: an unpolished solution-estimate seed (e.g. a raw MMEXOFAST
+    fit) can start hundreds of nats below its own basin's optimum, and
+    chains rationally defect to whichever basin LOOKS best at
+    initialization -- on DC2018 event 128, 26 of 27 chains abandoned the
+    true branch (ultimately 500 nats better once refined) because its seed
+    started ~100 nats below the wrong branch's seed. Gradient-free by
+    construction (the binary-lens magnification Op has no analytic
+    gradient). Greedy DE optimizers converge similarly but collapse the
+    population to a point; Metropolis-at-T=1 costs the same and the caller
+    only takes the best point anyway, with _make_starts re-jittering
+    chains around it as usual.
+
+    Returns (polished_starts, dlp_per_seed).
+    """
+    if isinstance(raw_starts, dict):
+        raw_starts = [raw_starts]
+    keys = list(raw_starts[0].keys())
+    n_params = sum(np.asarray(v).size for v in raw_starts[0].values())
+    if pop_size is None:
+        pop_size = int(max(8, min(2 * n_params, 64)))
+    if gamma is None:
+        gamma = 2.38 / np.sqrt(2 * max(n_params, 1))
+
+    polished, dlps = [], []
+    for s, center in enumerate(raw_starts):
+        pop = [{k: np.array(v, dtype=float) for k, v in center.items()}]
+        for _ in range(pop_size - 1):
+            pop.append(
+                {
+                    k: center[k]
+                    + scales[k] * rng.standard_normal(np.shape(center[k]))
+                    for k in keys
+                }
+            )
+        lps = np.array([float(logp_fn(p)) for p in pop])
+        # Non-finite members re-center (a jitter may cross a hard bound).
+        for i in np.nonzero(~np.isfinite(lps))[0]:
+            pop[i] = {k: np.array(v, dtype=float) for k, v in center.items()}
+            lps[i] = lps[0]
+        best_i = int(np.nanargmax(lps))
+        best = {k: v.copy() for k, v in pop[best_i].items()}
+        best_lp = float(lps[best_i])
+        lp0 = float(lps[0])  # the seed's own lp (member 0 = exact center)
+
+        for _ in range(int(n_steps)):
+            for i in range(pop_size):
+                j1, j2 = _pick_two(rng, pop_size, i)
+                prop = {
+                    k: pop[i][k]
+                    + gamma * (pop[j1][k] - pop[j2][k])
+                    + 1e-4 * scales[k] * rng.standard_normal(
+                        np.shape(pop[i][k])
+                    )
+                    for k in keys
+                }
+                lp = float(logp_fn(prop))
+                if np.isfinite(lp) and np.log(rng.random()) < lp - lps[i]:
+                    pop[i], lps[i] = prop, lp
+                    if lp > best_lp:
+                        best_lp = lp
+                        best = {k: v.copy() for k, v in prop.items()}
+        polished.append(best)
+        dlps.append(best_lp - lp0)
+        logger.info(
+            f"PTDE seed polish: seed {s} lp {lp0:.1f} -> {best_lp:.1f} "
+            f"(dlp=+{best_lp - lp0:.1f}, {n_steps} steps x {pop_size} pop)"
+        )
+    return polished, dlps
+
+
 def _make_starts(
     n_chains,
     raw_starts,
@@ -198,6 +285,7 @@ def _make_starts(
     seed_indices=None,
     system=None,
     raw_scales=None,
+    polish_steps=0,
 ):
     """Generate n_chains starting points near one or more seeds (P4).
 
@@ -253,6 +341,16 @@ def _make_starts(
     n_params = sum(v.size for v in raw_starts[0].values())
     factor = min(np.sqrt(500.0 / max(n_params, 1)), 3.0)
     max_iter = 1000
+
+    # Optional per-seed T=1 DE polish (run.py gates this on seed
+    # provenance: solution-estimate seeds only, never posterior-draw
+    # seed sets, which are already at their basin's equilibrium).
+    if polish_steps and int(polish_steps) > 0:
+        raw_starts, _dlps = polish_seed_starts(
+            raw_starts, logp_fn, rng, scales, n_steps=int(polish_steps)
+        )
+        map_lp = float(logp_fn(raw_starts[0]))
+
     _jitter = (
         getattr(system, "jitter_raw_start", None)
         if system is not None
@@ -271,16 +369,33 @@ def _make_starts(
     starts = []
     chain_seed_index = []
     seed_seen = set()
+    # Cap the number of chains that start EXACTLY at a seed. With K ~
+    # n_chains (a params.2-style posterior-draw seed set), every chain
+    # would otherwise start at a previous-run posterior draw with zero
+    # jitter -- and since the DE population's spread IS the proposal
+    # generator, the restart could then never explore beyond the previous
+    # posterior, entrenching whatever that run missed. At least half the
+    # chains always get the factor-scaled jitter.
+    max_exact = max(1, n_chains // 2)
+    n_exact = 0
+    if K > max_exact:
+        logger.info(
+            f"PTDE init: {K} seeds > {max_exact} exact-start budget "
+            f"(half the {n_chains} chains); the rest start jittered around "
+            f"their seed to keep restart overdispersion."
+        )
     for j in range(n_chains):
         s = j % K
         center = raw_starts[s]
-        # First chain of each seed group starts exactly at the solved seed.
-        if s not in seed_seen:
+        # First chain of each seed group starts exactly at the solved seed
+        # (up to the overdispersion budget above).
+        if s not in seed_seen and n_exact < max_exact:
             lp0 = float(logp_fn(center))
             if np.isfinite(lp0):
                 starts.append({k: v.copy() for k, v in center.items()})
                 chain_seed_index.append(seed_indices[s])
                 seed_seen.add(s)
+                n_exact += 1
                 logger.debug(
                     f"PTDE init chain {j}: exact seed {seed_indices[s]} "
                     f"(lp={lp0:.1f})"
@@ -654,6 +769,7 @@ def ptde_sample(
     raw_starts=None,
     seed_indices=None,
     raw_scales=None,
+    seed_polish_steps=0,
     gamma=None,
     target_accept=0.20,
     adapt_gamma=True,
@@ -875,6 +991,7 @@ def ptde_sample(
             seed_indices,
             system=system,
             raw_scales=raw_scales,
+            polish_steps=seed_polish_steps,
         )
 
     # ensemble start plots (T=1 starts only; raw→physical via the batched fn)

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -96,6 +96,7 @@ def ptde_async_sample(
     raw_starts=None,
     seed_indices=None,
     raw_scales=None,
+    seed_polish_steps=0,
     gamma=None,
     target_accept=0.20,
     adapt_gamma=True,
@@ -225,6 +226,7 @@ def ptde_async_sample(
             seed_indices,
             system=system,
             raw_scales=raw_scales,
+            polish_steps=seed_polish_steps,
         )
 
     if plot_prefix is not None:

--- a/tests/test_mkprior_multiseed.py
+++ b/tests/test_mkprior_multiseed.py
@@ -154,3 +154,51 @@ def test_multi_seed_seed0_is_map(tmp_path):
     assert params["lens.L.t_0"]["initval"][0] == pytest.approx(
         map_t0, abs=1e-6
     )
+
+
+def _make_bimodal_trace(tmp_path, nchain=6, ndraw=400, seed=0):
+    """Trace where chains 0-4 sit in one tight mode and chain 5 in another,
+    displaced far beyond the raw-z threshold, with HIGHER lp (the DC2018
+    event 128 topology). Without mode stratification, good_chain_mask
+    drops the five majority chains (their lp never reaches the best
+    chain's median) or the fallback pools by occupancy."""
+    rng = np.random.default_rng(seed)
+    t0_raw = 0.001 * rng.standard_normal((nchain, ndraw))
+    t0_raw[5] += 8.0  # minority mode, ~8000 robust-z away
+    lp = 1000.0 + 3.0 * rng.standard_normal((nchain, ndraw))
+    lp[5] += 500.0  # minority mode fits better
+    post = {
+        "lens.t_0": 2000.0 + t0_raw,
+        "lens.t_0_raw": t0_raw,
+    }
+    idata = az.from_dict({"posterior": post, "sample_stats": {"lp": lp}})
+    trace_path = tmp_path / "run_trace.nc"
+    idata.to_netcdf(str(trace_path))
+    return trace_path
+
+
+def test_multi_seed_stratifies_across_modes(tmp_path):
+    """
+    Given a bimodal trace (5 chains in one basin, 1 chain in a displaced,
+      better-lp basin),
+    When mkprior emits 8 seeds,
+    Then the initval list contains draws from BOTH basins -- a restart can
+      never launder a multimodal posterior into a single-basin seed set.
+    """
+    trace_path = _make_bimodal_trace(tmp_path)
+    out = mkprior(
+        {"prefix": "run", "lens": [{"name": "L"}]},
+        base_dir=tmp_path,
+        trace_path=trace_path,
+        n_seeds=8,
+    )
+    params = yaml.safe_load(Path(out).read_text())
+
+    t0_seeds = np.asarray(params["lens.L.t_0"]["initval"], dtype=float)
+    assert len(t0_seeds) == 8
+    in_minority = t0_seeds > 2004.0  # displaced basin sits at ~2008
+    in_majority = t0_seeds < 2004.0
+    assert in_minority.any(), f"no minority-mode seeds: {t0_seeds}"
+    assert in_majority.any(), f"no majority-mode seeds: {t0_seeds}"
+    # seed 0 is the global MAP, which lives in the better-lp minority basin
+    assert t0_seeds[0] > 2004.0

--- a/tests/test_mode_report.py
+++ b/tests/test_mode_report.py
@@ -604,3 +604,57 @@ def test_latex_tablecomments_notes_invalid_draws(tmp_path):
     text = tmpl_path.read_text()
     assert "5 draws" in text
     assert "model or sampler bug" in text
+
+
+# ----------------------------------------------------------------------
+# raw-z lp exemption: displaced high-lp basins are modes, not runaways
+# ----------------------------------------------------------------------
+
+
+def test_displaced_high_lp_minority_is_a_mode_not_invalid():
+    """
+    Given a minority cluster (one chain's worth) displaced far beyond the
+      raw-z threshold but with lp ABOVE the bulk's median (the DC2018 event
+      128 scenario: 2/54 chains found the true s-branch at +500 nats and
+      were discarded as 'raw-z invalid'),
+    When identify_modes runs,
+    Then those draws are exempted from invalidation and reported as a
+      second mode, with no invalid draws at all.
+    """
+    rng = np.random.default_rng(7)
+    a = rng.normal(0.0, 0.001, N)  # razor-tight bulk: huge robust z for any offset
+    lp = rng.normal(1000.0, 3.0, N)
+    minority = slice(0, N_DRAW)  # chain 0 entirely in the displaced basin
+    a[minority] = rng.normal(5.0, 0.001, N_DRAW)  # z ~ 5000 sigma_bulk
+    lp[minority] = rng.normal(1500.0, 3.0, N_DRAW)  # +500 nats: better fit
+
+    rep = identify_modes(_make_idata({"a_raw": a}, lp))
+
+    assert rep.n_invalid == 0
+    assert rep.n_modes == 2
+    assert any("candidate modes" in n for n in rep.notes)
+    # the displaced basin is the best mode (delta_lp_max = 0 by definition
+    # of the best); the majority mode trails by ~500 nats
+    lp_maxes = sorted((m.lp_max for m in rep.modes), reverse=True)
+    assert lp_maxes[0] - lp_maxes[1] > 400
+
+
+def test_displaced_low_lp_cluster_stays_invalid():
+    """
+    Given a cluster equally far beyond the raw-z threshold but with lp
+      ~1000 nats BELOW the bulk (the runaway/saturated-plateau signature),
+    When identify_modes runs,
+    Then the lp exemption does not fire and the draws stay invalid.
+    """
+    rng = np.random.default_rng(11)
+    a = rng.normal(0.0, 0.001, N)
+    lp = rng.normal(1000.0, 3.0, N)
+    runaway = slice(0, 300)
+    a[runaway] = rng.normal(5.0, 0.001, 300)
+    lp[runaway] = rng.normal(0.0, 3.0, 300)  # -1000 nats: degraded
+
+    rep = identify_modes(_make_idata({"a_raw": a}, lp))
+
+    assert rep.n_invalid == 300
+    assert rep.invalid_reason_counts == {"raw-z": 300}
+    assert rep.n_modes == 1

--- a/tests/test_ptde.py
+++ b/tests/test_ptde.py
@@ -753,3 +753,69 @@ def test_ladder_health_report_warns_only_when_communication_limited(caplog):
         ladder_health_report(np.array([1.0]), np.zeros(1), np.zeros(1))
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# Seed polish and exact-start overdispersion cap
+# ---------------------------------------------------------------------------
+
+
+def _quad_logp_factory(center):
+    def logp(point):
+        return -0.5 * float(
+            sum(np.sum((v - center[k]) ** 2) for k, v in point.items())
+        )
+
+    return logp
+
+
+def test_polish_seed_starts_climbs_to_basin_optimum():
+    """
+    Given a seed displaced ~5 sigma from its basin's optimum (a rough
+      solution estimate, like an unpolished MMEXOFAST fit),
+    When polish_seed_starts runs a T=1 DE polish,
+    Then the returned start's logp improves by nearly the full deficit and
+      the reported per-seed dlp matches.
+    """
+    from exozippy.samplers.ptde import polish_seed_starts
+
+    rng = np.random.default_rng(3)
+    center = {"a": np.array([5.0, -3.0]), "b": np.array([2.0])}
+    logp = _quad_logp_factory(center)
+    seed = {"a": np.zeros(2), "b": np.zeros(1)}  # lp = -19
+    scales = {k: np.ones_like(v) for k, v in seed.items()}
+
+    polished, dlps = polish_seed_starts(
+        [seed], logp, rng, scales, n_steps=200
+    )
+
+    assert logp(polished[0]) > -0.5  # from -19 to (near) 0
+    assert dlps[0] > 18.0
+
+
+def test_make_starts_caps_exact_seed_chains():
+    """
+    Given a params.2-style seed set nearly as large as the chain count,
+    When _make_starts builds the chain starts,
+    Then at most half the chains start exactly at a seed (the rest are
+      jittered), so a restart keeps overdispersed exploration power instead
+      of freezing the population at the previous run's posterior draws.
+    """
+    rng = np.random.default_rng(5)
+    logp = _quad_logp_factory({"a": np.zeros(2)})
+    K, n_chains = 10, 12
+    seeds = [{"a": np.array([float(k), float(-k)])} for k in range(K)]
+    scales = {"a": np.ones(2)}
+
+    starts, chain_seed_index = _make_starts(
+        n_chains, seeds, logp, rng, raw_scales=scales
+    )
+
+    assert len(starts) == n_chains
+    n_exact = sum(
+        any(np.array_equal(st["a"], sd["a"]) for sd in seeds)
+        for st in starts
+    )
+    assert n_exact <= n_chains // 2
+    # every seed still contributes a chain (round-robin unchanged)
+    assert set(chain_seed_index) == set(range(K))


### PR DESCRIPTION
Follow-up to #55, closing the remaining multi-seed failure modes found on DC2018 event 128 and in field reports of params.2 restarts underperforming.

## Fixes

- **Modes**: the raw-z invalid-draw filter exempts displaced draws whose lp is within 50 nats of the bulk median or better -- those are minority MODES, not runaways. Event 128's true branch (2/54 chains, +582 nats) was previously discarded as "invalid" and the wrong branch reported as a clean unimodal fit. Verified against archived runaway traces: none of their genuinely-broken draws would be exempted.

- **mkprior**: multi-seed draws are stratified by posterior mode (every mode gets >=1 seed, rest by weight). The old good-chain pooling used a stuck-chain detector that classifies mode membership as sickness, laundering multimodal traces into single-basin restarts.

- **PTDE seed polish**: short T=1 DE-MC per seed (gradient-free; the mag Op has no analytic gradient) promotes each solution-estimate seed to its basin's optimum before chains initialize. Gated on provenance: MMEXOFAST seeds yes, params.2 posterior-draw seeds no. On event 128: +238/+320 nats per seed, and the refit converged unimodally to the TRUE branch (u_0 pull 0.9, t_E pull 1.9; residual s/q offsets consistent with finite-source being off).

- **PTDE exact-start cap**: at most half the chains start exactly at a seed; a params.2-sized seed set previously left zero jittered chains, freezing the DE population's exploration power at the previous run's posterior width.

- **DC2018**: per-event evidence weighting (occupancy weights are init-dependent when chains don't mix) and an --n-temps flag (int or 'auto'); the new ladder-health report measured Lambda=6.57 vs n_temps=8 on event 128 and recommended ~15.

## Tests
5 new tests (lp-exemption both directions, mode-stratified seeding, polish convergence, exact-start cap); full cluster suite 911 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)