### PR TITLE
GalacticModel: center rotation on the azimuthal velocity, not the radial

### DIFF
--- a/src/exozippy/components/galacticmodel/galacticmodel.py
+++ b/src/exozippy/components/galacticmodel/galacticmodel.py
@@ -208,13 +208,26 @@ class GalacticModel(Component):
         y_bar = -x * sin_bar + y * cos_bar
 
         # 1. Compute Disk Likelihood (Spatial + Kinematic)
+        # Galactic rotation is AZIMUTHAL: the circular-speed offset belongs
+        # on v_phi (paired with the azimuthal dispersion sigma_V) and the
+        # radial component v_r is zero-centered (sigma_U). These centers
+        # were swapped until 2026-08: the prior penalized an EXACTLY
+        # circular co-rotating orbit by ~49 nats and was maximized by a
+        # star plunging radially at the rotation speed (pinned by
+        # tests/test_galactic_model.py). On examples/ob140939 the swap
+        # gave the anti-rotation parallax solution +5 nats and flipped the
+        # mode weights to 0.98/0.02 AGAINST the Yee et al. 2015 proper-
+        # motion-preferred solution. Sign convention: v_phi as computed by
+        # get_polar_velocity is positive for co-rotation at every position
+        # (verified against astropy Galactocentric), so the center is
+        # +DISK_ROTATION_VELOCITY.
         log_dens_disk = (-1.0 / DISK_SCALE_LENGTH) * r + (
             -1.0 / DISK_SCALE_HEIGHT
         ) * z_smooth
         log_vel_disk = (
-            (-0.5 / DISK_VELOCITY_SIGMA_U**2)
-            * (v_r - DISK_ROTATION_VELOCITY) ** 2
-            + (-0.5 / DISK_VELOCITY_SIGMA_V**2) * v_phi**2
+            (-0.5 / DISK_VELOCITY_SIGMA_U**2) * v_r**2
+            + (-0.5 / DISK_VELOCITY_SIGMA_V**2)
+            * (v_phi - DISK_ROTATION_VELOCITY) ** 2
             + (-0.5 / DISK_VELOCITY_SIGMA_W**2) * v_z**2
         )
         L_disk = log_dens_disk + log_vel_disk
@@ -226,10 +239,11 @@ class GalacticModel(Component):
             + (z / BULGE_DENSITY_Z_0) ** 2
         )
         log_dens_bulge = -0.5 * r_bulge_coord
+        # Bulge cylindrical rotation is azimuthal too (same fix as above).
         bulge_rot = BULGE_ROTATION_ANGULAR_VELOCITY * r
         log_vel_bulge = (
-            (-0.5 / BULGE_VELOCITY_SIGMA_1**2) * (v_r - bulge_rot) ** 2
-            + (-0.5 / BULGE_VELOCITY_SIGMA_2**2) * v_phi**2
+            (-0.5 / BULGE_VELOCITY_SIGMA_1**2) * v_r**2
+            + (-0.5 / BULGE_VELOCITY_SIGMA_2**2) * (v_phi - bulge_rot) ** 2
             + (-0.5 / BULGE_VELOCITY_SIGMA_3**2) * v_z**2
         )
         L_bulge = log_dens_bulge + log_vel_bulge

--- a/tests/test_galactic_model.py
+++ b/tests/test_galactic_model.py
@@ -129,3 +129,127 @@ def test_imf_salpeter_branch_does_not_crash():
     gm = _make_gm(config=[{"IMF": "Salpeter"}])
     with pm.Model():
         gm.build_likelihood(pm.modelcontext(None), _MockSystem())
