### PR TITLE
Mulens Op path: model annual parallax (one Skowron obs_pos convention)

### DIFF
--- a/scripts/repro_vbm_timeout.py
+++ b/scripts/repro_vbm_timeout.py
@@ -120,15 +120,15 @@ def build_pvec_fn(config):
         labels,
         coords,
         inst.time,
-        inst.observer_pos_abs,
+        inst.observer_pos,
         bandpass,
     )
 
 
-def trajectory(op, p, labels, times, obs_pos_abs):
+def trajectory(op, p, labels, times, obs_pos):
     """Numpy trajectory (x, y) plus (s, q, rho, u1) for a binary-lens event."""
     vals = dict(zip(labels, p))
-    dN, dE = op._deltas(times, obs_pos_abs)
+    dN, dE = op._deltas(obs_pos)
     t0, u0, tE = vals["t_0"], vals["u_0"], vals["t_E"]
     piN, piE = vals["pi_E_N"], vals["pi_E_E"]
     u0 = np.sign(u0) * max(abs(u0), 1e-9) if u0 != 0 else 1e-9
@@ -185,7 +185,7 @@ def main():
         use_rho=("rho" in labels),
         bandpass=bandpass,
     )
-    op._deltas(times, obs)  # warm the parallax-offset cache
+    op._deltas(obs)  # warm the parallax-offset cache
 
     for i, ev in enumerate(events):
         raw = ev["raw_params"]

--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -806,36 +806,20 @@ class Lens(Component):
             "alpha": alpha_deg,
         }
 
-    def get_magnification(self, times, obs_pos_abs, system, index=0):
+    def get_magnification(self, times, obs_pos, system, index=0):
         """Symbolic Paczynski magnification including parallax (PSPL only).
 
         ``index`` is the SOURCE slot (one trajectory per source body).
 
-        obs_pos_abs : (N, 3) absolute barycentric positions in AU — the same
-        convention as MulensModel's satellite_skycoord, so this function and
-        the MulensModel Op are interchangeable callers.
-
-        Internally converts to Skowron+2011 geocentric deviations using the
-        reference constants stored on the MulensInstrument.  When no
-        instrument is present (e.g. unit tests with zero positions) the
-        positions are treated as already-centered deviations (no parallax).
+        obs_pos : (N, 3) Skowron+2011 geocentric deviations in AU --
+        the observer's offset from the linear Earth trajectory anchored at
+        t0_par (MulensInstrument._abs_to_delta).  The MulensModel Op path
+        consumes the exact same array (fed as satellite_skycoord), so the
+        two paths are interchangeable.  Zero rows mean no parallax.
         """
         source_ndx = self.source_map[index]
         ra = system.star.ra.value[source_ndx]
         dec = system.star.dec.value[source_ndx]
-
-        instr = getattr(system, "mulensinstrument", None)
-        if instr is not None:
-            # Convert absolute barycentric → Skowron+2011 geocentric deviations:
-            #   delta(t) = xyz_obs(t) - [xyz_earth(t0_par) + v_earth(t0_par)*(t - t0_par)]
-            t_delta = times - instr._t0_par  # (N,)
-            ref = (
-                instr._earth_pos_ref[None, :]  # (1, 3) constant
-                + instr._earth_vel_ref[None, :] * t_delta[:, None]
-            )  # (N, 3)
-            obs_pos = obs_pos_abs - ref
-        else:
-            obs_pos = obs_pos_abs
 
         x, y, z = obs_pos[:, 0], obs_pos[:, 1], obs_pos[:, 2]
         delta_e = -x * pt.sin(ra) + y * pt.cos(ra)
@@ -866,9 +850,8 @@ class Lens(Component):
         Event-level property (the lens bodies and finite_source flag are shared
         by all sources), so ``index`` is ignored beyond backward compatibility.
 
