### PR TITLE
Mode ledger: 'considered and rejected' records for seeded solutions

### DIFF
--- a/src/exozippy/outputs/ledger.py
+++ b/src/exozippy/outputs/ledger.py
@@ -1,0 +1,327 @@
+"""Seeded-solution ledger: "considered and rejected" bookkeeping for
+multimodal fits.
+
+A posterior-suppressed mode (delta chi2 ~ 10 against the best solution)
+carries ~zero T=1 occupancy, so it vanishes from the trace -- and with it
+the distinction between "we considered this solution and rejected it at
+delta lp = X" and "we never looked".  Systematics routinely make such modes
+worth reporting anyway (published microlensing degenerate solutions are the
+canonical case), and a referee wants their parameters, not just their
+absence.
+
+The ledger keeps them, without touching the sampling math:
+
+- Every multi-seed start is already POLISHED to its own basin's optimum
+  (polish.polish_raw_starts) before sampling, so its logp IS the basin's
+  peak height.  build_seed_ledger measures, per seed, the local Gaussian
+  widths with the same gradient-immune symmetric-curvature probe the
+  whitening pass uses (whitening._probe_element; the model is whitened, so
+  every bracket lands in a few evaluations) -- a Laplace approximation of
+  each seeded mode: location, per-parameter sigmas, peak logp, and a
+  relative Laplace log-weight lp_max + sum(log sigma_raw).
+- After mode identification, match_ledger_to_modes assigns each seed to a
+  surviving posterior mode (by distance in the raw feature space,
+  normalized by the seed's own measured widths) or marks it REJECTED.
+- Rejected seeds are reported: a section in <prefix>_modes.txt, rows in
+  <prefix>_results.csv (mode column "rejected-seed<k>"), and a compact
+  standalone LaTeX table <prefix>_rejected_modes.tex.
+
+The Laplace numbers are approximations, labeled as such everywhere: good at
+the "is this mode at the 1e-2 or the 1e-8 level" fidelity that reporting
+needs, not for precision odds.  Values are quoted in each parameter's USER
+units.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# A seed farther than this many of its own measured sigmas (Chebyshev over
+# elements) from every surviving mode's center is "rejected".  Basins are
+# separated by many sigma by construction (else they'd be one mode), so the
+# threshold is not delicate; 10 keeps skew/nonlinearity from producing
+# false rejections.
+MATCH_SIGMA = 10.0
+
+
+@dataclass
+class SeedRecord:
+    seed_index: int  # original seed index (config order)
+    lp_max: float  # logp at the (polished) seed point
+    delta_lp: float  # lp_max(best seed) - lp_max  (>= 0)
+    laplace_logw: float  # lp_max + sum(log sigma_raw): relative Laplace
+    # log-weight (comparable ACROSS seeds only)
+    raw_point: dict = field(default_factory=dict)  # raw coords (current)
+    raw_scales: dict = field(default_factory=dict)  # curvature widths (raw)
+    phys: dict = field(default_factory=dict)  # label -> user-unit values
+    phys_sigma: dict = field(default_factory=dict)  # label -> user-unit widths
+    sampled_idx: dict = field(default_factory=dict)  # label -> element indices
+    matched_mode: Optional[int] = None  # 0-based surviving-mode index
+    match_distance: float = float("nan")  # in seed sigmas
+    source: str = "seed"  # "seed" | "hot-chain"
+
+
+def _flat_names(key, size):
+    """Element naming matching modes._feature_matrix: 'var' or 'var[j]'."""
+    if size == 1:
+        return [key]
+    return [f"{key}[{j}]" for j in range(size)]
+
+
+def build_seed_ledger(system, model, raw_starts, seed_indices, logp_fn=None):
+    """Measure a Laplace record for every (polished) seed start.
+
+    ``raw_starts``/``seed_indices`` are get_raw_starts' output in the
+    CURRENT raw coordinates (i.e. after the whitening rescale).  Costs
+    n_seeds x n_elements x O(15) logp evaluations -- the model is whitened,
+    so the curvature brackets land immediately.
+
+    Returns a list of SeedRecord ordered like ``raw_starts``.
+    """
+    from ..whitening import _probe_element
+
+    if logp_fn is None:
+        logp_fn = model.compile_logp()
+
+    lookup = {p.label: p for p in system.get_all_parameters()}
+    records = []
+    for s, center in enumerate(raw_starts):
+        lp0 = float(logp_fn(center))
+
+        raw_scales = {}
+        log_sigma_sum = 0.0
+        for key, val in center.items():
+            n = np.asarray(val).size
+            sc = np.ones(n)
+            for i in range(n):
+
+                def eval_delta(step, key=key, i=i):
+                    probe = {
+                        k: np.array(v, dtype=float, copy=True)
+                        for k, v in center.items()
+                    }
+                    probe[key].flat[i] += step
+                    return lp0 - float(logp_fn(probe))
+
+                scale, _method, _g = _probe_element(eval_delta)
+                if scale is not None and np.isfinite(scale):
+                    sc[i] = scale
+            raw_scales[key] = sc.reshape(np.shape(val))
+            log_sigma_sum += float(np.sum(np.log(sc)))
+
+        # Physical (user-unit) center and half-widths through each
+        # parameter's own frozen transform -- measured, not linearized.
+        phys, phys_sigma, sampled_idx = {}, {}, {}
+        for key, val in center.items():
+            name = key[: -len("_raw")] if key.endswith("_raw") else key
+            par = lookup.get(name)
+            tf = getattr(par, "_raw_transform", None) if par else None
+            if tf is None:
+                continue
+            c = np.asarray(val, dtype=float).reshape(-1)
+            sc = np.asarray(raw_scales[key], dtype=float).reshape(-1)
+            if c.size != len(tf["sampled_idx"]):
+                continue
+            p0 = np.asarray(par.phys_from_raw(c), dtype=float)
+            p_hi = np.asarray(par.phys_from_raw(c + sc), dtype=float)
+            p_lo = np.asarray(par.phys_from_raw(c - sc), dtype=float)
+            # internal -> user units
+            factors = np.asarray(
+                par._get_conversion_factors(), dtype=float
+            ).reshape(-1)
+            if factors.size != p0.size:
+                factors = np.ones(p0.size)
+            phys[name] = p0 / factors
+            phys_sigma[name] = 0.5 * np.abs(p_hi - p_lo) / factors
+            sampled_idx[name] = list(tf["sampled_idx"])
+
+        records.append(
+            SeedRecord(
+                seed_index=int(seed_indices[s]),
+                lp_max=lp0,
+                delta_lp=np.nan,  # filled below
+                laplace_logw=lp0 + log_sigma_sum,
+                raw_point={
+                    k: np.array(v, dtype=float, copy=True)
+                    for k, v in center.items()
+                },
+                raw_scales=raw_scales,
+                phys=phys,
+                phys_sigma=phys_sigma,
+                sampled_idx=sampled_idx,
+            )
+        )
+
+    best = max(r.lp_max for r in records) if records else np.nan
+    for r in records:
+        r.delta_lp = best - r.lp_max
+    return records
+
+
+def match_ledger_to_modes(ledger, mode_report, match_sigma=MATCH_SIGMA):
+    """Assign each ledger record to a surviving posterior mode, or reject.
+
+    Distance is Chebyshev over the mode-feature elements, each normalized
+    by the seed's own measured width along that element.  A record whose
+    nearest mode center is farther than ``match_sigma`` is left unmatched
+    (matched_mode = None): considered and rejected by the posterior.
+    """
+    if mode_report is None or not getattr(mode_report, "modes", None):
+        return ledger
+    for rec in ledger:
+        best_mode, best_d = None, np.inf
+        # element name -> (value, scale) in the current raw coordinates
+        elems = {}
+        for key, val in rec.raw_point.items():
+            flat_v = np.asarray(val, dtype=float).reshape(-1)
+            flat_s = np.asarray(rec.raw_scales[key], dtype=float).reshape(-1)
+            for j, nm in enumerate(_flat_names(key, flat_v.size)):
+                elems[nm] = (flat_v[j], max(flat_s[j], 1e-300))
+        for m in mode_report.modes:
+            ds = [
+                abs(elems[nm][0] - c) / elems[nm][1]
+                for nm, c in m.center.items()
+                if nm in elems
+            ]
+            if not ds:
+                continue
+            d = max(ds)
+            if d < best_d:
+                best_mode, best_d = m.index, d
+        if best_mode is not None and best_d <= match_sigma:
+            rec.matched_mode = best_mode
+            rec.match_distance = best_d
+        else:
+            rec.matched_mode = None
+            rec.match_distance = best_d
+    return ledger
+
+
+def rejected_records(ledger):
+    return [r for r in ledger if r.matched_mode is None]
+
+
+def ledger_to_text(ledger):
+    """Human-readable ledger section (appended to <prefix>_modes.txt)."""
+    lines = []
+    lines.append("")
+    lines.append("Seeded-solution ledger (Laplace approximations)")
+    lines.append("-----------------------------------------------")
+    lines.append(
+        "Every seeded start was polished to its basin optimum before "
+        "sampling; widths are"
+    )
+    lines.append(
+        "symmetric-curvature (Laplace) estimates at that optimum, NOT "
+        "posterior draws."
+    )
+    for r in sorted(ledger, key=lambda r: r.seed_index):
+        lines.append("")
+        status = (
+            f"survived as mode {r.matched_mode + 1} "
+            f"(match distance {r.match_distance:.1f} sigma)"
+            if r.matched_mode is not None
+            else "REJECTED: no surviving posterior mode at this solution"
+        )
+        lines.append(f"seed {r.seed_index} ({r.source}): {status}")
+        lines.append(
+            f"  lp at optimum = {r.lp_max:.2f}  (delta vs best seed = "
+            f"{r.delta_lp:.2f}; Laplace log-weight vs best is comparable "
+            "at the ~1-nat level)"
+        )
+        if r.matched_mode is None:
+            for name in sorted(r.phys):
+                vals = np.asarray(r.phys[name]).reshape(-1)
+                sigs = np.asarray(r.phys_sigma[name]).reshape(-1)
+                idx = r.sampled_idx.get(name, range(vals.size))
+                parts = [f"[{i}] {vals[i]:.6g} +/- {sigs[i]:.3g}" for i in idx]
+                lines.append(f"    {name}: " + "; ".join(parts))
+    return "\n".join(lines) + "\n"
+
+
+def append_ledger_csv(ledger, csv_filename):
+    """Append rejected-mode Laplace rows to the results CSV.
+
+    Row shape matches build_csv_output: name, mode, weight, value, +err,
+    -err -- with mode = 'rejected-seed<k>' and weight the Laplace weight
+    relative to the best seed (an upper-bound-flavored estimate, labeled
+    by the mode column itself).
+    """
+    rej = rejected_records(ledger)
+    if not rej:
+        return
+    best_logw = max(r.laplace_logw for r in ledger)
+    with open(csv_filename, "a", encoding="utf-8") as f:
+        for r in rej:
+            w = float(np.exp(r.laplace_logw - best_logw))
+            for name in sorted(r.phys):
+                vals = np.asarray(r.phys[name]).reshape(-1)
+                sigs = np.asarray(r.phys_sigma[name]).reshape(-1)
+                for i in r.sampled_idx.get(name, range(vals.size)):
+                    f.write(
+                        f"{name},rejected-seed{r.seed_index},{w:.3g},"
+                        f"{vals[i]:.6g},{sigs[i]:.3g},{sigs[i]:.3g}\n"
+                    )
+    logger.info(
+        f"Ledger: appended {len(rej)} rejected mode(s) to {csv_filename}"
+    )
+
+
+def write_rejected_latex(ledger, filename):
+    """Standalone LaTeX table of the rejected solutions (Laplace)."""
+    rej = rejected_records(ledger)
+    if not rej:
+        return False
+    lines = []
+    lines.append(r"% Considered-and-rejected solutions (Laplace")
+    lines.append(r"% approximations at each seeded basin's polished optimum;")
+    lines.append(r"% no posterior draws exist for these).")
+    lines.append(r"\begin{table}")
+    lines.append(r"\centering")
+    lines.append(
+        r"\caption{Solutions considered and rejected by the posterior. "
+        r"Values are Laplace approximations at each seeded basin's "
+        r"optimum; $\Delta \ln \mathcal{L}$ is measured against the best "
+        r"seeded solution.}"
+    )
+    cols = "l" + "c" * len(rej)
+    lines.append(r"\begin{tabular}{" + cols + "}")
+    lines.append(r"\hline")
+    header = ["Parameter"] + [f"seed {r.seed_index}" for r in rej]
+    lines.append(" & ".join(header) + r" \\")
+    lines.append(r"\hline")
+    dl = [r"$\Delta \ln \mathcal{L}$"] + [f"$-{r.delta_lp:.1f}$" for r in rej]
+    lines.append(" & ".join(dl) + r" \\")
+    names = sorted({n for r in rej for n in r.phys})
+    for name in names:
+        n_el = max(
+            np.asarray(r.phys[name]).reshape(-1).size
+            for r in rej
+            if name in r.phys
+        )
+        el_lists = [r.sampled_idx.get(name, list(range(n_el))) for r in rej]
+        for i in sorted({i for lst in el_lists for i in lst}):
+            row = [f"{name}[{i}]".replace("_", r"\_")]
+            for r in rej:
+                vals = np.asarray(r.phys.get(name, []), dtype=float).reshape(
+                    -1
+                )
+                sigs = np.asarray(
+                    r.phys_sigma.get(name, []), dtype=float
+                ).reshape(-1)
+                if i < vals.size and i in r.sampled_idx.get(name, []):
+                    row.append(f"${vals[i]:.6g} \\pm {sigs[i]:.3g}$")
+                else:
+                    row.append("--")
+            lines.append(" & ".join(row) + r" \\")
+    lines.append(r"\hline")
+    lines.append(r"\end{tabular}")
+    lines.append(r"\end{table}")
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+    logger.info(f"Ledger: wrote rejected-mode table {filename}")
+    return True

--- a/src/exozippy/outputs/report_pipeline.py
+++ b/src/exozippy/outputs/report_pipeline.py
@@ -31,6 +31,7 @@ def build_mode_reports(
     force=False,
     raise_on_invalid=True,
     evidence_weights=False,
+    seed_ledger=None,
 ):
     """Identify posterior modes, distribute the posterior, write tables.
 
