### PR TITLE
ob140939: densify the tempering ladder to n_temps 24 (validated)

### DIFF
--- a/examples/ob140939/ob140939.yaml
+++ b/examples/ob140939/ob140939.yaml
@@ -58,11 +58,16 @@ sampler:
   # between the four degenerate basins.
   tune: 0
   draws: 50000
-  # Size the tempering ladder from the measured communication barrier
-  # (the fixed default of 8 was communication-limited here: Lambda ~ 6.4
-  # wants ~14 rungs; without them the occupancy mode weights lose their
-  # validation).
-  n_temps: auto
+  # Densified tempering ladder, validated empirically: auto (17 rungs)
+  # left adjacent-swap acceptance at 5-7% and 3 round trips -- the
+  # ladder froze below T ~ 75 and the mode weights were initialization
+  # artifacts. At 24 rungs (measured Lambda = 9.4; use > 2*Lambda+1
+  # with margin) swap acceptance is 50-65%, round trips flow, and the
+  # per-rung basin-occupancy profile is smooth equilibrium from T=200
+  # (50/50) to T=1 (~98/2) -- the mode weights become a real posterior
+  # statement (u0,-,- ~ 98%, agreeing with the ledger's Laplace
+  # estimate and Yee+2015's proper-motion argument).
+  n_temps: 24
   # Keep thinned hot-rung draws: they detect posterior-suppressed modes
   # (occupancy ~exp(-dlp/T)) for the seeded-solution ledger, so solutions
   # nobody seeded still show up as "considered and rejected".


### PR DESCRIPTION
Closes the mode-weight loop on the example. `n_temps: auto` (17 rungs) left adjacent-swap acceptance at 5–7% with 3 round trips: the ladder froze below T ≈ 75 (measured per-rung basin occupancy from the stored hot draws — `store_hot_chains` paying off) and the T=1 mode weights were initialization artifacts.

At **24 rungs** (measured Λ = 9.4; sized > 2Λ+1 with margin): swap acceptance 50–65%, 42 round trips, ESS/Rhat convergence at 45k draws, and the per-rung basin-occupancy profile is a smooth equilibrium from T=200 (0.500) to the cold rungs (0.98) — no frozen plateau.

**Result**: u0,-,- carries ~98% of the posterior — three independent methods agree (equilibrated occupancy 0.983, the ledger's fixed-polish Laplace 0.993, and Yee+2015's proper-motion argument). The depth-vs-volume kicker: the u0,-,+ peak is the *global maximum* (1878.79, 0.6 nats above the winner) yet carries ~1% weight — the pinned source pm + corrected kinematics suppress it through basin **volume**. The ledger reports exactly this: 'REJECTED, Δlp = 0.0' for the highest peak in the problem.

All previously quoted '~2:1' weights came from broken-transport runs compounded by the polish ftol bug (#67); full narrative in notes/ob140939_lessons.txt (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)