+
+
+# ---------------------------------------------------------------------------
+# Kinematic prior physics: rotation must be azimuthal
+# ---------------------------------------------------------------------------
+
+
+def _pm_rv_for_velocity(ra_deg, dec_deg, d_kpc, v_gal):
+    """ICRS (pm_ra_cosdec [mas/yr], pm_dec [mas/yr], rv [m/s]) of a star at
+    the given position with the given astropy-Galactocentric velocity."""
+    import astropy.units as u
+    from astropy.coordinates import ICRS, Galactocentric, SkyCoord
+
+    sc = SkyCoord(
+        ra=ra_deg * u.deg, dec=dec_deg * u.deg, distance=d_kpc * u.kpc
+    )
+    gc = sc.transform_to(Galactocentric())
+    star = SkyCoord(
+        x=gc.x,
+        y=gc.y,
+        z=gc.z,
+        v_x=v_gal[0] * u.km / u.s,
+        v_y=v_gal[1] * u.km / u.s,
+        v_z=v_gal[2] * u.km / u.s,
+        frame=Galactocentric(),
+    ).transform_to(ICRS())
+    return (
+        float(star.pm_ra_cosdec.to_value(u.mas / u.yr)),
+        float(star.pm_dec.to_value(u.mas / u.yr)),
+        float(star.radial_velocity.to_value(u.m / u.s)),
+        (float(gc.x.to_value(u.kpc)), float(gc.y.to_value(u.kpc))),
+    )
+
+
+def _kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms):
+    """Evaluate the kinematic_prior Potential for a star with the given
+    observables (all other mock attributes at their defaults)."""
+    gm = _make_gm()
+    system = _MockSystem()
+    system.star.distance = _MockParam(d_pc)
+    system.star.pm_ra = _MockParam(pm_ra)
+    system.star.pm_dec = _MockParam(pm_dec)
+    system.star.rv = _MockParam(rv_ms)
+    with pm.Model() as model:
+        gm.build_likelihood(model, system)
+    return float(model["galacticmodel.kinematic_prior"].eval())
+
+
+def test_kinematic_prior_prefers_corotation_over_radial_plunge():
+    """
+    Given a disk-distance star toward the bulge whose space velocity is
+      (a) an EXACTLY circular co-rotating orbit,
+      (b) a radial plunge toward the Galactic center at the same speed,
+      (c) counter-rotation at the same speed,
+    When the kinematic prior evaluates each,
+    Then co-rotation wins by many nats -- Galactic rotation is azimuthal.
+
+    Before the 2026-08 fix the prior centered the rotation velocity on the
+    RADIAL component: (a) was penalized ~49 nats and (b) was the maximum,
+    which on examples/ob140939 handed the anti-rotation parallax solution
+    the posterior (0.98/0.02 against the Yee et al. 2015 proper-motion-
+    preferred solution).
+    """
+    from exozippy.constants import DISK_ROTATION_VELOCITY
+
+    # ARRANGE: the ob140939 field, lens-like distance
+    ra_deg, dec_deg, d_kpc = 266.8, -21.38, 2.5
+    v = DISK_ROTATION_VELOCITY
+    # astropy Galactocentric: Sun at x ~ -8 kpc, rotation at the Sun = +y.
+    # Co-rotation at (x, y): v = V * (y, -x)/r  (checks out at the Sun).
+    _, _, _, (x, y) = _pm_rv_for_velocity(ra_deg, dec_deg, d_kpc, (0, 0, 0))
+    r = np.hypot(x, y)
+    lps = {}
+    for tag, v_gal in [
+        ("corot", (v * y / r, -v * x / r, 0.0)),
+        ("radial", (-v * x / r, -v * y / r, 0.0)),  # plunge toward GC
+        ("counter", (-v * y / r, v * x / r, 0.0)),
+    ]:
+        pm_ra, pm_dec, rv, _ = _pm_rv_for_velocity(
+            ra_deg, dec_deg, d_kpc, v_gal
+        )
+        # ACT
+        lps[tag] = _kinematic_lp(d_kpc * 1e3, pm_ra, pm_dec, rv)
+
+    # ASSERT: margins allow for the logsumexp bulge branch, whose ~110 km/s
+    # dispersions partially absorb any velocity direction and floor the
+    # disk-term penalty (measured: corot beats radial by 7.9 nats and
+    # counter-rotation by 14.3; before the fix corot LOST to radial by 43).
+    assert lps["corot"] > lps["radial"] + 5.0
+    assert lps["corot"] > lps["counter"] + 10.0
+
+
+def test_kinematic_prior_corotating_star_pays_no_velocity_penalty():
+    """
+    Given the same star exactly on the circular orbit,
+    When compared against one with a 3-sigma azimuthal peculiar velocity,
+    Then the circular orbit scores higher -- i.e. it sits at the velocity
+      term's maximum, not merely above the alternatives.
+    """
+    from exozippy.constants import (
+        DISK_ROTATION_VELOCITY,
+        DISK_VELOCITY_SIGMA_V,
+    )
+
+    ra_deg, dec_deg, d_kpc = 266.8, -21.38, 2.5
+    _, _, _, (x, y) = _pm_rv_for_velocity(ra_deg, dec_deg, d_kpc, (0, 0, 0))
+    r = np.hypot(x, y)
+    phi_hat = (y / r, -x / r, 0.0)
+
+    def lp_at(speed):
+        v_gal = tuple(speed * c for c in phi_hat)
+        pm_ra, pm_dec, rv, _ = _pm_rv_for_velocity(
+            ra_deg, dec_deg, d_kpc, v_gal
+        )
+        return _kinematic_lp(d_kpc * 1e3, pm_ra, pm_dec, rv)
+
+    lp_circ = lp_at(DISK_ROTATION_VELOCITY)
+    lp_fast = lp_at(DISK_ROTATION_VELOCITY + 3.0 * DISK_VELOCITY_SIGMA_V)
+    lp_slow = lp_at(DISK_ROTATION_VELOCITY - 3.0 * DISK_VELOCITY_SIGMA_V)
+
+    # Margins again reflect bulge-branch flooring (measured: +1.4 and +2.5
+    # nats for +/-3 sigma; the disk term alone would give 4.5).
+    assert lp_circ > lp_fast + 1.0
+    assert lp_circ > lp_slow + 1.0