@@ -77,6 +78,15 @@ def build_mode_reports(
         the occupancy weights and provenance on ``mode_report`` in place, so
         the LaTeX/CSV output below picks the new weights up automatically.
         Self-diagnosing: a single refused mode falls back to occupancy.
+    seed_ledger : list of outputs.ledger.SeedRecord, optional
+        The multi-seed "considered and rejected" ledger built by run.py
+        after the seed polish (outputs.ledger.build_seed_ledger). When
+        given, each record is matched to a surviving posterior mode or
+        marked rejected; the ledger section is appended to
+        <prefix>_modes.txt, rejected solutions get Laplace rows in the
+        CSV and a standalone <prefix>_rejected_modes.tex table. Absent for
+        single-seed fits and for the trace-reprocessing CLI (the seeds no
+        longer exist there).
 
     Returns
     -------
@@ -163,6 +173,41 @@ def build_mode_reports(
                 exc_info=True,
             )
 
+    # Seeded-solution ledger: match every (polished) seed to a surviving
+    # mode or mark it rejected, and report the rejected ones -- the
+    # "considered and rejected" record that pure T=1 occupancy loses.
+    # Appended AFTER any evidence-weighting rewrite of the mode report.
+    if seed_ledger:
+        try:
+            from .ledger import (
+                ledger_to_text,
+                match_ledger_to_modes,
+                rejected_records,
+                write_rejected_latex,
+            )
+
+            match_ledger_to_modes(seed_ledger, mode_report)
+            text = ledger_to_text(seed_ledger)
+            if modes_path is None:
+                modes_path = Path(str(prefix) + "_modes.txt")
+            with open(modes_path, "a", encoding="utf-8") as f:
+                f.write(text)
+            n_rej = len(rejected_records(seed_ledger))
+            if n_rej:
+                write_rejected_latex(
+                    seed_ledger, str(prefix) + "_rejected_modes.tex"
+                )
+                logger.info(
+                    f"Seed ledger: {n_rej} seeded solution(s) rejected by "
+                    f"the posterior; Laplace characterization in "
+                    f"{modes_path} and {prefix}_rejected_modes.tex"
+                )
+        except Exception:
+            logger.warning(
+                "Seed-ledger reporting failed; continuing without it",
+                exc_info=True,
+            )
+
     # populate the parameters with the posteriors
     system.distribute_posterior(idata)
 
@@ -179,5 +224,15 @@ def build_mode_reports(
         csv_filename=str(prefix) + "_results.csv",
         mode_report=mode_report,
     )
+    if seed_ledger:
+        try:
+            from .ledger import append_ledger_csv
+
+            append_ledger_csv(seed_ledger, str(prefix) + "_results.csv")
+        except Exception:
+            logger.warning(
+                "Seed-ledger CSV rows failed; continuing without them",
+                exc_info=True,
+            )
 
     return mode_report

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -345,6 +345,32 @@ def _run_fit(config, gui, user_params=None):
         # seeds k>0 are re-derived from their polished physical values.
         raw_starts, seed_indices = system.get_raw_starts(model)
 
+        # Seeded-solution ledger (multi-seed fits only): a Laplace record
+        # of every polished seed -- peak logp and curvature widths at the
+        # basin optimum -- measured NOW, while the seeds exist, so the
+        # final report can distinguish "considered and rejected at
+        # delta lp = X" from "never looked" even for modes the T=1
+        # posterior abandons entirely. Costs n_seeds x n_params x O(15)
+        # logp calls on the freshly whitened model. Disable with config
+        # `modes: {ledger: false}`.
+        # (Skipped when reusing an existing trace: the polish was skipped
+        # there too, so seed lp would be a start value, not a basin peak.)
+        seed_ledger = None
+        _ledger_on = (config.get("modes", {}) or {}).get("ledger", True)
+        if len(raw_starts) > 1 and _ledger_on and not reusing_trace:
+            from .outputs.ledger import build_seed_ledger
+
+            try:
+                seed_ledger = build_seed_ledger(
+                    system, model, raw_starts, seed_indices
+                )
+            except Exception:
+                logger.warning(
+                    "Seed ledger measurement failed; final report will "
+                    "not carry rejected-mode records",
+                    exc_info=True,
+                )
+
         # convert raw starting point to the internal starting point
         internal_start = system.get_internal_point(model, raw_start)
 
@@ -598,6 +624,7 @@ def _run_fit(config, gui, user_params=None):
         raise_on_invalid=True,
         evidence_weights=str(modes_cfg.get("weights", "")).lower()
         == "evidence",
+        seed_ledger=seed_ledger,
     )
 
     summary_path = Path(str(prefix) + "_summary.txt")

