### PR TITLE
Pre-whitening seed polish: sampler-independent, gradient-aware

### DIFF
--- a/src/exozippy/components/parameter.py
+++ b/src/exozippy/components/parameter.py
@@ -914,9 +914,7 @@ class Parameter:
                 )
                 span_t = pt.maximum(up_t - lo_t, 1e-12)
                 q_i = pt.sigmoid(
-                    pt.clip(
-                        lq[i], -_LOGIT_SATURATION_LQ, _LOGIT_SATURATION_LQ
-                    )
+                    pt.clip(lq[i], -_LOGIT_SATURATION_LQ, _LOGIT_SATURATION_LQ)
                 )
                 phys_val = pt.set_subtensor(phys_val[i], lo_t + span_t * q_i)
                 if is_sampled[i]:
@@ -1352,12 +1350,17 @@ class Parameter:
         contour at exactly one raw unit, which is the "curvature = -1"
         conditioning the old init_scale tuning loop approximated by hand.
 
-        Deliberately does NOT recompute logit_q_inits / q_floors: the start
-        (raw = 0) must stay exactly where the probe measured, so the update
-        is a pure scale change in logit space.  Elements whose raw N(0,1) IS
-        the prior (unbounded with sigma) are never touched -- their scale is
-        the prior sigma, not a whitening choice.  Non-finite or non-positive
-        entries (a failed probe) leave that element's scale unchanged.
+        Deliberately does NOT recompute logit_q_inits / q_floors: the
+        anchor (raw = 0) stays exactly where build_pymc placed it, so the
+        update is a pure scale change in logit space.  A NONZERO
+        ``raw_initval`` (a pre-whitening seed polish moved the start off the
+        anchor) is rescaled by 1/multiplier in the same pass -- lq = lq0 +
+        scale*raw is invariant under (scale, raw) -> (scale*m, raw/m) -- so
+        the start stays the same PHYSICAL point the probe measured around.
+        Elements whose raw N(0,1) IS the prior (unbounded with sigma) are
+        never touched -- their scale is the prior sigma, not a whitening
+        choice.  Non-finite or non-positive entries (a failed probe) leave
+        that element's scale unchanged.
 
         Because the scales live in pytensor.shared variables, every function
         already compiled from this model sees the new values immediately;
@@ -1390,16 +1393,30 @@ class Parameter:
         # raw unit); the measured value where the element is deliberately not
         # rescaled (Gaussian-prior elements); 1.0 where the probe failed.
         post = np.ones(len(idx))
+        rescaled = np.zeros(len(idx), dtype=bool)
         for j, i in enumerate(idx):
             m = raw_scale[j]
             if not np.isfinite(m) or m <= 0:
                 continue
             if tf["use_logit"][i]:
                 scale_logits[i] *= m
+                rescaled[j] = True
             elif not ws["has_sigma_prior"][i]:
                 gauss_scales[i] *= m
+                rescaled[j] = True
             else:
                 post[j] = m
+
+        # Keep a polished (nonzero) raw start pinned to the same physical
+        # point through the rescale.  Historically raw_initval was always 0
+        # for rescaled elements, making this a silent no-op.
+        if self.raw_initval is not None:
+            ri = np.asarray(self.raw_initval, dtype=float).reshape(-1).copy()
+            if ri.size == len(idx):
+                for j in np.nonzero(rescaled)[0]:
+                    ri[j] /= raw_scale[j]
+                self.raw_initval = ri
+
         self._apply_whitening_state(scale_logits, gauss_scales)
         return post
 
@@ -1424,9 +1441,20 @@ class Parameter:
             int(np.prod(self.shape)) if self.shape not in ((), None) else 1
         )
         phys_scales = to_vec(self.init_scale, n_elements, fill=1.0)
-        for i in tf["sampled_idx"]:
+        raw_init = (
+            np.asarray(self.raw_initval, dtype=float).reshape(-1)
+            if self.raw_initval is not None
+            else None
+        )
+        for j, i in enumerate(tf["sampled_idx"]):
             if tf["use_logit"][i]:
-                q_init = 1.0 / (1.0 + np.exp(-tf["logit_q_inits"][i]))
+                # Evaluate dphys/draw at the START (anchor + scale*raw_init):
+                # identical to the anchor historically (raw_init 0), but a
+                # polished start sits off the anchor.
+                lq = tf["logit_q_inits"][i]
+                if raw_init is not None and raw_init.size > j:
+                    lq = lq + scale_logits[i] * raw_init[j]
+                q_init = 1.0 / (1.0 + np.exp(-np.clip(lq, -100.0, 100.0)))
                 span = tf["uppers"][i] - tf["lowers"][i]
                 phys_scales[i] = (
                     scale_logits[i] * q_init * (1.0 - q_init) * span

--- a/src/exozippy/polish.py
+++ b/src/exozippy/polish.py
@@ -1,0 +1,232 @@
+"""Pre-whitening seed polish: promote each solution-estimate start to its
+basin's optimum BEFORE anything downstream consumes the start.
+
+Why before whitening: the startup probe (whitening.probe_scales) measures
+logp contours around the start.  From a start far below its basin's optimum
+the contours are gradient-dominated and the measured scales come out
+arbitrarily tight -- on examples/ob140939 a start ~5900 nats low (raw error
+bars underestimated; err_scale starting at 1.0) measured scales ~1000x too
+small, NUTS's mass matrix re-widened the raw posterior to sd ~5e3 units, and
+86% of draws diverged against parameter.py's _RAW_CANCELLATION_CLIP wall at
+|raw| = 1e4.  Polishing first fixes that at the source; the probe then
+measures curvature at a genuine optimum, the barrier steepness measurement
+uses honest unit steps, PTDE scatters chains around a real basin center, and
+NUTS starts inside the typical set.  This generalizes the PTDE-only seed
+polish (samplers/ptde.py polish_seed_starts, PR #56), which ran inside
+_make_starts -- after the whitening probe had already measured its scales
+around the unpolished start, and never on the NUTS path at all.
+
+Two engines, dispatched on gradient availability:
+
+- L-BFGS-B on the compiled logp + gradient in raw space (raw space is
+  unconstrained -- hard bounds live inside the logit transform -- and smooth:
+  bounds are soft barriers, not -inf walls).  ~100-300 evaluations to the
+  mode.  The tolerances are deliberately LOOSE (the goal is "within a few
+  nats", not the exact MAP): for hierarchical/scale-like parameters the exact
+  MAP is not in the typical set and can run toward degenerate corners, and a
+  loose stop both avoids that and keeps the cost trivial.
+- The PR #56 T=1 DE-MC polish (gradient-free, the sampler's own move) when
+  the gradient graph cannot be built or is non-finite at the start -- e.g.
+  the binary-lens magnification Op has no analytic gradient.
+
+Seed-provenance gate (resolve_polish_steps): 'auto' polishes SOLUTION
+ESTIMATES -- the single canonical start (user/literature initvals, the
+relaxation engine's solution) and MMEXOFAST seed sets -- but never a
+multi-seed set WITHOUT seed hints, which is a posterior-draw restart
+(mkprior stratified draws): those are already at equilibrium, and polishing
+K draws per basin would collapse them onto K copies of the basin optimum,
+destroying the restart's overdispersion.
+"""
+
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_POLISH_STEPS = 150
+
+# L-BFGS stopping: loose on purpose (see module docstring).  ftol is in
+# nats; gtol is nats per raw unit -- one preliminary whitening scale, so
+# 0.01 nat/unit is deep inside the flat top of the basin.
+_LBFGS_FTOL = 1e-3
+_LBFGS_GTOL = 1e-2
+# Non-finite logp guard: L-BFGS line searches handle inf poorly, so a
+# non-finite evaluation returns this plateau plus a quadratic pull back
+# toward the last finite iterate's neighborhood (gradient points home).
+_NONFINITE_PENALTY = 1e15
+
+
+def resolve_polish_steps(spec, n_seeds, has_seed_hints):
+    """Map the sampler-config `seed_polish` value to a step count.
+
+    'auto' (default): DEFAULT_POLISH_STEPS when the starts are solution
+    estimates -- a single canonical start (n_seeds == 1) or component-pushed
+    seed hints (MMEXOFAST) -- and 0 for a multi-seed set without hints
+    (posterior-draw restarts; see module docstring).  True/'on' and
+    False/None/'off' force it; an int gives the step count directly.
+    """
+    if isinstance(spec, str) and spec.lower() == "auto":
+        return DEFAULT_POLISH_STEPS if (n_seeds == 1 or has_seed_hints) else 0
+    if spec in (True, "on"):
+        return DEFAULT_POLISH_STEPS
+    if spec in (False, None, "off"):
+        return 0
+    return max(0, int(spec))
+
+
+def _compile_logp_grad(model):
+    """Compiled point-function returning [logp, grad_1, ..., grad_n] over
+    model.value_vars, or None when the gradient graph cannot be built (an
+    Op without an analytic gradient, e.g. binary-lens magnification)."""
+    import pytensor
+
+    value_vars = list(model.value_vars)
+    try:
+        lp_node = model.logp()
+        grads = pytensor.grad(lp_node, wrt=value_vars)
+        return model.compile_fn(
+            [lp_node] + list(grads),
+            inputs=value_vars,
+            on_unused_input="ignore",
+        )
+    except Exception as e:
+        logger.info(
+            f"Seed polish: gradient graph unavailable ({type(e).__name__}: "
+            f"{e}); falling back to the gradient-free DE polish."
+        )
+        return None
+
+
+def _lbfgs_polish_one(center, fn_lp_grad, keys, shapes, sizes, maxiter):
+    """L-BFGS-B ascent of logp from one raw start dict.  Returns
+    (polished_dict, lp0, lp_best, n_evals)."""
+    from scipy.optimize import minimize
+
+    def flatten(d):
+        return np.concatenate(
+            [np.asarray(d[k], dtype=float).reshape(-1) for k in keys]
+        )
+
+    def unflatten(x):
+        out, ofs = {}, 0
+        for k, shp, n in zip(keys, shapes, sizes):
+            out[k] = x[ofs : ofs + n].reshape(shp)
+            ofs += n
+        return out
+
+    x0 = flatten(center)
+    n_evals = [0]
+
+    def objective(x):
+        n_evals[0] += 1
+        vals = fn_lp_grad(unflatten(x))
+        lp = float(vals[0])
+        if not np.isfinite(lp):
+            return (
+                _NONFINITE_PENALTY + float(np.sum((x - x0) ** 2)),
+                2.0 * (x - x0),
+            )
+        g = np.concatenate(
+            [np.asarray(v, dtype=float).reshape(-1) for v in vals[1:]]
+        )
+        if not np.all(np.isfinite(g)):
+            g = np.where(np.isfinite(g), g, 0.0)
+        return -lp, -g
+
+    lp0 = -objective(x0)[0]
+    res = minimize(
+        objective,
+        x0,
+        jac=True,
+        method="L-BFGS-B",
+        options={
+            "maxiter": int(maxiter),
+            "maxfun": int(max(4 * maxiter, 200)),
+            "ftol": _LBFGS_FTOL,
+            "gtol": _LBFGS_GTOL,
+        },
+    )
+    # res.x is the best iterate L-BFGS-B saw; never worse than the start
+    # except pathological line-search exits -- guard anyway.
+    lp_best = -float(res.fun)
+    if np.isfinite(lp_best) and lp_best >= lp0:
+        return unflatten(res.x), lp0, lp_best, n_evals[0]
+    return (
+        {k: np.array(v, dtype=float, copy=True) for k, v in center.items()},
+        lp0,
+        lp0,
+        n_evals[0],
+    )
+
+
+def polish_raw_starts(
+    model,
+    raw_starts,
+    n_steps=DEFAULT_POLISH_STEPS,
+    seed_indices=None,
+    logp_fn=None,
+    rng=None,
+):
+    """Polish each raw start toward its own basin's optimum.
+
+    Dispatch: L-BFGS-B on logp+grad when the model's gradient graph builds
+    and is finite at seed 0; otherwise the PR #56 T=1 DE-MC polish
+    (samplers/ptde.polish_seed_starts) with unit jitter scales (one raw unit
+    = one preliminary whitening scale, DE's population self-adapts from
+    there).
+
+    Returns (polished_starts, dlps, method) with method in
+    {"lbfgs", "de", "none"}.  A seed is never made worse: any engine result
+    below the seed's own lp is discarded in favor of the seed.
+    """
+    if isinstance(raw_starts, dict):
+        raw_starts = [raw_starts]
+    if seed_indices is None:
+        seed_indices = list(range(len(raw_starts)))
+    keys = list(raw_starts[0].keys())
+    shapes = [np.shape(raw_starts[0][k]) for k in keys]
+    sizes = [int(np.asarray(raw_starts[0][k]).size) for k in keys]
+
+    fn_lp_grad = _compile_logp_grad(model)
+    if fn_lp_grad is not None:
+        vals = fn_lp_grad(raw_starts[0])
+        grad_finite = np.all(
+            [np.all(np.isfinite(np.asarray(v))) for v in vals]
+        )
+        if not grad_finite:
+            logger.info(
+                "Seed polish: gradient non-finite at the start; falling "
+                "back to the gradient-free DE polish."
+            )
+            fn_lp_grad = None
+
+    if fn_lp_grad is not None:
+        polished, dlps = [], []
+        for s, center in enumerate(raw_starts):
+            best, lp0, lp_best, n_evals = _lbfgs_polish_one(
+                center, fn_lp_grad, keys, shapes, sizes, maxiter=n_steps
+            )
+            polished.append(best)
+            dlps.append(lp_best - lp0)
+            logger.info(
+                f"Seed polish (L-BFGS): seed {seed_indices[s]} lp "
+                f"{lp0:.1f} -> {lp_best:.1f} (dlp=+{lp_best - lp0:.1f}, "
+                f"{n_evals} evaluations)"
+            )
+        return polished, dlps, "lbfgs"
+
+    # Gradient-free fallback: the PR #56 polish, jittering at one raw unit.
+    from .samplers.ptde import polish_seed_starts
+
+    if logp_fn is None:
+        logp_fn = model.compile_logp()
+    if rng is None:
+        rng = np.random.default_rng(0)
+    scales = {
+        k: np.ones(np.shape(raw_starts[0][k]), dtype=float) for k in keys
+    }
+    polished, dlps = polish_seed_starts(
+        raw_starts, logp_fn, rng, scales, n_steps=n_steps
+    )
+    return polished, dlps, "de"

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -58,6 +58,7 @@ from .logger import setup_logging
 from .mkparam import mkprior
 from .outputs.modes import DEFAULT_MAX_INVALID_FRAC, mode_suffix
 from .outputs.report_pipeline import build_mode_reports
+from .polish import polish_raw_starts, resolve_polish_steps
 from .whitening import load_whitening, measure_and_whiten, save_whitening
 
 logger = logging.getLogger(__name__)
@@ -173,9 +174,7 @@ def _run_fit(config, gui, user_params=None):
     # parameter count once the model is built (ptde.resolve_n_temps).
     _n_temps_raw = sampler_cfg.get("n_temps", 8)
     n_temps = (
-        _n_temps_raw
-        if isinstance(_n_temps_raw, str)
-        else int(_n_temps_raw)
+        _n_temps_raw if isinstance(_n_temps_raw, str) else int(_n_temps_raw)
     )
     T_max = float(sampler_cfg.get("T_max", 200.0))
     _n_chains_raw = sampler_cfg.get("n_chains", None)
@@ -272,6 +271,42 @@ def _run_fit(config, gui, user_params=None):
         trace_path = str(prefix) + "_trace.nc"
         whitening_path = str(prefix) + "_whitening.json"
         reusing_trace = os.path.exists(trace_path) and not recompute_trace
+
+        # Pre-whitening seed polish (sampler-config `seed_polish`): promote
+        # each solution-estimate start to its basin's optimum BEFORE the
+        # whitening probe measures scales around it.  A start far below its
+        # optimum makes the probe gradient-dominated (scales come out
+        # orders of magnitude too tight -- examples/ob140939 measured
+        # ~1000x tight from a start ~5900 nats low and diverged on 86% of
+        # its draws), freezes the barrier steepness against dishonest unit
+        # steps, and starts every sampler outside the typical set.  'auto'
+        # (default) polishes the canonical single start and MMEXOFAST seed
+        # sets, never multi-seed posterior-draw restart sets (already at
+        # equilibrium; polishing would collapse their overdispersion);
+        # on/off/int override (int = step count).  L-BFGS on logp+grad
+        # when the model is differentiable, the PR #56 T=1 DE polish
+        # otherwise.  Skipped when reusing an existing trace (nothing will
+        # be sampled).  This supersedes the PTDE-internal seed polish,
+        # which ran after the probe and only under PTDE.
+        if not reusing_trace:
+            raw_starts_pre, seed_indices_pre = system.get_raw_starts(model)
+            polish_steps = resolve_polish_steps(
+                sampler_cfg.get("seed_polish", "auto"),
+                n_seeds=len(raw_starts_pre),
+                has_seed_hints=bool(
+                    getattr(system.config_manager, "seed_hint_sets", None)
+                ),
+            )
+            if polish_steps:
+                polished, _dlps, _pmethod = polish_raw_starts(
+                    model,
+                    raw_starts_pre,
+                    n_steps=polish_steps,
+                    seed_indices=seed_indices_pre,
+                )
+                system.apply_polished_starts(polished, seed_indices_pre)
+                raw_start = system.get_raw_start(model)
+
         whiten_report = None
         if measure_scales:
             loaded = (
@@ -284,6 +319,10 @@ def _run_fit(config, gui, user_params=None):
                 save_whitening(
                     system, whitening_path, map_lp=whiten_report["map_lp"]
                 )
+                # The rescale re-expressed a polished (nonzero) start in
+                # the new raw coordinates; re-read it for every consumer
+                # below (a no-op for an unpolished all-zeros start).
+                raw_start = system.get_raw_start(model)
 
         # 1. Get your starting dictionaries (after the rescale, so the
         # diagnostic table reports the measured scales)
@@ -302,29 +341,9 @@ def _run_fit(config, gui, user_params=None):
         # Multi-seed starts (P4): a list of raw start dicts (one per solved
         # seed) plus their original seed indices. seed 0 == raw_start above;
         # get_raw_starts returns just [raw_start], [0] for the ordinary case.
+        # After a polish, seed 0 comes from the polished raw_initval and
+        # seeds k>0 are re-derived from their polished physical values.
         raw_starts, seed_indices = system.get_raw_starts(model)
-
-        # Per-seed T=1 DE polish (sampler-config `seed_polish`): "auto"
-        # (default) polishes SOLUTION-ESTIMATE seeds -- MMEXOFAST fits,
-        # which can start hundreds of nats below their own basin's optimum
-        # and lose their chains to better-looking basins during tuning --
-        # but never posterior-draw seed sets (params.2 initval lists),
-        # which are already at equilibrium and would all polish to the
-        # same point per basin. `on`/`off`/int force it; int = step count.
-        _polish_raw = sampler_cfg.get("seed_polish", "auto")
-        _DEFAULT_POLISH_STEPS = 150
-        if isinstance(_polish_raw, str) and _polish_raw.lower() == "auto":
-            seed_polish_steps = (
-                _DEFAULT_POLISH_STEPS
-                if getattr(system.config_manager, "seed_hint_sets", None)
-                else 0
-            )
-        elif _polish_raw in (True, "on"):
-            seed_polish_steps = _DEFAULT_POLISH_STEPS
-        elif _polish_raw in (False, None, "off"):
-            seed_polish_steps = 0
-        else:
-            seed_polish_steps = max(0, int(_polish_raw))
 
         # convert raw starting point to the internal starting point
         internal_start = system.get_internal_point(model, raw_start)
@@ -376,7 +395,6 @@ def _run_fit(config, gui, user_params=None):
                     raw_scales=(
                         whiten_report["raw_scales"] if whiten_report else None
                     ),
-                    seed_polish_steps=seed_polish_steps,
                     plot_prefix=str(prefix),
                     min_ess=min_ess,
                     max_rhat=max_rhat,
@@ -411,7 +429,6 @@ def _run_fit(config, gui, user_params=None):
                     raw_scales=(
                         whiten_report["raw_scales"] if whiten_report else None
                     ),
-                    seed_polish_steps=seed_polish_steps,
                     plot_prefix=str(prefix),
                     min_ess=min_ess,
                     max_rhat=max_rhat,

--- a/src/exozippy/system.py
+++ b/src/exozippy/system.py
@@ -364,6 +364,70 @@ class System(Component):
         )
         return starts, seed_indices
 
+    def apply_polished_starts(self, polished_raws, seed_indices):
+        """Adopt polished raw starts (polish.polish_raw_starts) as the
+        canonical starts.
+
+        Seed 0 is written into each Parameter's ``raw_initval`` -- which
+        get_raw_start, get_mcmc_init, and the sampler initvals all read --
+        and its physical values into ``Parameter.initval`` so the startup
+        table and diagnostics report the polished start.  set_whitening
+        keeps a nonzero raw_initval pinned to the same physical point
+        through later rescales.  Seeds k > 0 are written back into
+        config_manager.seed_resolved as physical (internal-unit) values, so
+        get_raw_starts re-derives them through the frozen transform in
+        whatever raw coordinates are current.
+        """
+        lookup = {p.label: p for p in self.get_all_parameters()}
+        seed_resolved = getattr(self.config_manager, "seed_resolved", None)
+
+        for s, raw in enumerate(polished_raws):
+            for key, vec in raw.items():
+                name = key[: -len("_raw")] if key.endswith("_raw") else key
+                par = lookup.get(name)
+                tf = (
+                    getattr(par, "_raw_transform", None)
+                    if par is not None
+                    else None
+                )
+                if tf is None:
+                    continue
+                new_raw = np.asarray(vec, dtype=float).reshape(-1)
+                if new_raw.size != len(tf["sampled_idx"]):
+                    continue
+                phys = np.asarray(par.phys_from_raw(new_raw), dtype=float)
+
+                if s == 0:
+                    par.raw_initval = new_raw.copy()
+                    n_elements = (
+                        int(np.prod(par.shape))
+                        if par.shape not in ((), None)
+                        else 1
+                    )
+                    iv = np.asarray(
+                        to_vec(par.initval, n_elements, fill=np.nan),
+                        dtype=float,
+                    )
+                    for i in tf["sampled_idx"]:
+                        iv[i] = phys[i]
+                    par.initval = (
+                        float(iv[0]) if par.shape in ((), None) else iv
+                    )
+                else:
+                    k = seed_indices[s]
+                    if (
+                        not seed_resolved
+                        or k >= len(seed_resolved)
+                        or seed_resolved[k] is None
+                    ):
+                        continue
+                    comp_type = par.label.split(".")[0]
+                    param_name = par.label.split(".", 1)[1]
+                    for i in tf["sampled_idx"]:
+                        seed_resolved[k][f"{comp_type}.{i}.{param_name}"] = (
+                            float(phys[i])
+                        )
+
     def _seed_initvals_for(self, par, resolved):
         """Internal-unit initval vector for one Parameter under one seed's solved
         state, or None if that seed does not touch any of its elements."""

--- a/src/exozippy/whitening.py
+++ b/src/exozippy/whitening.py
@@ -214,6 +214,21 @@ def _param_for_raw(lookup, key):
     return lookup.get(name)
 
 
+def _refetch_raw_start(system, model, fallback):
+    """The current canonical raw start, re-read after a rescale.
+
+    set_whitening anchors raw = 0 and re-expresses a nonzero raw_initval (a
+    pre-whitening seed polish moved the start off the anchor) in the new
+    coordinates, so any raw-start dict captured BEFORE a rescale is stale
+    afterwards unless it was all zeros -- which it was, historically,
+    making this a no-op for unpolished runs.  Systems without get_raw_start
+    (test stubs) keep the fallback."""
+    getter = getattr(system, "get_raw_start", None)
+    if getter is None:
+        return fallback
+    return getter(model)
+
+
 def _probe_selected(raw_start, logp_fn, elems):
     """Re-probe only the given (raw_name, flat_index) elements."""
     map_lp = float(logp_fn(raw_start))
@@ -318,6 +333,11 @@ def apply_measured_whitening(system, model, raw_start=None, logp_fn=None):
             np.asarray(post, dtype=float) == 1.0
         )
 
