### PR TITLE
Relaxation engine: hash-order-proof iteration + pin the regression lp

### DIFF
--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -1820,7 +1820,11 @@ class ConfigManager:
         if not isinstance(eq, sp.Eq):
             return False
 
-        symbols_in_eq = [str(s) for s in eq.free_symbols]
+        # Sorted: free_symbols is a set of Symbols whose hashes include the
+        # PYTHONHASHSEED-randomized name string, so bare iteration order
+        # varies per process.  The July-2026 init_scale flakiness came from
+        # exactly this in the (since-deleted) scale passes.
+        symbols_in_eq = sorted(str(s) for s in eq.free_symbols)
 
         # 1. Gatekeeper: Skip if equation contains undefined variables
         if not all(s in self.master_symbol_map for s in symbols_in_eq):
@@ -2085,8 +2089,11 @@ class ConfigManager:
         if len(valid_solutions) == 1:
             valid_val, valid_sol = valid_solutions[0]
         else:
+            # Sorted by value: sp.solve's root order is not contractual, and
+            # the strict < below means equal-score roots go to whichever came
+            # first -- break that tie by value, not arrival order.
             best_val, best_sol, best_score = None, None, float("inf")
-            for val, sol in valid_solutions:
+            for val, sol in sorted(valid_solutions, key=lambda vs: vs[0]):
                 temp = {**resolved, target_str: val}
                 score = 0.0
                 for other_eq in self.all_relations:

--- a/tests/test_runaway_logp_regression.py
+++ b/tests/test_runaway_logp_regression.py
@@ -28,12 +28,18 @@ vectors), and an isolated single-parameter toy model does not reproduce the
 cancellation at all (see git history of this file/commit message for the
 toy-model dead end). The real draw sidesteps both problems.
 
-Note: the "good" draw's lp is checked only for ordinary magnitude, not an
-exact historical match -- System.prepare()'s symbolic relaxation engine
-turned out to not be perfectly deterministic across process runs (a
-*derived* bound can differ enough between two fresh builds of the identical
-model to shift lp by ~1e5-1e6), a separate pre-existing issue found while
-building this test. See test_good_draw_logp_is_ordinary's docstring.
+Note: the "good" draw's lp is pinned to the CURRENT model's value, not the
+historical stored lp (~2982.18) -- the model has legitimately changed since
+that trace (log_s sampling, pinned source mass).  The check used to be
+finite-only because System.prepare() was not deterministic across process
+runs; that turned out to be PYTHONHASHSEED-ordered iteration of
+eq.free_symbols in the relaxation engine's (since-deleted) sympy scale
+passes, scattering init_scale by orders of magnitude and with it the
+raw->physical map.  The whitening refactor removed the broken passes and
+config.py now sorts every free_symbols walk, so the build is bit-for-bit
+reproducible and the value check is back.  If a deliberate model change
+moves the value, re-measure it at this exact raw point and update
+GOOD_EXPECTED_LP.
 
 Marked 'slow' (builds a full System + compiles PyTensor graphs).
 """
@@ -138,27 +144,33 @@ def _point(raw_dict):
     return {k: np.asarray(v, dtype=float) for k, v in raw_dict.items()}
 
 
-def test_good_draw_logp_is_finite(dc2018_128_logp):
+# Measured at this exact raw point on a deterministic build (2026-08-07,
+# post free_symbols-sort hardening).  Differs from the historical stored lp
+# (~2982.18) because the model itself has changed since that trace; see the
+# module docstring.
+GOOD_EXPECTED_LP = -936.526
+
+
+def test_good_draw_logp_matches_deterministic_build(dc2018_128_logp):
     """
     Given the DC2018_128 model,
     When logp is evaluated at the last ordinary (pre-runaway) raw-space state
     of chain 23,
-    Then it is finite, confirming GOOD_RAW is read correctly against this
-    model's free_RVs.
-
-    This does NOT check the value is close to the historical stored lp
-    (~2982.18), and deliberately doesn't bound its magnitude either:
-    System.prepare()'s symbolic relaxation engine turned out, while building
-    this test, to not be perfectly deterministic across process runs -- a
-    *derived* bound (e.g. lens.q's) can differ enough between two fresh
-    builds of the identical model (same YAML+params) to shift lp by as much
-    as ~1e6. That's a separate, pre-existing bug, out of scope for the PTDE
-    cancellation fix this file otherwise regression-tests; the finite-only
-    check here just confirms the point evaluates at all.
+    Then it reproduces the pinned value of a deterministic build -- both
+    confirming GOOD_RAW is read correctly against this model's free_RVs and
+    regression-guarding System.prepare()'s run-to-run reproducibility
+    (this check was finite-only while the relaxation engine's deleted sympy
+    scale passes made init_scale, and with it the raw->physical map,
+    PYTHONHASHSEED-dependent).
     """
     logp_fn = dc2018_128_logp
     val = float(np.asarray(logp_fn(_point(GOOD_RAW))))
-    assert np.isfinite(val), f"expected a finite lp, got {val}"
+    assert abs(val - GOOD_EXPECTED_LP) < 5.0, (
+        f"lp at the good draw moved: got {val:.4f}, expected "
+        f"{GOOD_EXPECTED_LP} +/- 5. Either build reproducibility broke "
+        f"(PYTHONHASHSEED sensitivity) or the model changed deliberately -- "
+        f"if the latter, re-measure and update GOOD_EXPECTED_LP."
+    )
 
 
 def test_runaway_draw_no_longer_produces_large_positive_logp(dc2018_128_logp):


### PR DESCRIPTION
## Summary

Closes out the July-2026 relaxation-engine "nondeterminism" investigation. The root cause of the run-to-run lp variation (the reason `test_good_draw_logp_is_finite` was loosened to finite-only) was PYTHONHASHSEED-ordered iteration of `eq.free_symbols` in the since-deleted sympy scale passes: `init_scale` on ~20 parameters scattered by 3-4 orders of magnitude between hash seeds, moving the raw->physical whitening map and derived soft-bound barrier steepness (the observed ~1e5-1e6 lp shifts at an identical raw point, isolating to `low_bound.lens.q`). Solved values, provenance, and bounds were deterministic all along; the whitening refactor removed the broken passes.

This PR hardens what remains so the bug class cannot return, and re-arms the regression check:

- `_relax_equation` builds `symbols_in_eq` sorted (`free_symbols` is a set of Symbols whose hashes include the hash-randomized name string, so bare iteration order varies per process).
- `_execute_solve`'s multi-root scoring iterates roots sorted by value, so equal-score roots tie-break by value instead of sp.solve arrival order.
- `test_good_draw_logp_is_finite` -> `test_good_draw_logp_matches_deterministic_build`: pins the good draw's lp to -936.526 +/- 5, measured on the hardened build (bit-identical across random hash seeds; differs from the historical ~2982 because the model has legitimately changed since that trace).

## Evidence

- July-12 checkout (`0413b70`): 8 runs with random hash seeds -> 8 different init_scale sets; fixed PYTHONHASHSEED -> bit-identical (4/4 seed 0, 2/2 seed 7). Same signature at `71503b7`; gone from `bec3227` (whitening refactor) on.
- Current code + this PR: prepare() and full per-factor logp decomposition bit-identical across processes and hash seeds on DC2018_128.

## Test plan

- `tests/test_runaway_logp_regression.py` (2 passed on this branch, rebased on master)
- Engine-heavy subset (config healing, initial solver, linked params, log_s, multiseed, mmexofast support, solve API): 62 passed on this branch
- Full suite: 961 passed with these changes on the development tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)