--- a/tests/test_mode_ledger.py
+++ b/tests/test_mode_ledger.py
@@ -1,0 +1,188 @@
+"""Seeded-solution ledger (outputs/ledger.py): Laplace records for every
+polished seed, matched to surviving posterior modes or reported as
+"considered and rejected"."""
+
+import numpy as np
+import pymc as pm
+import pytest
+
+from exozippy.components.parameter import Parameter
+from exozippy.outputs.ledger import (
+    append_ledger_csv,
+    build_seed_ledger,
+    ledger_to_text,
+    match_ledger_to_modes,
+    rejected_records,
+    write_rejected_latex,
+)
+from exozippy.outputs.modes import ModeInfo, ModeReport
+
+
+def _two_basin_model():
+    """One bounded parameter with two Gaussian basins: x=2 (deep) and x=7
+    (shallow, delta lp = 6)."""
+    p = Parameter(label="toy.x", initval=2.0, lower=0.0, upper=10.0)
+    with pm.Model() as model:
+        xv = p.build_pymc()
+        lp1 = -0.5 * ((xv - 2.0) / 0.05) ** 2
+        lp2 = -0.5 * ((xv - 7.0) / 0.05) ** 2 - 6.0
+        pm.Potential("like", pm.math.logsumexp(pm.math.stack([lp1, lp2])))
+    return model, p
+
+
+class _StubSystem:
+    def __init__(self, params):
+        self._params = params
+
+    def get_all_parameters(self):
+        return self._params
+
+
+def _fake_report(centers, feature_name):
+    """Minimal ModeReport with the given raw-space centers."""
+    modes = [
+        ModeInfo(
+            index=k,
+            weight=1.0 / len(centers),
+            n_draws=100,
+            lp_med=0.0,
+            lp_max=0.0,
+            delta_lp_max=0.0,
+            per_chain_weight=np.ones(2),
+            center={feature_name: float(c)},
+        )
+        for k, c in enumerate(centers)
+    ]
+    return ModeReport(
+        labels=np.zeros((2, 100), dtype=int),
+        modes=modes,
+        n_valid=200,
+        n_invalid=0,
+        n_unassigned=0,
+        provenance="occupancy",
+        weights_reliable=True,
+        n_transitions=10,
+        feature_vars=[feature_name],
+    )
+
+
+def test_ledger_measures_peak_and_width_per_seed():
+    """
+    Given two seeds at the two basin optima of a known double-Gaussian,
+    When build_seed_ledger measures them,
+    Then each record carries the basin's peak lp (delta_lp = 6 between
+      them) and a physical width ~ the basin sigma (0.05).
+    """
+    # ARRANGE
+    model, p = _two_basin_model()
+    seeds = [
+        {"toy.x_raw": np.asarray(p.raw_from_initval(np.array([2.0])))},
+        {"toy.x_raw": np.asarray(p.raw_from_initval(np.array([7.0])))},
+    ]
+    stub = _StubSystem([p])
+
+    # ACT
+    ledger = build_seed_ledger(stub, model, seeds, [0, 1])
+
+    # ASSERT: the basin depth difference is 6 nats in the likelihood, minus
+    # the logit-Jacobian ratio between the two locations -- logp is a
+    # density in the sampled (raw) space, so the flat-in-x prior carries
+    # log[q(1-q)] with it: log(0.7*0.3) - log(0.2*0.8) = +0.272 at x=7.
+    expected = 6.0 - (np.log(0.7 * 0.3) - np.log(0.2 * 0.8))
+    assert ledger[0].delta_lp == pytest.approx(0.0, abs=0.01)
+    assert ledger[1].delta_lp == pytest.approx(expected, abs=0.05)
+    for rec in ledger:
+        assert rec.phys_sigma["toy.x"][0] == pytest.approx(0.05, rel=0.25)
+    assert ledger[0].phys["toy.x"][0] == pytest.approx(2.0, abs=0.01)
+    assert ledger[1].phys["toy.x"][0] == pytest.approx(7.0, abs=0.01)
+
+
+def test_matching_assigns_survivor_and_rejects_the_missing_mode():
+    """
+    Given a mode report containing only the deep basin,
+    When the ledger is matched against it,
+    Then the seed at that basin matches mode 0 and the other seed is
+      rejected (matched_mode None), with the distance recorded.
+    """
+    # ARRANGE
+    model, p = _two_basin_model()
+    raw0 = np.asarray(p.raw_from_initval(np.array([2.0])))
+    raw1 = np.asarray(p.raw_from_initval(np.array([7.0])))
+    seeds = [{"toy.x_raw": raw0}, {"toy.x_raw": raw1}]
+    ledger = build_seed_ledger(_StubSystem([p]), model, seeds, [0, 1])
+    report = _fake_report([float(raw0[0])], "toy.x_raw")
+
+    # ACT
+    match_ledger_to_modes(ledger, report)
+
+    # ASSERT
+    assert ledger[0].matched_mode == 0
+    assert ledger[0].match_distance < 1.0
+    assert ledger[1].matched_mode is None
+    assert ledger[1].match_distance > 10.0
+    assert rejected_records(ledger) == [ledger[1]]
+
+
+def test_text_csv_and_latex_report_the_rejected_solution(tmp_path):
+    """
+    Given a ledger with one rejected seed,
+    When the text/CSV/LaTeX emitters run,
+    Then the rejected solution appears with its delta lp and Laplace
+      value +/- sigma, labeled as rejected.
+    """
+    # ARRANGE
+    model, p = _two_basin_model()
+    raw0 = np.asarray(p.raw_from_initval(np.array([2.0])))
+    raw1 = np.asarray(p.raw_from_initval(np.array([7.0])))
+    ledger = build_seed_ledger(
+        _StubSystem([p]),
+        model,
+        [{"toy.x_raw": raw0}, {"toy.x_raw": raw1}],
+        [0, 1],
+    )
+    match_ledger_to_modes(ledger, _fake_report([float(raw0[0])], "toy.x_raw"))
+
+    # ACT
+    text = ledger_to_text(ledger)
+    csv_path = tmp_path / "results.csv"
+    csv_path.write_text("name,mode,weight,value,hi,lo\n")
+    append_ledger_csv(ledger, str(csv_path))
+    tex_path = tmp_path / "rejected.tex"
+    wrote = write_rejected_latex(ledger, str(tex_path))
+
+    # ASSERT
+    assert "seed 0 (seed): survived as mode 1" in text
+    assert "seed 1 (seed): REJECTED" in text
+    assert "delta vs best seed = 5.7" in text
+    csv = csv_path.read_text()
+    assert "toy.x,rejected-seed1," in csv
+    assert wrote and tex_path.exists()
+    tex = tex_path.read_text()
+    assert "considered and rejected" in tex.lower()
+    assert "seed 1" in tex
+
+
+def test_no_rejected_seeds_writes_nothing(tmp_path):
+    """
+    Given every seed matches a surviving mode,
+    When the CSV/LaTeX emitters run,
+    Then nothing is appended or written (the main tables already cover
+      every mode).
+    """
+    # ARRANGE
+    model, p = _two_basin_model()
+    raw0 = np.asarray(p.raw_from_initval(np.array([2.0])))
+    ledger = build_seed_ledger(
+        _StubSystem([p]), model, [{"toy.x_raw": raw0}], [0]
+    )
+    match_ledger_to_modes(ledger, _fake_report([float(raw0[0])], "toy.x_raw"))
+
+    # ACT
+    csv_path = tmp_path / "results.csv"
+    csv_path.write_text("header\n")
+    append_ledger_csv(ledger, str(csv_path))
+    wrote = write_rejected_latex(ledger, str(tmp_path / "rejected.tex"))
+
+    # ASSERT
+    assert csv_path.read_text() == "header\n"
+    assert not wrote


