### PR TITLE
PTDE-async: store_hot_chains + hot-rung discovery of suppressed modes

### DIFF
--- a/src/exozippy/outputs/ledger.py
+++ b/src/exozippy/outputs/ledger.py
@@ -325,3 +325,165 @@ def write_rejected_latex(ledger, filename):
         f.write("\n".join(lines) + "\n")
     logger.info(f"Ledger: wrote rejected-mode table {filename}")
     return True
+
+
+# ---------------------------------------------------------------------------
+# Hot-chain mode discovery (PTDE store_hot_chains)
+# ---------------------------------------------------------------------------
+
+# A hot draw whose UNtempered lp is within this many nats of the best lp
+# seen anywhere in the hot set is "near-viable": worth clustering as a
+# candidate mode. Matches the spirit of modes.DEFAULT_LP_EXEMPT_MARGIN --
+# a genuinely real mode more than 50 nats down carries e^-50 of the mass
+# and loses nothing by being ignored.
+HOT_LP_MARGIN = 50.0
+
+# Fewer near-viable points than this cannot support a cluster.
+HOT_MIN_POINTS = 25
+
+
+def discover_hot_modes(
+    system,
+    model,
+    hot,
+    seed_ledger=None,
+    margin_nats=HOT_LP_MARGIN,
+    min_points=HOT_MIN_POINTS,
+    max_modes=8,
+    subsample=20000,
+    seed=20260711,
+    polish_steps=150,
+):
+    """Find posterior-suppressed modes in the thinned hot-rung draws.
+
+    ``hot`` is the ``posterior_hot`` group written by
+    ptde_async_sample(store_hot_chains=...): raw variables + UNtempered
+    ``lp`` with dims (chain, draw). Hot draws are DETECTORS only -- a
+    T-tempered mode is ~sqrt(T) too wide, so nothing here uses their
+    spread. The pipeline is: filter to near-viable draws (lp within
+    ``margin_nats`` of the best), cluster them (the same BIC k-means +
+    density-dip merge the T=1 mode identification uses), take each
+    cluster's best-lp draw as a candidate, POLISH it to its basin optimum
+    (polish.polish_raw_starts), Laplace-characterize it
+    (build_seed_ledger), and append it to ``seed_ledger`` unless an
+    existing record already sits in the same basin.
+
+    Appended records carry source='hot-chain' and seed indices continuing
+    after the seeded ones. Returns the (possibly extended) ledger list.
+    match_ledger_to_modes then classifies them against the surviving T=1
+    modes like any other record -- a hot-chain record matching a surviving
+    mode is simply confirmation; an unmatched one is a mode the T=1
+    posterior never held.
+    """
+    from .modes import _dip_merge, _kmeans_bic
+
+    ledger = list(seed_ledger) if seed_ledger else []
+
+    raw_keys = [str(v) for v in hot.data_vars if str(v) != "lp"]
+    if not raw_keys or "lp" not in hot.data_vars:
+        return ledger
+    lp = np.asarray(hot["lp"].values, dtype=float).reshape(-1)
+
+    cols, names, shapes = [], [], {}
+    for key in raw_keys:
+        arr = np.asarray(hot[key].values, dtype=float)
+        n_chain, n_draw = arr.shape[0], arr.shape[1]
+        arr = arr.reshape(n_chain * n_draw, -1)
+        shapes[key] = arr.shape[1]
+        for j in range(arr.shape[1]):
+            cols.append(arr[:, j])
+        names.extend(_flat_names(key, arr.shape[1]))
+    X = np.column_stack(cols)
+
+    good = np.isfinite(lp) & np.all(np.isfinite(X), axis=1)
+    if not good.any():
+        return ledger
+    viable = good & (lp >= np.nanmax(lp[good]) - margin_nats)
+    n_viable = int(viable.sum())
+    if n_viable < min_points:
+        logger.info(
+            f"Hot-chain discovery: only {n_viable} near-viable hot draws "
+            f"(need {min_points}); nothing to cluster."
+        )
+        return ledger
+    Xv, lpv = X[viable], lp[viable]
+
+    rng = np.random.default_rng(seed)
+    if Xv.shape[0] > subsample:
+        keep = rng.choice(Xv.shape[0], size=subsample, replace=False)
+        Xv, lpv = Xv[keep], lpv[keep]
+
+    # Standardize for clustering (hot spreads are wide but finite).
+    mu = np.median(Xv, axis=0)
+    sig = np.maximum(np.std(Xv, axis=0), 1e-12)
+    Z = (Xv - mu) / sig
+    labels, centers = _kmeans_bic(Z, max_modes=max_modes, seed=seed)
+    # iterate the density-dip merge to a fixed point, as identify_modes does
+    while True:
+        labels, centers, changed = _dip_merge(
+            Z, labels, centers, merge_ratio=0.5
+        )
+        if not changed:
+            break
+    n_clusters = len(np.unique(labels[labels >= 0]))
+    logger.info(
+        f"Hot-chain discovery: {n_viable} near-viable draws -> "
+        f"{n_clusters} cluster(s)."
+    )
+
+    from ..polish import polish_raw_starts
+
+    next_index = max((r.seed_index for r in ledger), default=-1) + 1
+    for c in np.unique(labels[labels >= 0]):
+        sel = labels == c
+        best = int(np.argmax(lpv[sel]))
+        x_best = Xv[sel][best]
+        # rebuild the raw dict for this candidate
+        cand, ofs = {}, 0
+        for key in raw_keys:
+            n = shapes[key]
+            cand[key] = np.array(x_best[ofs : ofs + n], dtype=float)
+            ofs += n
+
+        polished, _dlps, _method = polish_raw_starts(
+            model, [cand], n_steps=polish_steps
+        )
+        recs = build_seed_ledger(system, model, polished, [next_index])
+        rec = recs[0]
+        rec.source = "hot-chain"
+
+        # Dedup: an existing record already sitting in this basin (within
+        # MATCH_SIGMA of the polished point, in the new record's own
+        # widths) makes this a rediscovery, not a discovery.
+        dup = False
+        for other in ledger:
+            ds = []
+            for key in raw_keys:
+                a = np.asarray(rec.raw_point[key], dtype=float).reshape(-1)
+                b = np.asarray(
+                    other.raw_point.get(key, np.full_like(a, np.nan)),
+                    dtype=float,
+                ).reshape(-1)
+                s = np.asarray(rec.raw_scales[key], dtype=float).reshape(-1)
+                if b.shape != a.shape or not np.all(np.isfinite(b)):
+                    ds = []
+                    break
+                ds.extend(np.abs(a - b) / np.maximum(s, 1e-300))
+            if ds and max(ds) <= MATCH_SIGMA:
+                dup = True
+                break
+        if dup:
+            continue
+        ledger.append(rec)
+        next_index += 1
+        logger.info(
+            f"Hot-chain discovery: new basin at lp={rec.lp_max:.2f} "
+            f"recorded as ledger entry {rec.seed_index} (hot-chain)."
+        )
+
+    # delta_lp is relative to the best record across the WHOLE ledger.
+    if ledger:
+        best_lp = max(r.lp_max for r in ledger)
+        for r in ledger:
+            r.delta_lp = best_lp - r.lp_max
+    return ledger

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -91,6 +91,7 @@ KNOWN_SAMPLER_KEYS = {
     "collect_rung_timing",
     "swap_schedule",
     "seed_polish",
+    "store_hot_chains",
 }
 
 
