### PR TITLE
Ledger matching: dual criterion (conditional OR marginal scale)

### DIFF
--- a/src/exozippy/outputs/ledger.py
+++ b/src/exozippy/outputs/ledger.py
@@ -47,6 +47,11 @@ logger = logging.getLogger(__name__)
 # false rejections.
 MATCH_SIGMA = 10.0
 
+# Marginal-scale matching threshold (criterion (b) in match_ledger_to_modes):
+# a mode's own median lies within ~2 of its marginal sigmas by construction,
+# and the density-dip merge keeps distinct modes much farther apart.
+_MATCH_MARGINAL_SIGMA = 3.0
+
 
 @dataclass
 class SeedRecord:
@@ -182,17 +187,38 @@ def match_ledger_to_modes(ledger, mode_report, match_sigma=MATCH_SIGMA):
             for j, nm in enumerate(_flat_names(key, flat_v.size)):
                 elems[nm] = (flat_v[j], max(flat_s[j], 1e-300))
         for m in mode_report.modes:
-            ds = [
-                abs(elems[nm][0] - c) / elems[nm][1]
-                for nm, c in m.center.items()
-                if nm in elems
-            ]
-            if not ds:
+            # Two complementary criteria, either suffices:
+            # (a) within `match_sigma` of the mode center in the seed's own
+            #     CONDITIONAL (curvature) widths -- catches a center right
+            #     at the polished peak;
+            # (b) within _MATCH_MARGINAL_SIGMA of the center in the mode's
+            #     per-dim MARGINAL scale (ModeInfo.center_scale) -- the mode
+            #     center is a posterior MEDIAN, which on correlated
+            #     posteriors sits tens of conditional sigmas from the basin
+            #     peak, so (a) alone falsely rejects surviving basins
+            #     (observed on ob140939: all four seeds rejected, two of
+            #     them sitting inside the two surviving modes). A mode
+            #     always holds its own median within ~2 marginal sigmas,
+            #     while the density-dip merge guarantees OTHER basins sit
+            #     much farther, so 3 is not delicate.
+            scales = getattr(m, "center_scale", {}) or {}
+            ds_cond, ds_marg = [], []
+            for nm, c in m.center.items():
+                if nm not in elems:
+                    continue
+                delta = abs(elems[nm][0] - c)
+                ds_cond.append(delta / elems[nm][1])
+                ds_marg.append(delta / max(scales.get(nm, 0.0), 1e-300))
+            if not ds_cond:
                 continue
-            d = max(ds)
+            # effective distance: fraction of whichever threshold is closer
+            d = min(
+                max(ds_cond) / match_sigma,
+                max(ds_marg) / _MATCH_MARGINAL_SIGMA,
+            )
             if d < best_d:
                 best_mode, best_d = m.index, d
-        if best_mode is not None and best_d <= match_sigma:
+        if best_mode is not None and best_d <= 1.0:
             rec.matched_mode = best_mode
             rec.match_distance = best_d
         else:
@@ -223,7 +249,7 @@ def ledger_to_text(ledger):
         lines.append("")
         status = (
             f"survived as mode {r.matched_mode + 1} "
-            f"(match distance {r.match_distance:.1f} sigma)"
+            f"(match distance {r.match_distance:.2f} of threshold)"
             if r.matched_mode is not None
             else "REJECTED: no surviving posterior mode at this solution"
         )

--- a/src/exozippy/outputs/modes.py
+++ b/src/exozippy/outputs/modes.py
@@ -140,6 +140,14 @@ class ModeInfo:
     center: dict = field(
         default_factory=dict
     )  # feature var -> center (raw units)
+    center_scale: dict = field(
+        default_factory=dict
+    )  # feature var -> robust per-dim MARGINAL scale of the mode's own
+    # draws (raw units). The seed ledger's matching normalizes by this:
+    # a seed's curvature widths are CONDITIONAL scales, and on correlated
+    # posteriors the marginal median sits tens of conditional sigmas from
+    # the basin peak, so normalizing by the seed widths alone falsely
+    # rejects seeds whose basins plainly survived.
     # Optional evidence-weighting fields (populated by
     # outputs.evidence.apply_evidence_weighting when modes: {weights: evidence}
     # is requested and every mode's bridge estimate is trustworthy).  weight is
@@ -627,9 +635,15 @@ def identify_modes(
             [(row == m).sum() / max((row >= 0).sum(), 1) for row in labels_2d]
         )
         center_raw = {}
+        center_scale_raw = {}
         sel_v = labels_valid == order[m]
         for jn, name in enumerate(dim_names):