### PR DESCRIPTION
## Problem

A posterior-suppressed mode (delta chi2 ~ 10 against the best solution) carries ~zero T=1 occupancy, so it vanishes from the trace — and with it the distinction between *we considered this solution and rejected it at delta lp = X* and *we never looked*. Systematics routinely make such modes worth reporting anyway: for OGLE-2014-BLG-0939, Yee et al. 2015 publish all four degenerate solutions with their delta chi2 (8 and 17 for the disfavored pair), while our four-seed fit correctly drops that pair from the posterior and, previously, from the report entirely.

## What this adds (no sampling changes)

New `outputs/ledger.py`:

- **`build_seed_ledger`** — a Laplace record per (polished) seed: peak logp (the polish already put each seed at its basin optimum), per-element widths from the gradient-immune symmetric-curvature probe (the model is whitened, so brackets land in a few evaluations; total cost n_seeds x n_params x O(15) logp calls), physical location/half-widths through each parameter's frozen transform in USER units, and a relative Laplace log-weight `lp_max + sum(log sigma_raw)`.
- **`match_ledger_to_modes`** — assign each seed to a surviving posterior mode by Chebyshev distance in raw feature space normalized by the seed's own widths (threshold 10 sigma; basins are many sigma apart by construction), else mark REJECTED.
- **Reporting** — a ledger section appended to `<prefix>_modes.txt`; rejected solutions get rows in `<prefix>_results.csv` (mode column `rejected-seed<k>`, weight = Laplace estimate relative to the best seed) and a compact standalone `<prefix>_rejected_modes.tex` table with delta ln L against the best seeded solution.

run.py measures the ledger right after the whitening rescale, while the polished seeds exist (multi-seed fits only; skipped when reusing a trace, where the polish was skipped too; disable with `modes: {ledger: false}`); `report_pipeline.build_mode_reports` carries it through matching and emission (absent for single-seed fits and the trace-reprocessing CLI, where the seeds no longer exist).

The Laplace numbers are labeled approximations everywhere: right for the "is this mode at the 1e-2 or 1e-8 level" fidelity reporting needs, not precision odds. Peak-lp comparisons are densities in the sampled raw space, so they include the (correct) logit-Jacobian volume term — pinned by test.

## Tests

4 new (`tests/test_mode_ledger.py`): peak/width measurement on a known double-Gaussian (including the Jacobian volume term), survivor-vs-rejected matching, text/CSV/LaTeX emission, and the no-rejections-writes-nothing invariant. Full suite: 992 passed, 0 failed (together with the stacked hot-chain PR).

Companion PR: hot-chain discovery extends this ledger to modes nobody seeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)