--- a/tests/test_runaway_logp_regression.py
+++ b/tests/test_runaway_logp_regression.py
@@ -160,7 +160,7 @@ def _point(raw_dict):
 # post free_symbols-sort hardening).  Differs from the historical stored lp
 # (~2982.18) because the model itself has changed since that trace; see the
 # module docstring.
-GOOD_EXPECTED_LP = -936.526
+GOOD_EXPECTED_LP = -942.995  # re-measured 2026-08: kinematic-prior rotation fix (v_phi centering) moved every lp
 
 
 def test_good_draw_logp_matches_deterministic_build(dc2018_128_logp):


### PR DESCRIPTION
## The bug

Galactic rotation is azimuthal. The disk kinematic term centered `DISK_ROTATION_VELOCITY` on **v_r** (radial) and zero-centered **v_phi** (azimuthal); the bulge term put `bulge_rot` on v_r the same way. Self-contained proof (no microlensing conventions involved): scoring a star on an **exactly circular co-rotating orbit** at 2.5 kpc toward the ob140939 field — the most probable disk star there is — the prior as coded assigned it **-48.8 nats** and was maximized by a star plunging radially at the rotation speed. The module's own `get_polar_velocity` decomposition is correct (v_phi is positive for co-rotation at every position, verified against astropy Galactocentric); only the term centers were swapped.

## How it was found

On `examples/ob140939` with the measured Yee et al. 2015 source proper motion as a prior, the swapped term gave the **anti-rotation** parallax solution (+130° E of N relative motion — the direction Yee excludes) +5.0 nats over the co-rotating one (52.7° — dead on her 53.9° ± 8.5° disk-rotation prediction), flipping the mode weights to 0.98/0.02 against the paper's proper-motion-preferred solution.

## Provenance

Traced on request: **genulens is correct** (`nkoshimoto/genulens`, `kinematics_runtime.cpp`: `vR = 0 + gaussian()*sigU; vphi = aveV + gaussian()*sigV`) — no upstream issue to file. The swap first appears in `rp.py` (PR #11), in both the disk and bulge weight functions, and the component integration transcribed those expressions faithfully (while fixing a separate rp.py bug — a spurious `SUN_GC_DISTANCE` term in `_get_galactic_xyz`'s y). Anything else built on rp.py's weight functions inherits the swap.

## The fix

`v_r²/σ_U² + (v_phi − V_rot)²/σ_V²` for the disk (dispersions keep their standard pairing: σ_U radial, σ_V azimuthal), and `(v_phi − bulge_rot)` for the bulge's cylindrical rotation.

## Tests

Two physics pins in `tests/test_galactic_model.py`, evaluated through the real Potential with astropy-constructed observables: (1) an exactly co-rotating star beats a radial plunge by >5 nats and counter-rotation by >10 (pre-fix it lost to the plunge by 43 — the test fails on the old code); (2) the circular orbit sits at the velocity-term maximum (±3σ azimuthal offsets score lower). Margins account for the logsumexp bulge branch flooring the disk penalty (measured values in comments). `GOOD_EXPECTED_LP` in the runaway-logp regression re-measured (-936.526 → -942.995): the prior legitimately moved every model's lp.

Full suite: **986 passed, 0 failed**. An ob140939 A/B rerun with the corrected prior (same sampler config) is in progress; results will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)