+    # The rescale above re-expressed a polished (nonzero) start in the new
+    # raw coordinates; re-read it so the escalation re-probe measures
+    # around the same physical point.
+    raw_start = _refetch_raw_start(system, model, raw_start)
+
     # Escalation: re-probe elements whose multiplier was clipped by the
     # probe's dynamic range.
     for round_i in range(_ESCALATION_ROUNDS):
@@ -350,6 +370,7 @@ def apply_measured_whitening(system, model, raw_start=None, logp_fn=None):
                     mult2[i] = m
                     multipliers[key].flat[i] *= m
             par.set_whitening(mult2)
+        raw_start = _refetch_raw_start(system, model, raw_start)
 
     still = [
         f"{key}[{i}]: cumulative={multipliers[key].flat[i]:.3g}"
@@ -465,6 +486,10 @@ def measure_and_whiten(system, model, raw_start=None, logp_fn=None):
         logp_fn = model.compile_logp()
 
     report = apply_measured_whitening(system, model, raw_start, logp_fn)
+    # Each rescale re-expresses a polished (nonzero) start in the new raw
+    # coordinates -- re-read it before evaluating or probing there again
+    # (a no-op for the historical all-zeros start).
+    raw_start = _refetch_raw_start(system, model, raw_start)
     lp_before = float(logp_fn(raw_start))
     measure_barrier_scales(system, model, raw_start)
     lp_after = float(logp_fn(raw_start))
@@ -476,6 +501,7 @@ def measure_and_whiten(system, model, raw_start=None, logp_fn=None):
             f"the start); re-measuring scales against the final barriers."
         )
         report2 = apply_measured_whitening(system, model, raw_start, logp_fn)