-        Callers use this to decide which obs_pos convention to pass:
-        - True  → absolute barycentric AU (MulensModel satellite_skycoord)
-        - False → Skowron+2011 geocentric deviations (symbolic get_magnification)
+        Both paths take the same obs_pos convention (Skowron+2011 geocentric
+        deviations); callers use this only to pick a sampler-compatible path.
         """
         n_lenses = self.n_lens_bodies[0]
         use_rho = self.finite_source[0]
@@ -912,11 +895,11 @@ class Lens(Component):
         through it without the O(N_params) numerical-gradient overhead of
         _MagGradOp.
 
-        obs_pos convention is caller's responsibility and must match:
-        - Symbolic path: Skowron+2011 geocentric deviations (AU)
-        - Op path:       absolute barycentric positions (AU); the Op
-          converts them to geocentric (satellite - earth_actual) before
-          passing to MulensModel, which expects geocentric input.
+        obs_pos: (N, 3) Skowron+2011 geocentric deviations in AU
+        (MulensInstrument._abs_to_delta) for BOTH paths -- the symbolic
+        formula projects them directly, and the Op path feeds them to
+        MulensModel as satellite_skycoord (whose satellite channel then
+        carries all parallax, annual + satellite).
 
         u1/bandpass: when finite_source is True and a Band component is wired,
         u1 (a PyTensor scalar) and bandpass (str) are passed so the Op can call

--- a/src/exozippy/components/mulensing/mulensinstrument.py
+++ b/src/exozippy/components/mulensing/mulensinstrument.py
@@ -166,7 +166,6 @@ class MulensInstrument(Instrument):
         self.q_flux_init = []  # per-instrument f_s2/f_s1 (binary source)
         self._raw_time_list = []
         all_obspos = []
-        all_obspos_abs = []
 
         self._n_sources = int(system.lens.n_sources)
 
@@ -179,26 +178,10 @@ class MulensInstrument(Instrument):
         ra_rad = ra_deg * np.pi / 180.0
         dec_rad = dec_deg * np.pi / 180.0
 
-        # Geocentric reference (Skowron+2011 convention): Earth's position and
-        # velocity at t_0_par define the inertial frame.  All observer positions
-        # are stored as deviations from this linear Earth trajectory so that
-        # t_0/u_0 remain geocentric parameters.
-        self._t0_par = float(system.lens.t0_par[0])
-        self._earth_pos_ref = self.get_observer_position(
-            np.array([self._t0_par]), "earth"
-        )[0]  # (3,) AU
-        _dt = 0.5  # days for finite-difference velocity
-        _ep = self.get_observer_position(
-            np.array([self._t0_par + _dt]), "earth"
-        )[0]
-        _em = self.get_observer_position(
-            np.array([self._t0_par - _dt]), "earth"
-        )[0]
-        self._earth_vel_ref = (_ep - _em) / (2.0 * _dt)  # AU/day
-
-        # Median absolute position per instrument (used by Lens to detect parallax)
-        self.inst_ref_pos = []
-
+        # Pass 1: read every file.  The raw times must exist before the
+        # Skowron reference frame is anchored below (t0_par can fall back to
+        # the median data time).
+        per_file = []
         for i in range(self.n_elements):
             fmt = self.config[i].get("data_format", "magnitude")
             # Shared reader: columns:, mask:, time_* conversion, then sort
@@ -215,20 +198,51 @@ class MulensInstrument(Instrument):
                 df.iloc[:, 2].values,
             )
 
-            if self.config[i].get("data_format", "magnitude") == "flux":
+            if fmt == "flux":
                 # Convert normalized flux to instrumental magnitudes.
                 # mag = -2.5*log10(flux);  err = (2.5/ln10) * flux_err/flux
                 safe_f = np.maximum(m, 1e-30)
                 e = (2.5 / np.log(10)) * np.maximum(e, 0.0) / safe_f
                 m = -2.5 * np.log10(safe_f)
 
+            per_file.append((t, m, e, df))
+
+        # Geocentric reference (Skowron+2011 convention): Earth's position and
+        # velocity at t_0_par define the inertial frame.  All observer positions
+        # are stored as deviations from this linear Earth trajectory so that
+        # t_0/u_0 remain geocentric parameters.  Re-resolved here rather than
+        # taken from Lens.__init__: MMEXOFAST seeds arrive in stage 1a (via
+        # _resolve_mmexofast above), after the Lens snapshotted user_params,
+        # and a reference epoch far from the data makes the linear Earth
+        # extrapolation diverge (O(100) AU after ~20 yr), shearing tau/u by
+        # O(deviation x pi_E).
+        self._t0_par = self._resolve_t0_par_final(
+            system, np.concatenate([f[0] for f in per_file])
+        )
+        system.lens.t0_par[0] = self._t0_par
+        self._earth_pos_ref = self.get_observer_position(
+            np.array([self._t0_par]), "earth"
+        )[0]  # (3,) AU
+        _dt = 0.5  # days for finite-difference velocity
+        _ep = self.get_observer_position(
+            np.array([self._t0_par + _dt]), "earth"
+        )[0]
+        _em = self.get_observer_position(
+            np.array([self._t0_par - _dt]), "earth"
+        )[0]
+        self._earth_vel_ref = (_ep - _em) / (2.0 * _dt)  # AU/day
+
+        # Median absolute position per instrument (used by Lens to detect parallax)
+        self.inst_ref_pos = []
+
+        # Pass 2: observer positions, flux bootstraps, and sanity checks.
+        for i, (t, m, e, df) in enumerate(per_file):
             obs_loc = self.config[i].get("observer_location", "earth")
             xyz_abs = self.get_observer_position(t, observer_location=obs_loc)
             self.inst_ref_pos.append(np.median(xyz_abs, axis=0))
 
             xyz_delta = self._abs_to_delta(t, xyz_abs)
             all_obspos.append(xyz_delta)
-            all_obspos_abs.append(xyz_abs)
 
             f_total, q_source, q_flux = self._estimate_flux_components(
                 t, m, xyz_delta, ra_rad, dec_rad, i
@@ -274,10 +288,7 @@ class MulensInstrument(Instrument):
         self.inst_map = np.concatenate(inst_indices).astype(int)
         self.observer_pos = np.vstack(all_obspos).astype(
             float
-        )  # geocentric deviations
-        self.observer_pos_abs = np.vstack(all_obspos_abs).astype(
-            float
-        )  # absolute barycentric (for get_magnification_op)
+        )  # Skowron geocentric deviations (both magnification paths)
         self.n_total_obs = len(self.time)
 
         # Block Diagonal Matrix (shared builder keeps coeffs per-instrument)
@@ -291,6 +302,37 @@ class MulensInstrument(Instrument):
         # Errors are already in the amplitude parameter's unit (mag).
         self._prepare_gp(self.time, self.err, self.inst_map)
         self._prepare_robust(self.err, self.inst_map)
+
+    def _resolve_t0_par_final(self, system, all_times):
+        """Final t0_par: the reference epoch anchoring the Skowron+2011 frame.
+
+        Lens.__init__ resolves t0_par from the lens config and user_params
+        only; MMEXOFAST seeds arrive later (stage 1a, add_seed_hints), so
+        the automated workflow -- whose params file deliberately omits the
+        microlensing start values -- used to fall through to the 2450000.0
+        default, parking the reference epoch decades before the data.
+
+        Priority: explicit lens ``t0_par`` > user ``lens.0.t_0`` initval >
+        MMEXOFAST seed t_0 > median data time.  Any of these keeps the
+        linear Earth extrapolation within the season it is a good
+        approximation for.
+        """
+        lens_config = system.lens.config[0]
+        if "t0_par" in lens_config:
+            return float(lens_config["t0_par"])
+        cm = self.config_manager
+        val = _raw_initval(cm.user_params.get("lens.0.t_0"))
+        if val is None:
+            val = cm.seed_start_value("lens.0.t_0")
+        if val is not None:
+            return float(val)
+        t_med = float(np.median(all_times))
+        logger.info(
+            f"[{self.prefix}] No t0_par, lens t_0, or MMEXOFAST seed found; "
+            f"anchoring the parallax reference epoch at the median data "
+            f"time ({t_med:.2f})."
+        )
+        return t_med
 
     def _reject_time_spec_with_mmexofast(self, spec):
         """Refuse to mix MMEXOFAST seeding with a per-file time system.
