### PR TITLE
Whitening: gradient-immune symmetric-curvature probe with fallback ladder

### DIFF
--- a/src/exozippy/whitening.py
+++ b/src/exozippy/whitening.py
@@ -4,11 +4,17 @@ rescale the model's whitening in place.
 The model is first built with PRELIMINARY whitening scales (defaults.yaml
 init_scale, or a fraction of the bound span when absent -- see
 Parameter.build_pymc).  probe_scales() then measures, per raw element, the
-step in the current raw coordinate at which logp falls 0.5 nats below the
-start (the EXOFASTv2 exofast_getmcmcscale convention: dlogp=0.5 <-> dchi2=1,
-the 1-sigma step for a locally Gaussian posterior).  Because one raw unit is
-one preliminary scale by construction, the measured step IS the multiplicative
-correction to the preliminary scale.  apply_measured_whitening() feeds it to
+step in the current raw coordinate whose symmetric second difference of logp
+reaches 1 nat -- 0.5 nats per side, the EXOFASTv2 exofast_getmcmcscale
+convention (dlogp=0.5 <-> dchi2=1, the 1-sigma step for a locally Gaussian
+posterior), made gradient-immune: the second difference cancels the linear
+Taylor term identically, so the measurement returns the local curvature width
+1/sqrt(h) even when the start is far below the mode (where the one-sided drop
+it replaces measured 0.5/|gradient| instead, arbitrarily tight).  Directions
+with no measurable positive curvature fall back to the one-sided nearer
+contour; see probe_scales.  Because one raw unit is one preliminary scale by
+construction, the measured step IS the multiplicative correction to the
+preliminary scale.  apply_measured_whitening() feeds it to
 Parameter.set_whitening(), which updates the pytensor.shared whitening scales
 in place -- no model rebuild, and the posterior is provably unchanged (the
 logit-uniform correction potential cancels the raw N(0,1) prior symbolically
@@ -42,6 +48,16 @@ _PROBE_MAX_BISECT = 40
 _PROBE_FLAT_SCALE = 1.0  # fallback when neither direction reaches target;
 # raw variables are N(0,1) by construction, so 1.0
 # is the natural unit for a direction logp ignores.
+
+# An element whose gradient contributes more than this many nats over one
+# measured scale unit is "gradient-dominated": for a locally quadratic logp,
+# |g|*sigma is the start's displacement from its conditional optimum in
+# sigmas, so 3.0 means "the start is >~3 sigma off along this direction".
+# The curvature probe still measures the width correctly there (that is its
+# point); the warning exists because everything else that uses the START --
+# chain scatter, tempered burn-in, the reported start table -- degrades with
+# displacement, and a seed polish would fix it at the source.
+_GRAD_DOMINATED_NATS = 3.0
 
 # The whitening pass widens the probe's dynamic range: a preliminary scale
 # (defaults.yaml, or the span-fraction fallback) can be off by 10+ orders of
@@ -104,6 +120,106 @@ def probe_step_1d(
     return max(0.5 * (lo + hi), min_step)
 
 
+def _probe_element(
+    eval_delta,
+    target=PROBE_TARGET_DELTA,
+    max_step=_PROBE_MAX_STEP,
+    min_step=_PROBE_MIN_STEP,
+    rtol=_PROBE_RTOL,
+    max_bisect=_PROBE_MAX_BISECT,
+):
+    """Measure one element's scale: symmetric curvature first, then the
+    one-sided nearer contour, then None (flat).
+
+    The symmetric second difference C(s) = delta(+s) + delta(-s)
+    (= 2*lp(x0) - lp(x0+s) - lp(x0-s)) cancels the gradient term of the
+    Taylor expansion identically, so bracket+bisect on C(s) = 2*target
+    returns 1/sqrt(h) -- the local Gaussian sigma -- whether or not the
+    start is at the mode.  A non-finite side (hard prior wall inside +/-s)
+    counts as past-target, so a wall bounds the scale at its own distance,
+    matching the one-sided behavior.
+
+    When C never reaches the target within max_step (h <= 0: a locally
+    linear direction, a ridge, or a saddle) the curvature is meaningless
+    and the measurement falls back to the one-sided probe of each sign,
+    taking the NEARER contour -- which errs tight, the direction every
+    downstream consumer absorbs.  When both signs are flat too, returns
+    (None, "flat", nan) and the caller applies its flat fallback.
+
+    Returns (scale_or_None, method, grad_nats) where method is one of
+    "curvature" / "linear" / "flat" and grad_nats = |delta(+s) - delta(-s)|/2
+    at the accepted curvature scale (nan otherwise): the gradient's nats over
+    one scale unit, i.e. the start's displacement from its conditional
+    optimum in sigmas for a locally quadratic logp.
+    """
+    cache = {}
+
+    def d(step):
+        if step not in cache:
+            cache[step] = eval_delta(step)
+        return cache[step]
+
+    def curv(s):
+        dp, dm = d(s), d(-s)
+        if not (np.isfinite(dp) and np.isfinite(dm)):
+            return np.inf  # a wall inside +/-s: treat as past-target (tight)
+        return dp + dm
+
+    target_c = 2.0 * target
+    # BRACKET on the symmetric drop; same geometry as probe_step_1d.
+    lo, hi = 0.0, None
+    step = 1.0
+    while step <= max_step:
+        if curv(step) >= target_c:
+            hi = step
+            break
+        lo = step
+        step *= 2.0
+
+    if hi is not None:
+        s_h = None
+        for _ in range(max_bisect):
+            mid = 0.5 * (lo + hi)
+            c = curv(mid)
+            if np.isfinite(c) and abs(c - target_c) <= rtol * target_c:
+                s_h = mid
+                break
+            if c > target_c:
+                hi = mid
+            else:
+                lo = mid
+            if (hi - lo) < min_step:
+                break
+        if s_h is None:
+            s_h = max(0.5 * (lo + hi), min_step)
+        dp, dm = d(s_h), d(-s_h)
+        grad_nats = (
+            0.5 * abs(dp - dm)
+            if np.isfinite(dp) and np.isfinite(dm)
+            else np.nan
+        )
+        return min(s_h, max_step), "curvature", grad_nats
+
+    # FALLBACK: no measurable positive curvature out to max_step.  The
+    # one-sided searches reuse the cached evaluations from the bracket above.
+    steps = [
+        probe_step_1d(
+            d,
+            sign,
+            target=target,
+            max_step=max_step,
+            min_step=min_step,
+            rtol=rtol,
+            max_bisect=max_bisect,
+        )
+        for sign in (1.0, -1.0)
+    ]
+    steps = [x for x in steps if x is not None]
+    if steps:
+        return min(float(np.min(steps)), max_step), "linear", np.nan
+    return None, "flat", np.nan
+
+
 def probe_scales(
     raw_start,
     logp_fn,
@@ -111,38 +227,48 @@ def probe_scales(
     min_step=_PROBE_MIN_STEP,
     max_bisect=_PROBE_MAX_BISECT,
     flat_scale=_PROBE_FLAT_SCALE,
+    diagnostics=None,
 ):
     """Adaptive probe: per-element scale whose raw step costs ~0.5 nats.
 
-    Follows EXOFASTv2's exofast_getmcmcscale in searching each sign
-    independently for the step where logp falls PROBE_TARGET_DELTA below the
-    start, but takes the NEARER of the two contours rather than their average
-    (a single direction is used when the other is flat; _PROBE_FLAT_SCALE when
-    both are).  EXOFASTv2 averages because it probes from an AMOEBA best fit,
-    where the two directions are near-symmetric.  Our seeds are not at the
-    mode -- an mkprior seed for examples/ogle0383 probes from ~41 nats below
-    the MAP -- and off the mode the two directions are wildly asymmetric: the
-    uphill one only turns over on the far side of the mode, so averaging it in
-    inflates the scale (u1_raw: 1.2 nearer contour, ~5.7 far side, 3.4
-    averaged).  Chains then jitter past the logit transform's saturation walls
-    and start pinned at the bounds, which is the pathology this scale exists to
-    avoid.  The nearer contour is a well-defined local width, is exactly sigma
-    at a mode (where both contours coincide), and only ever errs tight -- which
-    downstream consumers absorb (chain-scatter multipliers, DE's own ensemble
-    expansion, and NUTS mass-matrix adaptation).
+    Per element the measurement is _probe_element's three-rung ladder:
 
-    The step is found by bracket + bisect.  An earlier version instead walked a
-    fixed probe ladder [0.003 ... 2.0], took the FIRST magnitude registering any
-    drop at all, and extrapolated with a quadratic assumption,
-    scale = |dp| * sqrt(target/delta).  That assumption only holds AT a maximum.
-    raw_start is initval, not the MAP, so logp is generally LINEAR in a probe
-    around it -- doubling the probe doubles the drop (measured ratio 2.00, not
-    the 4.0 a quadratic implies) -- and for a linear response the formula
-    collapses to sqrt(0.5*|dp|/g), which never converges on the true step; it
-    just tracks the smallest rung of the ladder.  On examples/ogle0383 that
-    returned 0.048 where the true 0.5-nat step is 0.566, under-dispersing every
-    chain by 12-18x and leaving the ensemble still equilibrating well into the
-    recorded draws.
+    1. Symmetric curvature: bracket+bisect on the second difference
+       C(s) = 2*lp(x0) - lp(x0+s) - lp(x0-s) = h*s^2 + O(s^4), whose target
+       crossing is 1/sqrt(h) -- the local Gaussian sigma -- for ANY gradient.
+       The one-sided drop this replaces contains the gradient term g*s, so
+       from a start that is not the mode it measured 0.5/|g| instead of
+       sigma: on examples/ob140939 a start ~5900 nats below the posterior
+       returned scales ~1000x too small, the mass matrix re-widened the raw
+       posterior to sd ~5e3, and the sampler diverged on 86% of draws
+       against parameter.py's _RAW_CANCELLATION_CLIP wall at |raw|=1e4.
+    2. When C never reaches the target (h <= 0: locally linear directions,
+       ridges, saddles), fall back to EXOFASTv2's exofast_getmcmcscale
+       convention of searching each sign for the one-sided 0.5-nat drop,
+       taking the NEARER contour (not the average: EXOFASTv2 probes from an
+       AMOEBA best fit where the directions are near-symmetric; off the mode
+       the uphill contour only turns over on the far side, and averaging it
+       in inflates the scale -- chains then jitter past the logit
+       saturation walls and start pinned at the bounds).  The nearer contour
+       only ever errs tight, which downstream consumers absorb
+       (chain-scatter multipliers, DE ensemble expansion, NUTS adaptation).
+    3. When both signs are flat too, `flat_scale`.
+
+    The step search is bracket + bisect.  An earlier version instead walked a
+    fixed probe ladder [0.003 ... 2.0], took the FIRST magnitude registering
+    any drop at all, and extrapolated with a quadratic assumption,
+    scale = |dp| * sqrt(target/delta) -- which only holds AT a maximum, and
+    for the generic locally-linear response collapses to sqrt(0.5*|dp|/g),
+    tracking the smallest rung of the ladder (examples/ogle0383: 0.048
+    returned where the true 0.5-nat step is 0.566, under-dispersing every
+    chain 12-18x).
+
+    `diagnostics`, when given, is a dict filled with:
+      "linear_fallback" -- ["key[i]", ...] elements measured by rung 2
+      "flat"            -- ["key[i]", ...] elements that fell to rung 3
+      "gradient_nats"   -- {"key[i]": g} rung-1 elements' |gradient| in nats
+                           per measured scale unit (the start's displacement
+                           from its conditional optimum in sigmas, locally)
 
     Returns (map_lp, scales) where scales maps each raw-start key to an array
     shaped like its entry.
@@ -157,6 +283,8 @@ def probe_scales(
     scales = {}
     tight = []
     flat = []
+    linear_fallback = []
+    gradient_nats = {}
     for key, val in raw_start.items():
         n = val.size
         s = np.full(n, flat_scale)
@@ -165,28 +293,39 @@ def probe_scales(
             def eval_delta(step, key=key, i=i):
                 return _delta_at(key, i, step)
 
-            steps = [
-                probe_step_1d(
-                    eval_delta,
-                    sign,
-                    max_step=max_step,
-                    min_step=min_step,
-                    max_bisect=max_bisect,
-                )
-                for sign in (1.0, -1.0)
-            ]
-            steps = [x for x in steps if x is not None]
-            if steps:
-                s.flat[i] = min(float(np.min(steps)), max_step)
-            else:
+            scale, method, g_nats = _probe_element(
+                eval_delta,
+                max_step=max_step,
+                min_step=min_step,
+                max_bisect=max_bisect,
+            )
+            if scale is not None:
+                s.flat[i] = scale
+            if method == "flat":
                 flat.append(f"{key}[{i}]")
+            elif method == "linear":
+                linear_fallback.append(f"{key}[{i}]")
+            elif np.isfinite(g_nats):
+                gradient_nats[f"{key}[{i}]"] = float(g_nats)
             if s.flat[i] < 0.5:
                 tight.append(f"{key}[{i}]: scale={s.flat[i]:.3g}")
         scales[key] = s.reshape(val.shape)
 
+    if diagnostics is not None:
+        diagnostics["linear_fallback"] = linear_fallback
+        diagnostics["flat"] = flat
+        diagnostics["gradient_nats"] = gradient_nats
+
     if tight:
         logger.debug(
             "whitening probe: tightly-constrained params: " + "; ".join(tight)
+        )
+    if linear_fallback:
+        logger.debug(
+            "whitening probe: no measurable positive curvature (h <= 0) "
+            "along: "
+            + "; ".join(linear_fallback)
+            + " -- using the nearer one-sided contour (errs tight)."
         )
     if flat:
         logger.debug(
@@ -225,20 +364,13 @@ def _probe_selected(raw_start, logp_fn, elems):
             probe[key].flat[i] += step
             return map_lp - float(logp_fn(probe))
 
-        steps = [
-            probe_step_1d(
-                eval_delta,
-                sign,
-                max_step=_WHITEN_MAX_STEP,
-                min_step=_WHITEN_MIN_STEP,
-                max_bisect=_WHITEN_MAX_BISECT,
-            )
-            for sign in (1.0, -1.0)
-        ]
-        steps = [x for x in steps if x is not None]
-        out[(key, i)] = (
-            min(float(np.min(steps)), _WHITEN_MAX_STEP) if steps else np.nan
+        scale, _method, _g = _probe_element(
+            eval_delta,
+            max_step=_WHITEN_MAX_STEP,
+            min_step=_WHITEN_MIN_STEP,
+            max_bisect=_WHITEN_MAX_BISECT,
         )
+        out[(key, i)] = scale if scale is not None else np.nan
     return out
 
 
@@ -285,6 +417,7 @@ def apply_measured_whitening(system, model, raw_start=None, logp_fn=None):
     # flat_scale=NaN: a flat direction keeps its preliminary scale
     # (set_whitening skips non-finite entries) and stays flagged in the
     # report so the diagnostics table can warn about it.
+    probe_diag = {}
     map_lp, scales = probe_scales(
         raw_start,
         logp_fn,
@@ -292,7 +425,36 @@ def apply_measured_whitening(system, model, raw_start=None, logp_fn=None):
         min_step=_WHITEN_MIN_STEP,
         max_bisect=_WHITEN_MAX_BISECT,
         flat_scale=np.nan,
+        diagnostics=probe_diag,
     )
+
+    # Loud diagnostics: neither condition invalidates the measured scales
+    # (curvature is gradient-immune, and the linear fallback errs tight),
+    # but both are signatures of a start far from its conditional optimum,
+    # which degrades everything that uses the START itself -- chain scatter,
+    # tempering, the reported start table.  ob140939's 86%-divergence run
+    # would have printed ~16 gradient-dominated elements here.
+    grad_dom = {
+        k: g
+        for k, g in probe_diag.get("gradient_nats", {}).items()
+        if g > _GRAD_DOMINATED_NATS
+    }
+    if grad_dom:
+        worst = sorted(grad_dom.items(), key=lambda kv: -kv[1])
+        logger.warning(
+            "Whitening: gradient-dominated start -- displaced ~N sigma from "
+            "its conditional optimum along: "
+            + "; ".join(f"{k} (~{g:.0f} sigma)" for k, g in worst)
+            + " -- scales are curvature-measured and stay valid, but "
+            "consider a polished start (seed_polish) or closer initvals."
+        )
+    if probe_diag.get("linear_fallback"):
+        logger.warning(
+            "Whitening: no measurable positive curvature (ridge/saddle/"
+            "linear logp) along: "
+            + "; ".join(probe_diag["linear_fallback"])
+            + " -- using the nearer one-sided contour, which errs tight."
+        )
 
     lookup = {p.label: p for p in system.get_all_parameters()}
     multipliers = {
@@ -374,6 +536,7 @@ def apply_measured_whitening(system, model, raw_start=None, logp_fn=None):
         "map_lp": map_lp,
         "multipliers": multipliers,
         "raw_scales": raw_scales,
+        "probe_diagnostics": probe_diag,
     }
 
 

--- a/tests/test_ptde.py
+++ b/tests/test_ptde.py
@@ -408,17 +408,18 @@ def test_probe_step_1d_lands_on_the_target_drop():
         assert eval_delta(sign * step) == pytest.approx(0.5, abs=0.05)
 
 
-def test_probe_scale_takes_nearer_contour_when_start_is_off_mode():
+def test_probe_scale_measures_curvature_when_start_is_off_mode():
     """
     Given a Gaussian logp probed from a start offset from its mode,
     When _probe_scales probes it,
-    Then the scale is the NEARER 0.5-nat contour, not the average of the two.
+    Then the scale is the curvature width sigma, NOT the one-sided 0.5-nat
+      drop distance (0.5/gradient) an off-mode start contaminates.
 
-    EXOFASTv2 averages the two directions because it probes from an AMOEBA best
-    fit, where they are near-symmetric.  Off the mode they are not: the uphill
-    direction only turns over on the far side, and averaging it in inflates the
-    scale enough to jitter chains past the logit transform's saturation walls,
-    starting them pinned at the bounds.
+    The symmetric second difference cancels the gradient term identically,
+    so the probe returns sigma from any start.  The old nearer-contour rule
+    returned sqrt(10)-3 ~ 0.16 here (and ~1e-3 sigma on ob140939's start
+    5900 nats below the posterior, whose mass matrix then re-widened the
+    raw posterior into parameter.py's _RAW_CANCELLATION_CLIP wall).
     """
     # ARRANGE: mode at 3.0, unit width, start 3 sigma away at 0.0
     start = {"x": np.zeros(1)}
@@ -430,15 +431,9 @@ def test_probe_scale_takes_nearer_contour_when_start_is_off_mode():
     _, scales = _probe_scales(start, logp_fn)
     s = float(scales["x"][0])
 
-    # ASSERT: logp(0) - logp(x) = 0.5 at (x-3)^2 = 10, so the contours are at
-    # x = 3 - sqrt(10) (near) and x = 3 + sqrt(10) (far).  Take the near one.
-    assert s == pytest.approx(np.sqrt(10.0) - 3.0, rel=0.05)
-
-    # ASSERT: still far looser than the old quadratic extrapolation, which
-    # collapsed to sqrt(0.5*|dp|/g) at the smallest rung of its probe ladder.
-    old = 0.003 * np.sqrt(0.5 / (3.0 * 0.003))
-    assert old < 0.03
-    assert s > 5 * old
+    # ASSERT: the local (and global) Gaussian width is 1.0 regardless of the
+    # 3-sigma displacement.
+    assert s == pytest.approx(1.0, rel=0.05)
 
 
 def test_probe_scale_linear_logp_is_not_extrapolated_quadratically():
@@ -732,15 +727,11 @@ def test_ladder_health_report_warns_only_when_communication_limited(caplog):
     temps = _geometric_ladder(8, 200.0)
 
     with caplog.at_level(logging.WARNING, logger="exozippy.samplers.ptde"):
-        lam = ladder_health_report(
-            temps, np.full(7, 90.0), np.full(7, 100.0)
-        )
+        lam = ladder_health_report(temps, np.full(7, 90.0), np.full(7, 100.0))
         assert np.isclose(lam, 0.7)
         assert not caplog.records
 
-        lam = ladder_health_report(
-            temps, np.full(7, 20.0), np.full(7, 100.0)
-        )
+        lam = ladder_health_report(temps, np.full(7, 20.0), np.full(7, 100.0))
         assert np.isclose(lam, 5.6)
         assert any(
             "communication-limited" in r.message for r in caplog.records
@@ -750,8 +741,7 @@ def test_ladder_health_report_warns_only_when_communication_limited(caplog):
 
     assert ladder_health_report(temps, np.zeros(7), np.zeros(7)) is None
     assert (
-        ladder_health_report(np.array([1.0]), np.zeros(1), np.zeros(1))
-        is None
+        ladder_health_report(np.array([1.0]), np.zeros(1), np.zeros(1)) is None
     )
 
 
@@ -785,9 +775,7 @@ def test_polish_seed_starts_climbs_to_basin_optimum():
     seed = {"a": np.zeros(2), "b": np.zeros(1)}  # lp = -19
     scales = {k: np.ones_like(v) for k, v in seed.items()}
 
-    polished, dlps = polish_seed_starts(
-        [seed], logp, rng, scales, n_steps=200
-    )
+    polished, dlps = polish_seed_starts([seed], logp, rng, scales, n_steps=200)
 
     assert logp(polished[0]) > -0.5  # from -19 to (near) 0
     assert dlps[0] > 18.0
@@ -813,8 +801,7 @@ def test_make_starts_caps_exact_seed_chains():
 
     assert len(starts) == n_chains
     n_exact = sum(
-        any(np.array_equal(st["a"], sd["a"]) for sd in seeds)
-        for st in starts
+        any(np.array_equal(st["a"], sd["a"]) for sd in seeds) for st in starts
     )
     assert n_exact <= n_chains // 2
     # every seed still contributes a chain (round-robin unchanged)

--- a/tests/test_whitening_probe.py
+++ b/tests/test_whitening_probe.py
@@ -1,0 +1,273 @@
+"""Symmetric-curvature whitening probe: the three-rung measurement ladder.
+
+Rung 1: symmetric second difference -> curvature width 1/sqrt(h),
+        gradient-immune (the ob140939 failure mode).
+Rung 2: h <= 0 (linear/ridge/saddle) -> nearer one-sided contour (errs tight).
+Rung 3: flat both ways -> flat_scale.
+
+Plus the probe diagnostics that make a bad start loud instead of silent.
+"""
+
+import numpy as np
+import pytest
+
+from exozippy.whitening import (
+    _probe_element,
+    probe_scales,
+)
+
+
+def _delta_fn(logp_1d, x0=0.0):
+    """Wrap a 1-d logp into the eval_delta(step) the probe consumes."""
+    lp0 = logp_1d(x0)
+
+    def eval_delta(step):
+        return lp0 - logp_1d(x0 + step)
+
+    return eval_delta
+
+
+# ---------------------------------------------------------------------------
+# rung 1: curvature
+# ---------------------------------------------------------------------------
+
+
+def test_probe_element_returns_sigma_at_the_mode():
+    """
+    Given a Gaussian logp probed from its mode,
+    When _probe_element measures it,
+    Then the scale is sigma via the curvature rung, with ~zero gradient.
+    """
+    # ARRANGE
+    sigma = 0.37
+    eval_delta = _delta_fn(lambda x: -0.5 * (x / sigma) ** 2)
+
+    # ACT
+    scale, method, g_nats = _probe_element(eval_delta)
+
+    # ASSERT
+    assert method == "curvature"
+    assert scale == pytest.approx(sigma, rel=0.05)
+    assert g_nats == pytest.approx(0.0, abs=1e-6)
+
+
+def test_probe_element_is_gradient_immune_far_from_the_mode():
+    """
+    Given a Gaussian logp probed from 200 sigma below its mode (a start
+      ~20000 nats off, the ob140939 regime),
+    When _probe_element measures it,
+    Then the scale is still sigma -- the second difference cancels the
+      gradient term identically -- and grad_nats reports the ~200-sigma
+      displacement.
+
+    The one-sided drop this rung replaces returns ~0.5/|g| = sigma/400
+    here: the 1000x-too-tight scales that re-widened ob140939's raw
+    posterior into the _RAW_CANCELLATION_CLIP wall (86% divergences).
+    """
+    # ARRANGE: mode at 200, sigma 1, start at 0
+    delta_sigmas = 200.0
+    eval_delta = _delta_fn(lambda x: -0.5 * (x - delta_sigmas) ** 2)
+
+    # ACT
+    scale, method, g_nats = _probe_element(eval_delta)
+
+    # ASSERT
+    assert method == "curvature"
+    assert scale == pytest.approx(1.0, rel=0.05)
+    assert g_nats == pytest.approx(delta_sigmas, rel=0.1)
+    # the old one-sided measurement for reference: ~400x too tight
+    assert 0.5 / delta_sigmas < 0.01 * scale
+
+
+def test_probe_element_anisotropic_scales_far_from_mode():
+    """
+    Given a 2-element Gaussian with very different sigmas, probed off-mode,
+    When probe_scales measures it,
+    Then each element recovers its own sigma (no cross-contamination).
+    """
+    # ARRANGE
+    sigmas = np.array([0.02, 30.0])
+    modes = np.array([1.0, -900.0])  # 50 and 30 sigma displaced
+    start = {"x": np.zeros(2)}
+
+    def logp_fn(p):
+        return float(-0.5 * np.sum(((p["x"] - modes) / sigmas) ** 2))
+
+    # ACT
+    _, scales = probe_scales(start, logp_fn)
+
+    # ASSERT
+    np.testing.assert_allclose(scales["x"], sigmas, rtol=0.05)
+
+
+# ---------------------------------------------------------------------------
+# rung 2: h <= 0 fallback to the nearer one-sided contour
+# ---------------------------------------------------------------------------
+
+
+def test_probe_element_linear_logp_falls_back_to_one_sided():
+    """
+    Given a logp exactly linear in the element (h = 0),
+    When _probe_element measures it,
+    Then curvature is unmeasurable and the one-sided 0.5-nat step 0.5/g is
+      returned via the linear rung.
+    """
+    # ARRANGE
+    g = 0.32
+    eval_delta = _delta_fn(lambda x: -g * x)
+
+    # ACT
+    scale, method, g_nats = _probe_element(eval_delta)
+
+    # ASSERT
+    assert method == "linear"
+    assert scale == pytest.approx(0.5 / g, rel=0.05)
+    assert np.isnan(g_nats)
+
+
+def test_probe_element_negative_curvature_falls_back():
+    """
+    Given a start where logp is CONVEX along the element (h < 0 for the
+      concavity the probe needs: a shoulder between basins) but still
+      downhill in one direction,
+    When _probe_element measures it,
+    Then the curvature rung declines (C(s) < 0 at every scale) and the
+      nearer one-sided contour is used -- which errs tight, never wide.
+    """
+    # ARRANGE: logp = -g*x + k*x^2 (convex, k > 0).  C(s) = -2k*s^2 < 0
+    # everywhere; the +x direction still drops 0.5 nats at the near root of
+    # k*s^2 - g*s + 0.5 = 0, and -x rises monotonically (no contour).
+    g, k = 0.5, 0.01
+    eval_delta = _delta_fn(lambda x: -g * x + k * x**2)
+    expected = (g - np.sqrt(g**2 - 4 * k * 0.5)) / (2 * k)
+
+    # ACT
+    scale, method, g_nats = _probe_element(eval_delta)
+
+    # ASSERT
+    assert method == "linear"
+    assert scale == pytest.approx(expected, rel=0.05)
+    assert np.isnan(g_nats)
+
+
+# ---------------------------------------------------------------------------
+# rung 3: flat
+# ---------------------------------------------------------------------------
+
+
+def test_probe_element_flat_direction_returns_none():
+    """
+    Given an element logp ignores entirely,
+    When _probe_element measures it,
+    Then it reports (None, "flat", nan) so the caller applies flat_scale.
+    """
+    # ARRANGE
+    eval_delta = _delta_fn(lambda x: 0.0)
+
+    # ACT
+    scale, method, g_nats = _probe_element(eval_delta)
+
+    # ASSERT
+    assert scale is None
+    assert method == "flat"
+    assert np.isnan(g_nats)
+
+
+def test_probe_element_wall_bounds_the_scale():
+    """
+    Given a hard prior wall (logp = -inf) nearer than the curvature width,
+    When _probe_element measures it,
+    Then the scale is bounded at the wall distance (errs tight) rather than
+      proposing across the wall.
+    """
+    # ARRANGE: sigma 3 Gaussian at the start, wall at x = -0.5
+    wall = -0.5
+
+    def logp(x):
+        if x <= wall:
+            return -np.inf
+        return -0.5 * (x / 3.0) ** 2
+
+    eval_delta = _delta_fn(logp)
+
+    # ACT
+    scale, method, _ = _probe_element(eval_delta)
+
+    # ASSERT
+    assert method == "curvature"
+    assert 0.0 < scale <= abs(wall) * 1.05
+
+
+# ---------------------------------------------------------------------------
+# diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_probe_scales_fills_diagnostics():
+    """
+    Given elements exercising all three rungs plus a displaced Gaussian,
+    When probe_scales runs with a diagnostics dict,
+    Then gradient_nats flags the displaced element, linear_fallback the
+      linear one, and flat the ignored one.
+    """
+    # ARRANGE: x[0] displaced Gaussian, x[1] linear, x[2] flat
+    start = {"x": np.zeros(3)}
+
+    def logp_fn(p):
+        x = p["x"]
+        return float(-0.5 * (x[0] - 50.0) ** 2 - 0.7 * x[1])
+
+    diag = {}
+
+    # ACT
+    _, scales = probe_scales(start, logp_fn, diagnostics=diag)
+
+    # ASSERT
+    assert diag["gradient_nats"]["x[0]"] == pytest.approx(50.0, rel=0.1)
+    assert diag["linear_fallback"] == ["x[1]"]
+    assert diag["flat"] == ["x[2]"]
+    assert scales["x"][0] == pytest.approx(1.0, rel=0.05)
+    assert scales["x"][1] == pytest.approx(0.5 / 0.7, rel=0.05)
+    assert scales["x"][2] == pytest.approx(1.0)  # flat_scale
+
+
+def test_gradient_dominated_start_warns_by_name(caplog):
+    """
+    Given a model whose start is far below its conditional optimum,
+    When apply_measured_whitening probes it,
+    Then a WARNING names the gradient-dominated element and its displacement
+      -- the loud version of the ob140939 failure signature.
+    """
+    import logging
+
+    from exozippy.whitening import apply_measured_whitening
+
+    # ARRANGE: a minimal stand-in system exposing one whitened parameter is
+    # heavyweight to build here; drive the warning through probe_scales'
+    # diagnostics contract instead, monkeypatching a no-op system.
+    class _NoParams:
+        def get_all_parameters(self):
+            return []
+
+        def get_raw_start(self, model):
+            return {"x": np.zeros(1)}
+
+    def logp_fn(raw):
+        return float(-0.5 * (raw["x"][0] - 40.0) ** 2)
+
+    class _Model:
+        def compile_logp(self):
+            return logp_fn
+
+    with caplog.at_level(logging.WARNING, logger="exozippy.whitening"):
+        # ACT
+        report = apply_measured_whitening(_NoParams(), _Model())
+
+    # ASSERT
+    assert report["probe_diagnostics"]["gradient_nats"]["x[0]"] == (
+        pytest.approx(40.0, rel=0.1)
+    )
+    assert any(
+        "gradient-dominated start" in r.message and "x[0]" in r.message
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Problem

The startup whitening probe measures the step where logp falls 0.5 nats below the START. That quantity contains the gradient term of the Taylor expansion, so from any start that is not the mode it returns `0.5/|g|`, not the local width. On `examples/ob140939` (start ~5900 nats below the posterior: raw error bars underestimated, `err_scale` starting at 1.0) it measured scales ~1000x too small. NUTS's mass-matrix adaptation absorbed the mis-scaling, re-widening the raw posterior to sd ~5e3 raw units -- which put `parameter.py`'s `_RAW_CANCELLATION_CLIP` wall at |raw| = 1e4 *inside* the posterior's reach (a spurious `-0.5*(raw^2 - 1e8)` parabola). Result: 86% of draws divergent (`max_energy_error` ~1e9), squeezed tails, ESS ~50. Diagnosed by 1D logp scans around a stored divergent draw: cliffs of 1e6-1e8 nats exactly where |raw| crosses 1e4, on every wide-raw element.

## Fix: three-rung measurement ladder per element

1. **Symmetric second difference** `C(s) = 2*lp(x0) - lp(x0+s) - lp(x0-s) = h*s^2 + O(s^4)`: the gradient cancels identically, so bracket+bisect on C = 1 nat returns the local sigma `1/sqrt(h)` from ANY start. A non-finite side (hard wall) counts as past-target, bounding the scale at the wall distance.
2. **h <= 0 fallback** (locally linear, ridge, saddle): the old one-sided nearer contour, which only ever errs tight -- the direction downstream consumers absorb.
3. **Flat both ways**: `flat_scale`, as before.

## Loud diagnostics (the ob140939 signature, named at startup instead of post-mortem)

- WARNING naming **gradient-dominated** elements (`|g|*sigma > 3` nats = displaced >~3 sigma from the conditional optimum; ob140939 would have printed 16 elements at up to ~87 sigma).
- WARNING naming elements measured by the one-sided fallback.
- Both exposed in the whitening report as `probe_diagnostics`.

## Validation

Replaying ob140939's divergent start: scales measured **40-180x wider** than the one-sided probe from the same point (raw posterior sd drops ~5e3 -> ~30; the clip wall goes from inside the posterior to 300+ sigma away). Measured scales still err ~30x tight vs the true posterior sigmas -- local curvature at a displaced start -- which is what the companion pre-whitening seed-polish PR removes; this PR is the insurance layer.

PTDE's chain-scatter probe inherits the behavior through its existing `probe_scales` import; `probe_step_1d` is unchanged.

## Tests

9 new (`tests/test_whitening_probe.py`): sigma at the mode, gradient immunity at 200 sigma displacement, anisotropic off-mode scales, linear/negative-curvature fallbacks, flat, wall bounding, diagnostics dict, gradient-dominated warning. One existing test rewritten to pin the new off-mode semantics (`test_probe_scale_takes_nearer_contour_when_start_is_off_mode` -> `test_probe_scale_measures_curvature_when_start_is_off_mode`). Full suite: 945 passed (2 environment-only failures -- full /tmp tmpfs -- pass with TMPDIR redirected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)