+        raw_start = _refetch_raw_start(system, model, raw_start)
         # Fold the correction into the cumulative multipliers for reporting.
         for key, m2 in report2["multipliers"].items():
             m1 = report["multipliers"].get(key)

--- a/tests/test_polish.py
+++ b/tests/test_polish.py
@@ -1,0 +1,285 @@
+"""Pre-whitening seed polish (polish.py) and its start re-anchoring.
+
+The polish promotes a solution-estimate start to its basin's optimum BEFORE
+the whitening probe measures scales around it (a start far off its optimum
+makes the probe gradient-dominated).  These tests pin: the seed-provenance
+gate, the L-BFGS engine, the gradient-free DE fallback dispatch, the
+adoption of polished starts (raw_initval / initval / seed_resolved), and
+set_whitening keeping a nonzero raw start pinned to the same physical point
+through a rescale.
+"""
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import pytest
+from pytensor.graph.op import Op
+
+from exozippy.components.parameter import Parameter
+from exozippy.polish import (
+    DEFAULT_POLISH_STEPS,
+    polish_raw_starts,
+    resolve_polish_steps,
+)
+from exozippy.system import System
+
+# ---------------------------------------------------------------------------
+# resolve_polish_steps: the seed-provenance gate
+# ---------------------------------------------------------------------------
+
+
+def test_gate_auto_polishes_single_start_and_hint_sets_only():
+    """
+    Given the default 'auto' setting,
+    When the seeds are a single canonical start or MMEXOFAST hint sets,
+    Then polish runs; a multi-seed set WITHOUT hints (posterior-draw
+      restart) is never polished -- polishing K draws per basin would
+      collapse the restart's overdispersion.
+    """
+    assert (
+        resolve_polish_steps("auto", n_seeds=1, has_seed_hints=False)
+        == DEFAULT_POLISH_STEPS
+    )
+    assert (
+        resolve_polish_steps("auto", n_seeds=3, has_seed_hints=True)
+        == DEFAULT_POLISH_STEPS
+    )
+    assert resolve_polish_steps("auto", n_seeds=3, has_seed_hints=False) == 0
+
+
+def test_gate_overrides():
+    """
+    Given explicit on/off/int settings,
+    When resolve_polish_steps maps them,
+    Then they override the provenance logic entirely.
+    """
+    assert (
+        resolve_polish_steps("on", n_seeds=5, has_seed_hints=False)
+        == DEFAULT_POLISH_STEPS
+    )
+    assert resolve_polish_steps(False, n_seeds=1, has_seed_hints=True) == 0
+    assert resolve_polish_steps("off", n_seeds=1, has_seed_hints=True) == 0
+    assert resolve_polish_steps(42, n_seeds=1, has_seed_hints=False) == 42
+
+
+# ---------------------------------------------------------------------------
+# engines
+# ---------------------------------------------------------------------------
+
+
+def test_lbfgs_polish_climbs_to_the_mode():
+    """
+    Given a differentiable model started 40 sigma below its mode,
+    When polish_raw_starts runs,
+    Then the L-BFGS engine is chosen and the polished start lands at the
+      mode (lp gain ~0.5*40^2 = 800 nats).
+    """
+    # ARRANGE
+    with pm.Model() as model:
+        x = pm.Flat("x")
+        pm.Potential("like", -0.5 * ((x - 40.0) / 1.0) ** 2)
+    start = {"x": np.array(0.0)}
+
+    # ACT
+    polished, dlps, method = polish_raw_starts(model, [start])
+
+    # ASSERT
+    assert method == "lbfgs"
+    assert polished[0]["x"] == pytest.approx(40.0, abs=0.1)
+    assert dlps[0] == pytest.approx(800.0, rel=0.01)
+
+
+class _NoGradSquare(Op):
+    """-(x - 3)^2 / 2 with NO gradient implementation."""
+
+    itypes = [pt.dscalar]
+    otypes = [pt.dscalar]
+
+    def perform(self, node, inputs, outputs):
+        (x,) = inputs
+        outputs[0][0] = np.asarray(-0.5 * (x - 3.0) ** 2)
+
+
+def test_gradient_free_model_falls_back_to_de():
+    """
+    Given a model whose logp contains an Op with no analytic gradient (the
+      binary-lens magnification situation),
+    When polish_raw_starts runs,
+    Then the DE engine is dispatched and still improves the start.
+    """
+    # ARRANGE
+    with pm.Model() as model:
+        x = pm.Flat("x")
+        pm.Potential("like", _NoGradSquare()(x))
+    start = {"x": np.array(0.0)}
+
+    # ACT
+    polished, dlps, method = polish_raw_starts(
+        model, [start], n_steps=200, rng=np.random.default_rng(3)
+    )
+
+    # ASSERT
+    assert method == "de"
+    assert dlps[0] > 0
+    assert abs(polished[0]["x"] - 3.0) < 1.0
+
+
+def test_polish_never_returns_a_worse_seed():
+    """
+    Given a start already exactly at its mode,
+    When polish_raw_starts runs,
+    Then the returned start is not worse than the input (dlp >= 0) and
+      stays at the mode.
+    """
+    with pm.Model() as model:
+        x = pm.Flat("x")
+        pm.Potential("like", -0.5 * x**2)
+    start = {"x": np.array(0.0)}
+
+    polished, dlps, method = polish_raw_starts(model, [start])
+
+    assert dlps[0] >= 0.0
+    assert polished[0]["x"] == pytest.approx(0.0, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# adoption + rescale invariance
+# ---------------------------------------------------------------------------
+
+
+def _toy_param_model():
+    """One bounded parameter whose likelihood mode (7.5) is far from its
+    initval (2.0) relative to the 0.01-wide likelihood."""
+    p = Parameter(label="toy.x", initval=2.0, lower=0.0, upper=10.0)
+    with pm.Model() as model:
+        xv = p.build_pymc()
+        pm.Potential("like", -0.5 * ((xv - 7.5) / 0.01) ** 2)
+    return model, p
+
+
+class _StubSystem:
+    """Duck-typed stand-in for System: parameter lookup + seed storage."""
+
+    def __init__(self, params, seed_resolved=None):
+        self._params = params
+
+        class _CM:
+            pass
+
+        self.config_manager = _CM()
+        self.config_manager.seed_resolved = seed_resolved
+
+    def get_all_parameters(self):
+        return self._params
+
+
+def test_apply_polished_starts_reanchors_seed0():
+    """
+    Given a polished raw start for seed 0,
+    When System.apply_polished_starts adopts it,
+    Then raw_initval carries the polished raw point and initval the
+      polished physical value, so get_raw_start/get_mcmc_init and the
+      startup table all report the polished start.
+    """
+    # ARRANGE
+    model, p = _toy_param_model()
+    polished, _, method = polish_raw_starts(
+        model, [{"toy.x_raw": np.zeros(1)}]
+    )
+    assert method == "lbfgs"
+    stub = _StubSystem([p])
+
+    # ACT
+    System.apply_polished_starts(stub, polished, [0])
+
+    # ASSERT
+    assert p.initval == pytest.approx(7.5, abs=0.01)
+    np.testing.assert_allclose(
+        p.raw_initval, polished[0]["toy.x_raw"].reshape(-1)
+    )
+    # and the raw start round-trips to the same physical point
+    assert p.phys_from_raw(np.asarray(p.raw_initval))[0] == pytest.approx(
+        7.5, abs=0.01
+    )
+
+
+def test_apply_polished_starts_writes_extra_seeds_to_seed_resolved():
+    """
+    Given polished raw starts for seeds 0 and 2,
+    When System.apply_polished_starts adopts them,
+    Then seed 2's polished PHYSICAL value lands in
+      config_manager.seed_resolved[2] under the indexed path, so
+      get_raw_starts re-derives it in whatever raw coordinates are current.
+    """
+    # ARRANGE
+    model, p = _toy_param_model()
+    seed_resolved = [{}, {"toy.0.x": 1.0}, {"toy.0.x": 3.0}]
+    stub = _StubSystem([p], seed_resolved=seed_resolved)
+    raw_seed2 = p.raw_from_initval(np.array([6.0]))
+    polished = [
+        {"toy.x_raw": np.zeros(1)},
+        {"toy.x_raw": np.asarray(raw_seed2, dtype=float)},
+    ]
+
+    # ACT
+    System.apply_polished_starts(stub, polished, [0, 2])
+
+    # ASSERT
+    assert seed_resolved[2]["toy.0.x"] == pytest.approx(6.0, abs=1e-6)
+    assert seed_resolved[1]["toy.0.x"] == 1.0  # untouched
+
+
+def test_set_whitening_keeps_polished_start_at_same_physical_point():
+    """
+    Given a nonzero raw_initval (a polished start off the raw=0 anchor),
+    When set_whitening rescales by a large multiplier,
+    Then raw_initval is re-expressed so it decodes to the SAME physical
+      value -- the invariance that lets the whitening probe measure around
+      the polished start and rescale in place.
+    """
+    # ARRANGE
+    model, p = _toy_param_model()
+    raw_pol = np.asarray(p.raw_from_initval(np.array([7.5])), dtype=float)
+    p.raw_initval = raw_pol.copy()
+    phys_before = p.phys_from_raw(raw_pol)[0]
+
+    # ACT
+    p.set_whitening(np.array([0.003]))
+
+    # ASSERT
+    raw_after = np.asarray(p.raw_initval, dtype=float)
+    assert not np.allclose(raw_after, raw_pol)  # coordinates changed...
+    assert p.phys_from_raw(raw_after)[0] == pytest.approx(
+        phys_before, rel=1e-9
+    )  # ...the physical start did not
+
+
+def test_polished_start_survives_measure_and_whiten():
+    """
+    Given a model polished to its mode and a stub system exposing
+      get_raw_start from the parameter's raw_initval,
+    When measure_and_whiten runs (probe + rescale + barrier pass),
+    Then the canonical start still decodes to the polished physical point
+      and the re-probed scale at it is ~1 raw unit.
+    """
+    from exozippy.whitening import measure_and_whiten, probe_scales
+
+    # ARRANGE
+    model, p = _toy_param_model()
+    polished, _, _ = polish_raw_starts(model, [{"toy.x_raw": np.zeros(1)}])
+    stub = _StubSystem([p])
+    System.apply_polished_starts(stub, polished, [0])
+
+    def get_raw_start(mdl):
+        return {"toy.x_raw": np.asarray(p.raw_initval, dtype=float).copy()}
+
+    stub.get_raw_start = get_raw_start
+
+    # ACT
+    measure_and_whiten(stub, model)
+
+    # ASSERT
+    raw_now = np.asarray(p.raw_initval, dtype=float)
+    assert p.phys_from_raw(raw_now)[0] == pytest.approx(7.5, abs=0.01)
+    _, scales = probe_scales(get_raw_start(model), model.compile_logp())
+    assert scales["toy.x_raw"][0] == pytest.approx(1.0, rel=0.15)


### PR DESCRIPTION
## Problem

PR #56's seed polish runs inside PTDE's `_make_starts` -- after `measure_and_whiten` has already measured its scales around the unpolished start, and never on the NUTS path. On `examples/ob140939` (NUTS; start ~5900 nats below the posterior because the raw error bars are underestimated and `err_scale` starts at 1.0) the probe measured scales ~1000x too small, NUTS re-widened the raw posterior to sd ~5e3 units, and 86% of draws diverged against `_RAW_CANCELLATION_CLIP` at |raw| = 1e4. The polish has to run BEFORE the probe, for every sampler.

## What this does

**New `polish.py`**, wired in run.py between `get_raw_starts` and `measure_and_whiten` (skipped when reusing an existing trace); the PTDE-internal polish invocation is dropped as superseded (`ptde.polish_seed_starts` stays as the DE engine and for standalone use).

- **`polish_raw_starts`** dispatches on gradient availability: **L-BFGS-B** on the compiled logp+grad in raw space (unconstrained -- bounds are soft barriers) with deliberately loose tolerances (the goal is 'within a few nats', not the exact MAP, which for hierarchical/scale parameters is not in the typical set); falls back to the **PR #56 T=1 DE-MC polish** when the gradient graph cannot be built or is non-finite at the start (binary-lens magnification has no analytic gradient). A seed is never made worse.
- **`resolve_polish_steps`** generalizes the PR #56 'auto' gate: polish solution estimates -- the canonical single start (user/literature initvals, the relaxation solution) and MMEXOFAST seed sets -- never a multi-seed set without seed hints (a posterior-draw restart, already at equilibrium; polishing K draws per basin would collapse the restart's overdispersion). on/off/int override as before.

## Re-anchoring (the subtle part)

A polished start is OFF the raw = 0 anchor, which the whitening rescale keeps fixed:

- `System.apply_polished_starts` writes seed 0 into `Parameter.raw_initval` (read by `get_raw_start` / `get_mcmc_init` / sampler initvals) and its physical values into `Parameter.initval` (startup table); seeds k>0 go into `config_manager.seed_resolved` as physical values so `get_raw_starts` re-derives them under any later coordinates.
- `Parameter.set_whitening` re-expresses a nonzero `raw_initval` by 1/multiplier in the same pass (`lq = lq0 + s*raw` is invariant under `(s, raw) -> (s*m, raw/m)`) -- historically `raw_initval` was always 0 for rescaled elements, making this a silent no-op. `_apply_whitening_state` now reports the physical scale at the actual start, not the anchor.
- `whitening.apply_measured_whitening` / `measure_and_whiten` re-fetch the canonical start via `system.get_raw_start` after every in-place rescale (escalation rounds and the barrier-feedback round). No-op for all-zeros starts.
- The whitening.json persistence format is unchanged.

## Validation

Replaying ob140939's divergent start: **L-BFGS +5928 nats in 26 evaluations** (DE fallback: +5908 in ~5000); post-whitening start lp = +718 (inside the typical set), probe scales 16-100x wider even with the current one-sided probe. Complementary to #58 (symmetric-curvature probe), which removes the residual local-curvature tightness; the two compose but do not depend on each other.

## Tests

9 new (`tests/test_polish.py`): the provenance gate matrix, L-BFGS climb, DE dispatch on a gradient-less Op, polish-never-worsens, seed-0 re-anchoring, extra-seed write-back to seed_resolved, set_whitening physical-point invariance for nonzero raw_initval, and polished-start survival through full `measure_and_whiten`. Full suite: 952 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)