-            center_raw[name] = float(np.median(Xv[sel_v, jn]))
+            col = Xv[sel_v, jn]
+            center_raw[name] = float(np.median(col))
+            # 1.4826 * MAD: robust marginal sigma of this mode along jn
+            center_scale_raw[name] = float(
+                1.4826 * np.median(np.abs(col - np.median(col)))
+            )
         modes.append(
             ModeInfo(
                 index=m,
@@ -642,6 +656,7 @@ def identify_modes(
                 ),
                 per_chain_weight=per_chain,
                 center=center_raw,
+                center_scale=center_scale_raw,
             )
         )
 

--- a/tests/test_mode_ledger.py
+++ b/tests/test_mode_ledger.py
@@ -117,9 +117,9 @@ def test_matching_assigns_survivor_and_rejects_the_missing_mode():
 
     # ASSERT
     assert ledger[0].matched_mode == 0
-    assert ledger[0].match_distance < 1.0
+    assert ledger[0].match_distance < 1.0  # fraction of threshold
     assert ledger[1].matched_mode is None
-    assert ledger[1].match_distance > 10.0
+    assert ledger[1].match_distance > 1.0  # beyond every criterion
     assert rejected_records(ledger) == [ledger[1]]
 
 
@@ -186,3 +186,44 @@ def test_no_rejected_seeds_writes_nothing(tmp_path):
     # ASSERT
     assert csv_path.read_text() == "header\n"
     assert not wrote
+
+
+def test_matching_uses_the_modes_marginal_scale():
+    """
+    Given a mode whose center (a posterior MEDIAN) sits ~20 of the seed's
+      conditional widths from the basin peak but within the mode's own
+      marginal spread,
+    When the ledger is matched,
+    Then the seed still matches (no false rejection) -- while a seed
+      genuinely far away in BOTH scales stays rejected.
+
+    Regression: on ob140939 all four seeds were falsely rejected because
+    correlated posteriors put marginal medians tens of conditional sigmas
+    from the polished peaks.
+    """
+    # ARRANGE
+    model, p = _two_basin_model()
+    raw0 = np.asarray(p.raw_from_initval(np.array([2.0])), dtype=float)
+    raw7 = np.asarray(p.raw_from_initval(np.array([7.0])), dtype=float)
+    ledger = build_seed_ledger(
+        _StubSystem([p]),
+        model,
+        [{"toy.x_raw": raw0}, {"toy.x_raw": raw7}],
+        [0, 1],
+    )
+    sep = abs(float(raw7[0]) - float(raw0[0]))
+    # mode center displaced sep/6 from the peak (tens of the seed's tiny
+    # conditional widths) with a marginal scale sep/12 -- the median sits
+    # 2 marginal sigmas from the peak, and the other basin 10 away
+    center = (
+        float(raw0[0]) + np.sign(float(raw7[0]) - float(raw0[0])) * sep / 6.0
+    )
+    report = _fake_report([center], "toy.x_raw")
+    report.modes[0].center_scale = {"toy.x_raw": sep / 12.0}
+
+    # ACT
+    match_ledger_to_modes(ledger, report)
+
+    # ASSERT
+    assert ledger[0].matched_mode == 0  # matched despite 20 seed-widths
+    assert ledger[1].matched_mode is None  # other basin: still rejected


### PR DESCRIPTION
## Bug (found on the ledger's first production run)

The four-seed ob140939 fit falsely rejected **all four** seeds — including the two sitting inside the two surviving posterior modes. Matching normalized seed-to-mode-center distance by the seed's CONDITIONAL (curvature) widths, but `ModeInfo.center` is a posterior MEDIAN, and on correlated posteriors the marginal median sits tens of conditional sigmas from the basin peak (the same conditional-vs-marginal factor measured at ~10–25x on this model during the whitening work).

## Fix

- `identify_modes` records `ModeInfo.center_scale`: per-dim robust marginal scale (1.4826·MAD) of each mode's own draws.
- `match_ledger_to_modes` matches when EITHER criterion holds: within MATCH_SIGMA (10) in the seed's conditional widths, OR within 3 in the mode's marginal scale — a mode holds its own median within ~2 marginal sigmas by construction, while the density-dip merge keeps distinct modes much farther apart. `match_distance` becomes a fraction of the nearer threshold (≤ 1 matches).

## Validation against the exposing run

Replaying the fixed-galactic-prior / no-pm-prior ob140939 trace: seeds u0,-,+ and u0,-,- now match the two surviving modes at 0.51/0.40 of threshold; **u0,+,+ and u0,+,- stay REJECTED** at 4.97/3.37 with Δlp = 8.7/14.6 — the ledger's intended output for exactly Yee's Table 1. Regression test with realistic geometry added; full suite **993 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)