@@ -884,9 +926,10 @@ class MulensInstrument(Instrument):
         obs_mag = pm.Data("mu_obs_mag", self.mag)
         obs_err = pm.Data("mu_obs_err", self.err)
 
-        # 2. Magnification — both symbolic and Op paths take absolute barycentric AU.
-        #    get_magnification_op dispatches: PSPL→symbolic (NUTS-friendly),
-        #    binary/finite-source→MulensModel Op (use Metropolis).
+        # 2. Magnification — both symbolic and Op paths take Skowron+2011
+        #    geocentric deviations (AU).  get_magnification_op dispatches:
+        #    PSPL→symbolic (NUTS-friendly), binary/finite-source→MulensModel
+        #    Op (use Metropolis).
         #
         #    When finite source is active, pass u1 and bandpass from the connected
         #    Band component.  Multiple distinct bands across instruments are not yet
@@ -920,7 +963,7 @@ class MulensInstrument(Instrument):
             A_per_source.append(
                 system.lens.get_magnification_op(
                     t,
-                    self.observer_pos_abs,
+                    self.observer_pos,
                     system,
                     index=j,
                     u1=u1,
@@ -1288,13 +1331,13 @@ class MulensInstrument(Instrument):
 
         t_model, t0, tE = self._model_time_grid()
         unique_observers, obs_to_inst, inst_obs_loc = self._observer_groups()
-        # Absolute barycentric positions for each unique observer over the
-        # model grid. Both the symbolic PSPL path and the MulensModel Op
-        # expect absolute barycentric AU; get_magnification converts
-        # internally to geocentric deviations as needed.
+        # Skowron geocentric deviations for each unique observer over the
+        # model grid -- the single obs_pos convention both the symbolic PSPL
+        # path and the MulensModel/VBM Ops consume.
         obs_model_pos = {
-            obs_loc: self.get_observer_position(
-                t_model, observer_location=obs_loc
+            obs_loc: self._abs_to_delta(
+                t_model,
+                self.get_observer_position(t_model, observer_location=obs_loc),
             )
             for obs_loc in unique_observers
         }

--- a/src/exozippy/components/mulensing/op.py
+++ b/src/exozippy/components/mulensing/op.py
@@ -3,51 +3,44 @@ import MulensModel as mm
 import numpy as np
 import pytensor.tensor as pt
 import VBMicrolensing
-from astropy.coordinates import (
-    SkyCoord,
-    get_body_barycentric,
-    solar_system_ephemeris,
-)
-from astropy.time import Time
+from astropy.coordinates import SkyCoord
 from pytensor.gradient import DisconnectedType
 from pytensor.graph import Apply, Op
 
-# Cache Earth positions keyed on sorted unique times (immutable between MCMC steps).
-_earth_pos_cache = {}
 
+def _clear_mm_satellite_cache():
+    """Drop MulensModel's class-level satellite-delta cache before each call.
 
-def _earth_xyz_at(times_np):
-    """Return (N,3) AU array of Earth barycentric positions, cached by times."""
-    times_np = np.asarray(times_np)
-    key = hash(times_np.tobytes())
-    if key not in _earth_pos_cache:
-        # Set lazily, not at import: the first set downloads the ~115 MB
-        # de430 kernel, and doing that at import time made `import exozippy`
-        # itself require network (and fail suite-wide when JPL was slow).
-        # Same pattern as ephemeris.get_observer_position.
-        solar_system_ephemeris.set("jpl")
-        t = Time(times_np, format="jd", scale="tdb")
-        _earth_pos_cache[key] = (
-            get_body_barycentric("earth", t).xyz.to("au").value.T
-        )
-    return _earth_pos_cache[key]
-
-
-def _get_sat_coord(obs_pos_abs_np, times_np, cache):
-    """Build and cache a geocentric SkyCoord from absolute observer positions.
-
-    MulensModel's _get_delta_satellite computes -dot(satellite_skycoord, north),
-    so satellite_skycoord must be GEOCENTRIC (obs_abs - earth_actual), not absolute.
+    Trajectory._get_delta_satellite_results is keyed on (ra, dec, times)
+    ONLY -- it ignores the satellite positions themselves -- so two
+    evaluations sharing a time grid but carrying different observer
+    deviations (e.g. ground and satellite model curves on one plot grid)
+    would silently reuse the first observer's parallax deltas.  Clearing is
+    cheap next to the mm.Model rebuild this path already pays per call; the
+    speed-critical binary path (VBMDirectMagOp) has its own correctly-keyed
+    cache and never enters MulensModel.
     """
-    obs_pos_2d = np.atleast_2d(obs_pos_abs_np)
+    mm.Trajectory._get_delta_satellite_results.clear()
+
+
+def _dev_skycoord(obs_pos_np, cache):
+    """Build and cache a SkyCoord from Skowron+2011 geocentric deviations.
+
+    ``obs_pos_np`` are the observer's deviations from the linear Earth
+    trajectory anchored at t0_par (MulensInstrument._abs_to_delta) -- the
+    same array the symbolic path consumes.  Fed to MulensModel as
+    satellite_skycoord with parallax(satellite=True, earth_orbital=False):
+    _get_delta_satellite computes -dot(satellite_skycoord, north/east),
+    which on these deviations carries ALL parallax (annual + satellite),
+    exactly matching Lens.get_magnification.
+    """
+    obs_pos_2d = np.atleast_2d(obs_pos_np)
     key = (obs_pos_2d.shape, hash(obs_pos_2d.tobytes()))
     if key not in cache:
-        earth_xyz = _earth_xyz_at(times_np)
-        geocentric = obs_pos_2d - earth_xyz
         cache[key] = SkyCoord(
-            x=geocentric[:, 0] * u.au,
-            y=geocentric[:, 1] * u.au,
-            z=geocentric[:, 2] * u.au,
+            x=obs_pos_2d[:, 0] * u.au,
+            y=obs_pos_2d[:, 1] * u.au,
+            z=obs_pos_2d[:, 2] * u.au,
             representation_type="cartesian",
         )
     return cache[key]
@@ -80,10 +73,11 @@ def _build_pspl_model(p, coords, mag_method, use_rho=False):
         mm_params["rho"] = _safe_rho(p[5])
 
     model = mm.Model(parameters=mm_params, coords=coords)
-    # We supply geocentric satellite_skycoord, so satellite=True covers all
-    # parallax.  Annual Earth parallax (earth_orbital) needs t_0_par which is
-    # not in the Op param vector and would fail; its contribution is also
-    # already embedded in the geocentric conversion (satellite - earth_actual).
+    # The satellite channel is fed the Skowron+2011 geocentric deviations
+    # (see _dev_skycoord), which already contain the annual Earth term, so
+    # satellite=True covers ALL parallax.  earth_orbital stays False: it
+    # would double-count the annual term (and needs t_0_par, which is not
+    # in the Op param vector).
     model.parallax(earth_orbital=False, satellite=True, topocentric=False)
 
     if isinstance(mag_method, list):
@@ -121,6 +115,8 @@ def _build_binary_model(p, coords, mag_method, use_rho=False):
     mm_params["alpha"] = float(p[idx + 2])
 
     model = mm.Model(parameters=mm_params, coords=coords)
+    # Same convention as _build_pspl_model: the satellite channel carries
+    # all parallax via the Skowron geocentric deviations.
     model.parallax(earth_orbital=False, satellite=True, topocentric=False)
 
     if isinstance(mag_method, list):
@@ -171,7 +167,8 @@ class _MagOpBase(Op):
             model = self._builder(
                 p, self.coords, self.mag_method, self.use_rho
             )
-            sat_coord = _get_sat_coord(obs_pos_np, times_np, self._coord_cache)
+            sat_coord = _dev_skycoord(obs_pos_np, self._coord_cache)
+            _clear_mm_satellite_cache()
             with np.errstate(invalid="ignore", divide="ignore"):
                 if self.bandpass is not None:
                     model.set_limb_coeff_u(self.bandpass, float(p[-1]))
@@ -254,9 +251,10 @@ class VBMDirectMagOp(Op):
 
     Parallax convention mirrors the MulensModel Ops exactly (validated by
     tests/test_vbm_direct_vs_mulensmodel.py): observer positions arrive as
-    absolute barycentric AU, are converted to geocentric (obs - earth_actual),
-    projected on sky-plane north/east with a minus sign
-    (MulensModel Trajectory._get_delta_satellite), and applied as
+    Skowron+2011 geocentric deviations in AU (MulensInstrument._abs_to_delta,
+    the same array the symbolic path consumes), are projected on sky-plane
+    north/east with a minus sign (MulensModel
+    Trajectory._get_delta_satellite), and applied as
     delta_tau = +dN*pi_E_N + dE*pi_E_E, delta_beta = -dN*pi_E_E + dE*pi_E_N
     (Trajectory._project_delta).
 
@@ -347,18 +345,18 @@ class VBMDirectMagOp(Op):
     def infer_shape(self, node, input_shapes):
         return [input_shapes[1]]
 
-    def _deltas(self, times_np, obs_pos_np):
-        """Cached parallax offsets (delta_N, delta_E) for a (times, obs) pair.
+    def _deltas(self, obs_pos_np):
+        """Cached parallax offsets (delta_N, delta_E) for a deviation array.
 
+        ``obs_pos_np`` are Skowron+2011 geocentric deviations (AU).
         Independent of the sampled parameters: depend only on epochs, event
         coordinates, and the observer ephemeris, so they are computed once and
         reused for every proposal.
         """
-        obs = np.atleast_2d(obs_pos_np)
-        key = (hash(times_np.tobytes()), obs.shape, hash(obs.tobytes()))
+        dev = np.atleast_2d(obs_pos_np)
+        key = (dev.shape, hash(dev.tobytes()))
         if key not in self._delta_cache:
-            geo = obs - _earth_xyz_at(times_np)
-            self._delta_cache[key] = (-geo @ self._north, -geo @ self._east)
+            self._delta_cache[key] = (-dev @ self._north, -dev @ self._east)
         return self._delta_cache[key]
 
     def _magnify(self, companions, x, y, rho, u1):
@@ -460,7 +458,7 @@ class VBMDirectMagOp(Op):
         if not np.all(np.isfinite(p)):
             return np.full(len(times_np), np.nan)
 
-        dN, dE = self._deltas(times_np, obs_pos_np)
+        dN, dE = self._deltas(obs_pos_np)
         tau = (
             (times_np - base["t_0"]) / base["t_E"]
             + dN * base["pi_E_N"]
@@ -550,7 +548,10 @@ class _MagGradOp(Op):
         params, times_np, obs_pos_np, g = inputs
         out = np.zeros(params.shape, dtype=params.dtype)
         times_1d = np.atleast_1d(times_np)
-        sat_coord = _get_sat_coord(obs_pos_np, times_1d, self._coord_cache)
+        sat_coord = _dev_skycoord(obs_pos_np, self._coord_cache)
+        # One clear covers the whole finite-difference loop: every _calc
+        # below shares this sat_coord and time grid.
+        _clear_mm_satellite_cache()
         f_x = self._calc(params, times_1d, sat_coord)
         for i in range(len(params)):
             p_plus = params.copy()

--- a/tests/test_mulens_review_fixes.py
+++ b/tests/test_mulens_review_fixes.py
@@ -14,42 +14,36 @@ from exozippy.components.mulensing.mulensinstrument import MulensInstrument
 from exozippy.components.mulensing.op import (
     _build_binary_model,
     _build_pspl_model,
-    _get_sat_coord,
+    _dev_skycoord,
 )
 from exozippy.run import KNOWN_SAMPLER_KEYS
 
 COORDS = "270.0d -28.0d"
 
 
-def test_sat_coord_cache_distinguishes_same_length_arrays():
+def test_dev_skycoord_cache_distinguishes_same_length_arrays():
     """
-    Given two observer-position arrays with the same number of epochs but
-      different positions (e.g. Earth and a satellite over one model grid),
+    Given two observer-deviation arrays with the same number of epochs but
+      different positions (e.g. ground and a satellite over one model grid),
     When both are passed through the same coordinate cache,
     Then each gets its own SkyCoord (the old length-keyed cache silently
       returned the first observer's coordinates for the second).
     """
     # Arrange
     cache = {}
-    times_np = np.linspace(2450000.0, 2450004.0, 5)
-    earth = np.zeros((5, 3))
+    ground = np.zeros((5, 3))
     satellite = np.ones((5, 3))
 
-    # Mock Earth ephemeris so the test doesn't require network / JPL file access.
-    with patch(
-        "exozippy.components.mulensing.op._earth_xyz_at",
-        return_value=np.zeros((5, 3)),
-    ):
-        # Act
-        coord_earth = _get_sat_coord(earth, times_np, cache)
-        coord_sat = _get_sat_coord(satellite, times_np, cache)
+    # Act
+    coord_ground = _dev_skycoord(ground, cache)
+    coord_sat = _dev_skycoord(satellite, cache)
 
-        # Assert
-        assert not np.allclose(
-            coord_earth.cartesian.xyz.value, coord_sat.cartesian.xyz.value
-        )
-        assert _get_sat_coord(earth, times_np, cache) is coord_earth
-        assert _get_sat_coord(satellite, times_np, cache) is coord_sat
+    # Assert
+    assert not np.allclose(
+        coord_ground.cartesian.xyz.value, coord_sat.cartesian.xyz.value
+    )
+    assert _dev_skycoord(ground, cache) is coord_ground
+    assert _dev_skycoord(satellite, cache) is coord_sat
 
 
 def test_pspl_model_floors_nonpositive_rho():
@@ -544,6 +538,86 @@ def test_pspl_finite_source_requires_ptde():
     reqs = lens.sampler_requirements()
     assert "nuts" in reqs.get("incompatible", set())
     assert reqs.get("recommended") == "ptde"
+
+
+# ---------------------------------------------------------------------------
+# t0_par re-resolution in load_data (2026-08-08 review item 1.11)
+# ---------------------------------------------------------------------------
+
+
+class _T0ParConfigManager(_DummyConfigManager):
+    def __init__(self, user_params=None, seed_t0=None):
+        self.user_params = user_params or {}
+        self._seed_t0 = seed_t0
+
+    def seed_start_value(self, path, seed=0):
+        return self._seed_t0 if path == "lens.0.t_0" else None
+
+
+def _t0_par_fixture(user_params=None, seed_t0=None, lens_config=None):
+    inst = MulensInstrument.__new__(MulensInstrument)
+    inst.config_manager = _T0ParConfigManager(user_params, seed_t0)
+    system = _DummySystem()
+    system.lens = _DummySystem()
+    system.lens.config = [lens_config or {}]
+    return inst, system
+
+
+def test_t0_par_explicit_config_wins():
+    """
+    Given an explicit lens t0_par alongside a user t_0 and a seed,
+    When the final t0_par is resolved in load_data,
+    Then the explicit config value wins.
+    """
+    inst, system = _t0_par_fixture(
+        user_params={"lens.0.t_0": {"initval": 2458800.0}},
+        seed_t0=2458700.0,
+        lens_config={"t0_par": 2458554.89},
+    )
+    times = np.linspace(2458500.0, 2458600.0, 11)
+    assert inst._resolve_t0_par_final(system, times) == 2458554.89
+
+
+def test_t0_par_user_t0_beats_seed():
+    """
+    Given both a user lens.0.t_0 initval and an MMEXOFAST seed,
+    When the final t0_par is resolved,
+    Then the user's value wins (seeds sit below RANK_USER).
+    """
+    inst, system = _t0_par_fixture(
+        user_params={"lens.0.t_0": {"initval": 2458800.0}},
+        seed_t0=2458700.0,
+    )
+    times = np.linspace(2458500.0, 2458600.0, 11)
+    assert inst._resolve_t0_par_final(system, times) == 2458800.0
+
+
+def test_t0_par_uses_mmexofast_seed():
+    """
+    Given no explicit t0_par and no user t_0 (the automated MMEXOFAST
+      workflow deliberately omits the microlensing start values),
+    When the final t0_par is resolved after the seeds arrived,
+    Then the seed t_0 is used -- NOT the 2450000.0 construction-time default
+      that parked the Skowron reference epoch ~8300 days before the data
+      (2026-08-08 review item 1.11).
+    """
+    inst, system = _t0_par_fixture(seed_t0=2458554.89)
+    times = np.linspace(2458500.0, 2458600.0, 11)
+    assert inst._resolve_t0_par_final(system, times) == 2458554.89
+
+
+def test_t0_par_falls_back_to_median_data_time():
+    """
+    Given no explicit t0_par, no user t_0, and no seeds,
+    When the final t0_par is resolved,
+    Then the median data time anchors the frame (keeps the linear Earth
+      extrapolation within the season) instead of a fixed ancient epoch.
+    """
+    inst, system = _t0_par_fixture()
+    times = np.linspace(2458500.0, 2458600.0, 11)
+    assert inst._resolve_t0_par_final(system, times) == pytest.approx(
+        2458550.0
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pspl_symbolic_vs_op.py
+++ b/tests/test_pspl_symbolic_vs_op.py
@@ -52,11 +52,15 @@ def _build_system(extra_params=None):
     return system, model
 
 
-def _eval_both(system, model, obs_abs, t_vals):
-    """Compile and evaluate symbolic + Op magnification at raw=0 (initvals)."""
+def _eval_both(system, model, obs_dev, t_vals):
+    """Compile and evaluate symbolic + Op magnification at raw=0 (initvals).
+
+    obs_dev: Skowron+2011 geocentric deviations (AU) -- the single obs_pos
+    convention both magnification paths consume.
+    """
     with model:
         A_sym_node = system.lens.get_magnification(
-            t_vals, obs_abs, system, index=0
+            t_vals, obs_dev, system, index=0
         )
 
         sp = system.lens._get_safe_mm_params(0)
@@ -66,7 +70,7 @@ def _eval_both(system, model, obs_abs, t_vals):
         A_op_node = mag_op(
             pt.stack([sp["t0"], sp["u0"], sp["tE"], sp["pi_N"], sp["pi_E"]]),
             pt.as_tensor_variable(t_vals),
-            pt.as_tensor_variable(obs_abs),
+            pt.as_tensor_variable(obs_dev),
         )
 
         f_sym = pytensor.function(
@@ -101,23 +105,12 @@ def test_pspl_symbolic_vs_op_no_parallax():
     )
 
 
-def test_pspl_symbolic_vs_op_with_earth_parallax():
-    """
-    Given a satellite observer (Earth + constant ~0.05 AU displacement) and
-      non-zero pi_E so parallax changes the light curve,
-    When symbolic and Op are evaluated,
-    Then they agree to < 1e-3.
+def _skowron_deviations(t_vals, t0_par, offset=None):
+    """Skowron+2011 geocentric deviations for an Earth(+offset) observer.
 
-    This test guards against the ephemeris-convention bug where the symbolic
-    formula received Skowron+2011 geocentric deviations while MulensModel
-    expected absolute barycentric positions.
-
-    Uses a ±1-day window centred on t0: Earth's orbit deviates from a linear
-    fit by < 1.5e-4 AU over that interval (far smaller than the 0.05 AU
-    satellite offset), so the symbolic linear-Earth approximation and the Op's
-    real ephemeris both yield geocentric ≈ satellite_offset.  No mocking needed.
-    Earth-ephemeris accuracy error → < 2.6e-5 in u → < 5e-4 in magnification,
-    well within the 1e-3 tolerance.
+    delta(t) = earth(t) - [earth(t0_par) + v_earth(t0_par)*(t - t0_par)],
+    using astropy's builtin ephemeris (no network).  ``offset`` adds a
+    constant satellite displacement in AU.
     """
     import astropy.units as u_ast
     from astropy.coordinates import (
@@ -128,9 +121,6 @@ def test_pspl_symbolic_vs_op_with_earth_parallax():
 
     solar_system_ephemeris.set("builtin")
 
-    t0 = 2460025.0
-    t_vals = np.linspace(t0 - 1.0, t0 + 1.0, 10)
-
     def _earth(t_arr):
         return (
             get_body_barycentric(
@@ -140,38 +130,90 @@ def test_pspl_symbolic_vs_op_with_earth_parallax():
             .value.T
         )  # (N, 3)
 
-    earth_xyz = _earth(t_vals)
-    satellite_offset = np.array([0.04, 0.03, 0.01])
-    xyz_abs = earth_xyz + satellite_offset[np.newaxis, :]
-
     dt = 0.5
-    earth_pos_ref = _earth(np.array([t0]))[0]
-    earth_vel_ref = (
-        _earth(np.array([t0 + dt]))[0] - _earth(np.array([t0 - dt]))[0]
+    pos_ref = _earth(np.array([t0_par]))[0]
+    vel_ref = (
+        _earth(np.array([t0_par + dt]))[0] - _earth(np.array([t0_par - dt]))[0]
     ) / (2.0 * dt)
+    dev = _earth(t_vals) - (
+        pos_ref[None, :] + vel_ref[None, :] * (t_vals - t0_par)[:, None]
+    )
+    if offset is not None:
+        dev = dev + np.asarray(offset)[None, :]
+    return dev
 
+
+def test_pspl_symbolic_vs_op_with_annual_parallax():
+    """
+    Given a full observing season of ground-based Skowron+2011 geocentric
+      deviations (Earth's orbit departs from the linear reference by O(1) AU)
+      and non-zero pi_E,
+    When symbolic and Op are evaluated on the SAME deviation array,
+    Then (a) they agree to < 1e-6 -- both paths consume one obs_pos
+      convention -- and (b) the Op's magnification RESPONDS to the
+      deviations (max |A - A_no_parallax| > 0.01).
+
+    (b) is the regression for the 2026-08-08 review item 1.1: the Op used to
+    subtract the ACTUAL Earth ephemeris from the observer positions, which
+    deleted annual parallax entirely (pi_E had zero likelihood response for
+    every ground-based Op-path fit).
+    """
+    t0 = 2460025.0
+    t_vals = np.linspace(t0 - 150.0, t0 + 150.0, 200)
+    dev = _skowron_deviations(t_vals, t0)
+
+    # pi_E is derived from the pm/mass/distance chain (~0.18 here);
+    # initvals on lens.pi_E_* would be ignored (derived parameter).
     extra = {
-        "lens.Lens.pi_E_N": {"initval": 0.3, "sigma": 0.0},
-        "lens.Lens.pi_E_E": {"initval": 0.2, "sigma": 0.0},
         "star.Lens.pm_ra": {"initval": 10.0},
         "star.Lens.pm_dec": {"initval": 5.0},
     }
     system, model = _build_system(extra)
 
-    class _MockInstr:
-        pass
-
-    instr = _MockInstr()
-    instr._t0_par = t0
-    instr._earth_pos_ref = earth_pos_ref
-    instr._earth_vel_ref = earth_vel_ref
-    system.mulensinstrument = instr
-
-    m_sym, m_op = _eval_both(system, model, xyz_abs, t_vals)
+    m_sym, m_op = _eval_both(system, model, dev, t_vals)
 
     max_diff = np.max(np.abs(m_sym - m_op))
-    assert max_diff < 1e-3, (
-        f"max |A_sym - A_op| with satellite parallax = {max_diff:.2e}\n"
-        "Possible ephemeris-convention mismatch: check that both paths "
-        "receive absolute barycentric AU and convert consistently."
+    assert max_diff < 1e-6, (
+        f"max |A_sym - A_op| with annual parallax = {max_diff:.2e}\n"
+        "Possible obs_pos-convention mismatch: both paths must consume "
+        "Skowron+2011 geocentric deviations."
+    )
+
+    zero_obs = np.zeros_like(dev)
+    _, m_op_no_par = _eval_both(system, model, zero_obs, t_vals)
+    response = np.max(np.abs(m_op - m_op_no_par))
+    assert response > 0.01, (
+        f"Op magnification ignores annual parallax: max |dA| = {response:.2e}"
+    )
+
+
+def test_pspl_symbolic_vs_op_with_satellite_offset():
+    """
+    Given annual deviations plus a constant ~0.05 AU satellite displacement,
+    When symbolic and Op are evaluated on the same deviations,
+    Then they agree to < 1e-6 and differ from the ground-only curve (the
+      satellite term survives on top of the annual term).
+    """
+    t0 = 2460025.0
+    t_vals = np.linspace(t0 - 30.0, t0 + 30.0, 60)
+    dev_ground = _skowron_deviations(t_vals, t0)
+    dev_sat = dev_ground + np.array([0.04, 0.03, 0.01])[None, :]
+
+    # pm values give a finite t_E (~23 d) so the curve actually varies
+    # over the window; pi_E is derived (~0.18) from the same chain.
+    extra = {
+        "star.Lens.pm_ra": {"initval": 10.0},
+        "star.Lens.pm_dec": {"initval": 5.0},
+    }
+    system, model = _build_system(extra)
+
+    m_sym, m_op = _eval_both(system, model, dev_sat, t_vals)
+    max_diff = np.max(np.abs(m_sym - m_op))
+    assert max_diff < 1e-6, (
+        f"max |A_sym - A_op| with satellite offset = {max_diff:.2e}"
+    )
+
+    _, m_op_ground = _eval_both(system, model, dev_ground, t_vals)
+    assert np.max(np.abs(m_op - m_op_ground)) > 1e-4, (
+        "satellite displacement has no effect on the Op magnification"
     )

--- a/tests/test_runaway_logp_regression.py
+++ b/tests/test_runaway_logp_regression.py
@@ -160,7 +160,7 @@ def _point(raw_dict):
 # post free_symbols-sort hardening).  Differs from the historical stored lp
 # (~2982.18) because the model itself has changed since that trace; see the
 # module docstring.
-GOOD_EXPECTED_LP = -942.995  # re-measured 2026-08: kinematic-prior rotation fix (v_phi centering) moved every lp
+GOOD_EXPECTED_LP = -934.604  # re-measured 2026-08-08: Op-path annual parallax fix (review 1.1) moved the mulens likelihood
 
 
 def test_good_draw_logp_matches_deterministic_build(dc2018_128_logp):

--- a/tests/test_vbm_direct_vs_mulensmodel.py
+++ b/tests/test_vbm_direct_vs_mulensmodel.py
@@ -18,7 +18,6 @@ pytestmark = pytest.mark.slow
 from exozippy.components.mulensing.op import (
     BinaryLensMagOp,
     VBMDirectMagOp,
-    _earth_xyz_at,
 )
 
 _COORDS = "268.0d -29.0d"
@@ -51,7 +50,13 @@ _ORDER = [
 
 
 def _times_and_obs(n=400, span=150.0):
-    """Times plus an L2-like satellite observer (absolute barycentric AU).
+    """Times plus Skowron+2011 geocentric deviations for an L2-like observer.
+
+    Both Ops consume the same deviation array, so a smooth annual-scale
+    curve (Earth's orbit departs quadratically-then-worse from the linear
+    reference, reaching O(1) AU over a season) plus a constant satellite
+    offset exercises the parallax projection without any ephemeris or
+    network dependency.
 
     The default span reaches u ~ 8 Einstein radii in the wings, past the
     far-field point-source guard boundary in VBMDirectMagOp._magnify, so the
@@ -59,8 +64,16 @@ def _times_and_obs(n=400, span=150.0):
     dispatch paths.
     """
     times = np.linspace(_T0_PAR - span, _T0_PAR + span, n)
+    phase = 2.0 * np.pi * (times - _T0_PAR) / 365.25
+    dev = np.column_stack(
+        [
+            0.5 * (1.0 - np.cos(phase)),
+            0.5 * (np.sin(phase) - phase),
+            0.2 * (1.0 - np.cos(phase)),
+        ]
+    )
     offset = np.array([0.009, 0.004, 0.002])
-    return times, _earth_xyz_at(times) + offset[None, :]
+    return times, dev + offset[None, :]
 
 
 def _compile(op):


### PR DESCRIPTION
Fixes the 2026-08-08 audit's top finding (item 1.1) plus the coupled item 1.11 it masked.

## The bug

The MulensModel/VBM magnification Ops fed `satellite_skycoord = obs_abs - earth_actual`, which is identically zero for ground observers -- annual parallax was deleted and **pi_E had zero likelihood response in every binary-lens or finite-source fit**. Confirmed numerically: `max|A(pi_E=0) - A(pi_E=0.5)|` was exactly 0.0 on ground data (now 0.018 PSPL / 0.27 binary for the same setup). The symbolic PSPL path was always correct.

## The fix

- One obs_pos convention everywhere: both paths consume Skowron+2011 geocentric deviations (`MulensInstrument.observer_pos`; `observer_pos_abs` deleted). The Ops pass the deviations to MulensModel as `satellite_skycoord` with `satellite=True, earth_orbital=False` -- on deviations the satellite channel carries ALL parallax (annual + satellite), exactly matching the symbolic formula. `VBMDirectMagOp` projects them directly; no ephemeris call left in the hot path.
- **Item 1.11**: t0_par no longer silently defaults to 2450000.0 in the MMEXOFAST auto workflow. `load_data` re-resolves it after seeds arrive: explicit `t0_par` > user `t_0` > seed `t_0` > median data time.
- Cleared per Op call: MulensModel's class-level `Trajectory._get_delta_satellite_results` cache, keyed on (ra, dec, times) only -- it would silently reuse one observer's parallax deltas for another on the same time grid.

## Verification

- Symbolic vs Op parity < 1e-6 over a full season; explicit A-responds-to-deviations regression (the section-9 test gap that let 1.1 survive).
- Symbolic path unchanged: ob140939 start logp identical pre/post-fix.
- Full suite green (1002 tests). DC2018_128 pinned lp re-measured (-942.995 -> -934.604, bit-deterministic across builds) per that test's own instructions.
- `test_vbm_direct_vs_mulensmodel` now uses synthetic deviations -- JPL/network dependency removed.

## Follow-ups (not in this PR)

- Existing Op-path traces (ob161003, ogle0383, KMT-2019-BLG-1806, DC2018 batches) were sampled with pi_E disconnected from ground data; their lens mass/distance/PM posteriors need refitting.
- New pre-existing finding filed as notes item 1.19: `backend: mulensmodel` + binary + `finite_source: false` selects method "VBBL", which MulensModel rejects for a point source (all-NaN -> -inf on every proposal). Unreachable with the default `vbm_direct` backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)