@@ -197,6 +198,10 @@ def _run_fit(config, gui, user_params=None):
     eval_timeout = (
         float(_eval_timeout_raw) if _eval_timeout_raw is not None else None
     )
+    # Thinned hot-rung retention (ptde_async only): detector data for
+    # post-hoc discovery of posterior-suppressed modes; see
+    # outputs.ledger.discover_hot_modes. False | True (thin 20) | int thin.
+    store_hot_chains = sampler_cfg.get("store_hot_chains", False)
     rung_thin_factor = int(sampler_cfg.get("rung_thin_factor", 1))
     _rung_thin_start_raw = sampler_cfg.get("rung_thin_start", None)
     rung_thin_start = (
@@ -446,6 +451,7 @@ def _run_fit(config, gui, user_params=None):
                     system,
                     draws,
                     tune,
+                    store_hot_chains=store_hot_chains,
                     n_temps=n_temps,
                     T_max=T_max,
                     n_chains=n_chains,
@@ -597,6 +603,25 @@ def _run_fit(config, gui, user_params=None):
     # the fix for the DC2018_128 pathology (notes/todo.txt): the reported
     # summary previously discarded zero burn-in even though a likelihood-flat
     # degenerate direction drifted for ~half the run.
+    # Hot-chain mode discovery (store_hot_chains): cluster the thinned
+    # hot-rung draws, polish each new basin's best point, and append
+    # Laplace records to the seed ledger -- so a mode the T=1 posterior
+    # never held still shows up as "considered and rejected" in the final
+    # report. Runs BEFORE burn-in trimming (hot draws are detectors; no
+    # burn-in semantics) and tolerates a missing/empty group.
+    if hasattr(idata, "posterior_hot"):
+        try:
+            from .outputs.ledger import discover_hot_modes
+
+            seed_ledger = discover_hot_modes(
+                system, model, idata.posterior_hot, seed_ledger
+            )
+        except Exception:
+            logger.warning(
+                "Hot-chain mode discovery failed; continuing without it",
+                exc_info=True,
+            )
+
     idata, burn_diag = convergence.analyze_idata(
         idata, min_ess=min_ess, max_rhat=max_rhat
     )

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -112,6 +112,7 @@ def ptde_async_sample(
     eval_timeout=None,
     collect_rung_timing=False,
     progress_callback=None,
+    store_hot_chains=False,
 ):
     """
     Asynchronous Parallel Tempering + Differential Evolution sampler.
@@ -142,6 +143,21 @@ def ptde_async_sample(
                Invoked at each geometric convergence check; exceptions are
                logged and swallowed (_safe_progress) so it can never abort the
                fit.
+
+    Returns
+    -------
+    store_hot_chains : False | True | int -- keep THINNED draws from the
+               hot rungs (T > 1) as an extra ``posterior_hot`` group on the
+               returned InferenceData: every int-th post-tune iteration of
+               each hot chain (True -> 20), with its UNtempered logp and a
+               per-chain ``temperature`` coordinate. Hot draws are not
+               posterior draws -- a T-tempered mode is ~sqrt(T) too wide --
+               but they visit posterior-suppressed basins (occupancy
+               ~exp(-dlp/T)) that the T=1 chains abandon, so they are the
+               mode DETECTOR for outputs.ledger.discover_hot_modes, which
+               polishes and Laplace-characterizes anything they find.
+               Memory: n_raw_elements x (n_temps-1) x n_chains x
+               (draws/thin) float64.
 
     Returns
     -------
@@ -314,6 +330,25 @@ def ptde_async_sample(
     }
     stored_lp = np.zeros((n_chains, draws))
     per_chain_draws = np.zeros(n_chains, dtype=int)
+
+    # Optional thinned hot-rung storage (store_hot_chains): detector data
+    # for post-hoc discovery of posterior-suppressed modes; see the
+    # parameter docstring. UNtempered logp is stored (current_lp holds the
+    # raw logp; tempering happens in the acceptance rule), so hot lp values
+    # are directly comparable to T=1.
+    hot_thin = 0
+    if store_hot_chains and n_temps > 1:
+        hot_thin = (
+            20 if store_hot_chains is True else max(1, int(store_hot_chains))
+        )
+    hot_cap = max(1, draws // hot_thin) if hot_thin else 0
+    if hot_thin:
+        stored_hot_raw = {
+            k: np.zeros((n_temps - 1, n_chains, hot_cap) + raw_start[k].shape)
+            for k in model_keys
+        }
+        stored_hot_lp = np.full((n_temps - 1, n_chains, hot_cap), np.nan)
+        per_hot_draws = np.zeros((n_temps - 1, n_chains), dtype=int)
 
     n_accept = np.zeros(n_temps)
     n_propose = np.zeros(n_temps)
@@ -608,6 +643,22 @@ def ptde_async_sample(
                     stored_lp[i, d] = current_lp[k][i]
                     per_chain_draws[i] = d + 1
 
+                # thinned hot-rung storage (see store_hot_chains)
+                if (
+                    hot_thin
+                    and k >= 1
+                    and iter_count[k][i] > tune
+                    and iter_count[k][i] % hot_thin == 0
+                    and per_hot_draws[k - 1, i] < hot_cap
+                ):
+                    d = per_hot_draws[k - 1, i]
+                    for key in model_keys:
+                        stored_hot_raw[key][k - 1, i, d] = current_state[k][i][
+                            key
+                        ]
+                    stored_hot_lp[k - 1, i, d] = current_lp[k][i]
+                    per_hot_draws[k - 1, i] = d + 1
+
             n_completed_total[0] += 1
 
             if n_completed_total[0] % swap_interval == 0:
@@ -731,6 +782,51 @@ def ptde_async_sample(
     # Multi-seed provenance (P4): which solved seed each T=1 chain started from.
     # TODO(P4): surface in outputs/modes.py ModeReport; per-chain attr for now.
     idata.posterior.attrs["chain_seed_index"] = list(chain_seed_index)
+
+    if hot_thin:
+        import xarray as xr
+
+        # Rectangular cut at the shortest hot chain (rungs run at slightly
+        # different speeds); rungs x chains flatten into one 'chain' dim
+        # with a per-chain temperature coordinate, which round-trips
+        # through netcdf.
+        n_hot = int(per_hot_draws.min())
+        if n_hot > 0:
+            n_hot_chains = (n_temps - 1) * n_chains
+            data_vars = {}
+            for key in model_keys:
+                arr = stored_hot_raw[key][:, :, :n_hot].reshape(
+                    (n_hot_chains, n_hot) + raw_start[key].shape
+                )
+                dims = ("chain", "draw") + tuple(
+                    f"{key}_dim_{j}" for j in range(arr.ndim - 2)
+                )
+                data_vars[str(key)] = (dims, arr)
+            data_vars["lp"] = (
+                ("chain", "draw"),
+                stored_hot_lp[:, :, :n_hot].reshape(n_hot_chains, n_hot),
+            )
+            idata["posterior_hot"] = xr.Dataset(
+                data_vars,
+                coords={
+                    "chain": np.arange(n_hot_chains),
+                    "draw": np.arange(n_hot),
+                    "temperature": (
+                        "chain",
+                        np.repeat(np.asarray(temperatures[1:]), n_chains),
+                    ),
+                },
+            )
+            logger.info(
+                f"PTDE-async: stored {n_hot} thinned hot draws/chain from "
+                f"{n_temps - 1} rungs x {n_chains} chains "
+                f"(store_hot_chains={store_hot_chains}, thin={hot_thin})"
+            )
+        else:
+            logger.warning(
+                "PTDE-async: store_hot_chains was set but no hot draws "
+                "accumulated (draws too small for the thinning factor?)"
+            )
     if len(set(chain_seed_index)) > 1:
         logger.info(
             f"PTDE-async multi-seed provenance (chain -> seed): "

--- a/tests/test_hot_chains.py
+++ b/tests/test_hot_chains.py
@@ -1,0 +1,187 @@
+"""Hot-chain retention (ptde_async store_hot_chains) and posterior-
+suppressed-mode discovery (outputs.ledger.discover_hot_modes)."""
+
+import numpy as np
+import pymc as pm
+import pytest
+import xarray as xr
+
+from exozippy.components.parameter import Parameter
+from exozippy.outputs.ledger import (
+    build_seed_ledger,
+    discover_hot_modes,
+    ledger_to_text,
+    match_ledger_to_modes,
+)
+from exozippy.samplers.ptde_async import ptde_async_sample
+
+
+class _MinimalSystem:
+    active_components = {}
+
+    def get_raw_start(self, model):
+        return model.initial_point()
+
+
+def test_store_hot_chains_writes_the_posterior_hot_group():
+    """
+    Given ptde_async with store_hot_chains=5 and 3 temperatures,
+    When sampling completes,
+    Then the InferenceData carries a posterior_hot group: (n_temps-1) x
+      n_chains hot chains, a per-chain temperature coordinate on the hot
+      rungs' values, finite untempered lp, and ~draws/5 thinned draws.
+    """
+    # ARRANGE
+    with pm.Model() as model:
+        pm.Normal("x", mu=0.0, sigma=1.0)
+        pm.Normal("y", mu=3.0, sigma=0.5)
+
+    # ACT
+    idata = ptde_async_sample(
+        model,
+        _MinimalSystem(),
+        draws=60,
+        tune=20,
+        n_temps=3,
+        T_max=8.0,
+        n_chains=4,
+        cores=1,
+        seed=7,
+        log_interval=10000,
+        store_hot_chains=5,
+    )
+
+    # ASSERT
+    assert hasattr(idata, "posterior_hot")
+    hot = idata.posterior_hot
+    assert hot.sizes["chain"] == (3 - 1) * 4
+    temps = np.asarray(hot["temperature"].values)
+    assert np.all(temps > 1.0)
+    assert len(np.unique(temps)) == 2
+    lp = np.asarray(hot["lp"].values)
+    assert np.all(np.isfinite(lp))
+    assert 1 <= hot.sizes["draw"] <= 60 // 5
+
+
+def test_store_hot_chains_off_by_default():
+    """
+    Given ptde_async without store_hot_chains,
+    When sampling completes,
+    Then no posterior_hot group exists (byte-identical legacy output).
+    """
+    with pm.Model() as model:
+        pm.Normal("x", mu=0.0, sigma=1.0)
+    idata = ptde_async_sample(
+        model,
+        _MinimalSystem(),
+        draws=30,
+        tune=10,
+        n_temps=2,
+        T_max=4.0,
+        n_chains=3,
+        cores=1,
+        seed=1,
+        log_interval=10000,
+    )
+    assert not hasattr(idata, "posterior_hot")
+
+
+def _two_basin_model():
+    """Bounded parameter with basins at x=2 (deep) and x=7 (6 nats down)."""
+    p = Parameter(label="toy.x", initval=2.0, lower=0.0, upper=10.0)
+    with pm.Model() as model:
+        xv = p.build_pymc()
+        lp1 = -0.5 * ((xv - 2.0) / 0.05) ** 2
+        lp2 = -0.5 * ((xv - 7.0) / 0.05) ** 2 - 6.0
+        pm.Potential("like", pm.math.logsumexp(pm.math.stack([lp1, lp2])))
+    return model, p
+
+
+class _StubSystem:
+    def __init__(self, params):
+        self._params = params
+
+    def get_all_parameters(self):
+        return self._params
+
+
+def _fake_hot_group(model, p, rng):
+    """Synthetic posterior_hot: hot draws around BOTH basins with real
+    (untempered) logp values, like a T ~ 6 rung would produce."""
+    logp = model.compile_logp()
+    raw2 = float(np.asarray(p.raw_from_initval(np.array([2.0])))[0])
+    raw7 = float(np.asarray(p.raw_from_initval(np.array([7.0])))[0])
+    # spread ~ sqrt(T) x basin sigma in raw units; basins are far apart
+    draws = np.concatenate(
+        [
+            raw2 + 0.5 * rng.standard_normal(120),
+            raw7 + 0.5 * rng.standard_normal(120),
+        ]
+    )
+    lp = np.array([float(logp({"toy.x_raw": np.array([d])})) for d in draws])
+    return xr.Dataset(
+        {
+            "toy.x_raw": (("chain", "draw"), draws.reshape(2, 120)),
+            "lp": (("chain", "draw"), lp.reshape(2, 120)),
+        },
+        coords={
+            "chain": [0, 1],
+            "draw": np.arange(120),
+            "temperature": ("chain", [6.0, 6.0]),
+        },
+    )
+
+
+def test_discovery_finds_polishes_and_dedups_the_suppressed_basin():
+    """
+    Given a seed ledger holding only the deep basin and hot draws visiting
+      both basins,
+    When discover_hot_modes runs,
+    Then exactly one new record appears (source 'hot-chain'), polished to
+      the suppressed basin's optimum with delta_lp ~ 6, and a second
+      discovery pass adds nothing (dedup).
+    """
+    # ARRANGE
+    model, p = _two_basin_model()
+    stub = _StubSystem([p])
+    raw2 = np.asarray(p.raw_from_initval(np.array([2.0])))
+    ledger0 = build_seed_ledger(stub, model, [{"toy.x_raw": raw2}], [0])
+    hot = _fake_hot_group(model, p, np.random.default_rng(11))
+
+    # ACT
+    ledger = discover_hot_modes(stub, model, hot, ledger0, min_points=20)
+
+    # ASSERT
+    assert len(ledger) == 2
+    rec = ledger[1]
+    assert rec.source == "hot-chain"
+    assert rec.phys["toy.x"][0] == pytest.approx(7.0, abs=0.05)
+    assert rec.delta_lp == pytest.approx(5.73, abs=0.3)
+
+    # ACT again: rediscovery must dedup
+    ledger2 = discover_hot_modes(stub, model, hot, ledger, min_points=20)
+
+    # ASSERT
+    assert len(ledger2) == 2
+
+
+def test_hot_record_reports_as_hot_chain_in_the_ledger_text():
+    """
+    Given a ledger extended by discovery,
+    When it is matched against a report holding only the deep basin and
+      rendered,
+    Then the hot-chain record appears as REJECTED with the '(hot-chain)'
+      source tag.
+    """
+    from test_mode_ledger import _fake_report
+
+    model, p = _two_basin_model()
+    stub = _StubSystem([p])
+    raw2 = np.asarray(p.raw_from_initval(np.array([2.0])))
+    ledger0 = build_seed_ledger(stub, model, [{"toy.x_raw": raw2}], [0])
+    hot = _fake_hot_group(model, p, np.random.default_rng(3))
+    ledger = discover_hot_modes(stub, model, hot, ledger0, min_points=20)
+    match_ledger_to_modes(ledger, _fake_report([float(raw2[0])], "toy.x_raw"))
+
+    text = ledger_to_text(ledger)
+    assert "(hot-chain): REJECTED" in text


### PR DESCRIPTION
Stacked on #61 (the mode ledger); GitHub will retarget to master when that merges.

## Problem

The seed ledger (#61) covers modes we KNEW to seed. Hot tempering rungs visit posterior-suppressed basins nobody seeded — occupancy ~exp(-dlp/T), so a rung at T ~ dlp holds a healthy population where the T=1 chains hold none. They are the detector for modes the ledger would otherwise never hear about.

## What this adds

**`ptde_async_sample(store_hot_chains=False|True|int)`** — keep every int-th post-tune draw of each hot rung (True → 20) in a new `posterior_hot` group on the returned InferenceData: raw variables + UNtempered logp (`current_lp` holds the raw logp; tempering lives in the acceptance rule, so hot lp is directly comparable to T=1), with rungs x chains flattened into one chain dim carrying a per-chain `temperature` coordinate that round-trips through netcdf. Off by default; legacy output is byte-identical. Memory: n_raw_elements x (n_temps-1) x n_chains x (draws/thin) float64.

**`outputs.ledger.discover_hot_modes`** — filter hot draws to near-viable (lp within 50 nats of the best seen, the same margin philosophy as `modes.DEFAULT_LP_EXEMPT_MARGIN`), cluster with the same BIC k-means + density-dip merge the T=1 mode identification uses, take each cluster's best-lp draw as a candidate, **polish** it to its basin optimum and **Laplace-characterize** it via the #61 machinery. New basins append to the ledger as `source='hot-chain'` (deduped against existing records); `match_ledger_to_modes` then classifies them like any seeded record, so a mode the T=1 posterior never held still lands in modes.txt / results.csv / rejected_modes.tex as *considered and rejected*.

Hot draws are detectors ONLY — a T-tempered mode is ~sqrt(T) too wide, so nothing uses their spread; the polish + curvature probe do the characterizing.

**run.py** — sampler key `store_hot_chains` (ptde_async only); discovery runs after sampling and BEFORE burn-in trimming (hot draws have no burn-in semantics), tolerating a missing/empty group and a None seed ledger (single-seed fits gain discovery-only ledgers).

## Tests

4 new (`tests/test_hot_chains.py`): the posterior_hot group's shape/temperature-coordinate/lp contract, off-by-default byte-identity, end-to-end discovery of a planted suppressed basin (found → polished to its optimum → correct delta lp → deduped on rediscovery), and the '(hot-chain): REJECTED' ledger rendering. Full suite: 992 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)