### PR TITLE
PTDE: dedupe sync/async into samplers/_common, fix 1.14-1.16, default ptde_async

### DIFF
--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -863,7 +863,10 @@ class Lens(Component):
 
         Binary/finite-source lenses use the MulensModel Op, which is not
         differentiable.  Gradient-based samplers (NUTS, numpyro, blackjax)
-        will produce invalid results; PTDE is required.
+        will produce invalid results; PTDE is required.  The asynchronous
+        dispatch loop (ptde_async) is recommended: near-caustic evaluations
+        concentrate in the hot rungs and stall the synchronous sampler's
+        every step behind the slowest proposal (samplers/ptde_async.py).
 
         PSPL lenses use a symbolic PyTensor formula and are NUTS-compatible,
         so no constraints are returned.
@@ -871,7 +874,7 @@ class Lens(Component):
         if any(self.uses_op(i) for i in range(len(self.n_lens_bodies))):
             return {
                 "incompatible": {"nuts", "numpyro", "blackjax"},
-                "recommended": "ptde",
+                "recommended": "ptde_async",
                 "reason": (
                     "binary/finite-source microlensing uses the MulensModel Op, "
                     "which is not differentiable — gradient-based samplers produce "

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -242,7 +242,7 @@ def _run_fit(config, gui, user_params=None):
     if method is None:
         method = next(iter(_recommended)) if _recommended else "nuts"
     elif method.lower() in _incompatible:
-        rec_str = next(iter(_recommended)) if _recommended else "ptde"
+        rec_str = next(iter(_recommended)) if _recommended else "ptde_async"
         reason_str = (
             "; ".join(_reasons) if _reasons else "incompatible with this model"
         )
@@ -438,14 +438,13 @@ def _run_fit(config, gui, user_params=None):
                     progress_callback=gui.progress_callback,
                 )
             elif method == "ptde_async":
-                # EXPERIMENTAL (hpc_optimization.txt PROMPT 13): a separate,
-                # non-blocking PTDE dispatch loop -- see
-                # exozippy/samplers/ptde_async.py's module docstring for the
-                # statistical caveat around stale DE partner states before
-                # using this for a production posterior. rung_thin_factor/
-                # rung_thin_start are ptde-only (thinning addresses the
-                # blocking problem that async dispatch removes outright) and
-                # are not forwarded here.
+                # The non-blocking PTDE dispatch loop (hpc_optimization.txt
+                # PROMPT 13) -- the recommended default for Op-based models;
+                # see exozippy/samplers/ptde_async.py's module docstring for
+                # the stale-DE-partner caveat and how swaps stay rigorous.
+                # rung_thin_factor/rung_thin_start are ptde-only (thinning
+                # addresses the blocking problem that async dispatch removes
+                # outright) and are not forwarded here.
                 idata = ptde_async_sample(
                     model,
                     system,

--- a/src/exozippy/samplers/_common.py
+++ b/src/exozippy/samplers/_common.py
@@ -1,0 +1,802 @@
+"""
+Shared, zero-statistical-risk scaffolding for the PTDE samplers.
+
+exozippy.samplers.ptde (synchronous) and exozippy.samplers.ptde_async
+(asynchronous) are two dispatch loops over the same non-sampling machinery:
+worker-pool plumbing, compiled raw -> physical conversion, start-population
+generation, signal handling, posterior assembly, and diagnostics. That
+machinery lives here exactly once so the two samplers cannot drift apart
+again (they did -- see notes/code_review_20260808.txt section 4: the sync
+sampler grew the lp-plausibility guard while async had neither the parameter
+nor the check, and log_interval silently meant different things in the two).
+
+The sampling LOOPS stay separate by design: this module must never grow
+accept/reject, temperature-swap, or adaptation logic. Anything statistical
+belongs in the sampler that owns it.
+
+Helpers that log take the calling sampler's ``log`` (a logging.Logger) so
+messages appear under "exozippy.samplers.ptde" / "...ptde_async" -- the
+logger names tests and users filter on.
+"""
+
+import gc
+import logging
+import multiprocessing as mp
+import os
+import signal
+import threading
+import time
+
+import arviz as az
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+from pytensor.graph.replace import vectorize_graph
+
+# Force single-threaded BLAS/OMP in every forked worker.  Without this,
+# numpy (OpenBLAS/MKL) and C extensions (VBBinaryLensing) each spawn their
+# own thread pool, producing n_workers x n_blas_threads threads on a fixed
+# number of physical cores and causing catastrophic scheduler thrash -- and,
+# separately, each with a memory arena sized to the (over-subscribed) thread
+# count, which is what actually blows up h_vmem once forked N-ways.
+# exozippy/__init__.py already sets these before numpy/pytensor/pymc/arviz/
+# jax are imported at all -- the only point where it's effective, since a
+# native thread pool can't be shrunk after the fact by setting os.environ
+# once numpy et al. are already loaded (import exozippy always runs
+# __init__.py first, before this module). This block is redundant there;
+# kept as a guard for any environment that imports the samplers without
+# ever importing the exozippy package proper.
+for _tvar in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "BLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+):
+    os.environ.setdefault(_tvar, "1")
+
+logger = logging.getLogger(__name__)
+
+# Shared with outputs.modes.identify_modes: |lp| above this is numerically
+# broken, not a real posterior mode (no realistic dataset's logp reaches
+# 1e12). Imported (not duplicated) so the two ceilings can't drift apart.
+from exozippy.outputs.modes import DEFAULT_LP_ABS_MAX  # noqa: E402
+
+# The chain-initialization probe lives in exozippy.whitening (it is also the
+# engine behind the data-driven whitening rescale done at model setup); PTDE
+# re-probes the already-whitened model, where every scale is ~1, so the
+# default (narrow) dynamic range is the right one here.
+from exozippy.whitening import probe_scales as _probe_scales  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Worker-side logp evaluation (fork-inherited globals)
+# ---------------------------------------------------------------------------
+
+# Module-level logp function: set in the parent process (set_worker_globals)
+# before the Pool is forked.  Fork children inherit the compiled PyTensor
+# function via copy-on-write without pickling.  Proposals (dicts of numpy
+# arrays) are the only IPC payload.
+_PTDE_LOGP_FN = None
+
+# Diagnostic flag (see collect_rung_timing in the samplers and
+# hpc_optimization.txt P13): set in the parent before forking, like
+# _PTDE_LOGP_FN, so workers inherit it via copy-on-write. When True,
+# _eval_logp times its own call and returns (lp, elapsed_seconds) instead of
+# a bare float, so the parent can attribute wall time to a rung.
+_PTDE_COLLECT_TIMING = False
+
+
+def set_worker_globals(logp_fn, collect_timing=False):
+    """Install the compiled logp function (and the timing flag) in this
+    module's namespace BEFORE the worker pool is forked, so children inherit
+    both via copy-on-write. Both samplers must call this instead of writing
+    the globals directly -- _eval_logp's __globals__ point here."""
+    global _PTDE_LOGP_FN, _PTDE_COLLECT_TIMING
+    _PTDE_LOGP_FN = logp_fn
+    _PTDE_COLLECT_TIMING = collect_timing
+
+
+def timing_enabled():
+    """Whether _eval_logp currently returns (lp, elapsed) tuples."""
+    return _PTDE_COLLECT_TIMING
+
+
+def _eval_logp(proposal):
+    """Worker: evaluate logp for one raw-space proposal dict.
+
+    Returns a bare float normally. When _PTDE_COLLECT_TIMING is set, returns
+    (lp, elapsed_seconds) instead (diagnostic mode; see the comment above
+    _PTDE_COLLECT_TIMING).
+    """
+    if _PTDE_COLLECT_TIMING:
+        t0 = time.perf_counter()
+        try:
+            lp = float(_PTDE_LOGP_FN(proposal))
+        except Exception:
+            lp = -np.inf
+        return lp, time.perf_counter() - t0
+    try:
+        return float(_PTDE_LOGP_FN(proposal))
+    except Exception:
+        return -np.inf
+
+
+# ---------------------------------------------------------------------------
+# Worker pool lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _worker_init():
+    """Pool worker: ignore SIGINT/SIGTERM so only the parent handles graceful
+    stop. A batch scheduler typically signals the whole process group, and a
+    worker that died mid pool.map() would break the parent's current step
+    (BrokenProcessPool) instead of letting it finish and wrap up cleanly."""
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+
+def _shutdown_pool(pool, grace=1.0):
+    """terminate() a Pool, escalating to SIGKILL for workers that outlive the
+    grace period.
+
+    _worker_init has the workers ignore SIGTERM (so a batch scheduler signalling
+    the whole process group cannot break the parent mid-step). But pool.terminate()
+    kills workers *by sending SIGTERM*, then joins them -- so a worker stuck in a
+    pathological logp evaluation ignores the terminate and the join blocks forever.
+    That is the "recycling worker pool" hang: a timed-out worker is exactly the
+    one that can never be reaped this way.
+
+    The SIGKILL is issued from a watchdog thread rather than up front, because it
+    must land only AFTER terminate() is past its _help_stuff_finish step. That
+    step drains inqueue while holding inqueue._rlock; a worker blocked in
+    inqueue.get() holds that same lock, so SIGKILLing it before terminate()
+    reaches _help_stuff_finish wedges the lock and deadlocks terminate() even
+    earlier. Waiting `grace` seconds lets a well-behaved terminate() finish
+    untouched (the escalation never fires), and only forces the issue when a
+    worker is genuinely wedged.
+    """
+    done = threading.Event()
+
+    def _reaper():
+        if done.wait(grace):
+            return  # terminate()/join() completed cleanly; no escalation needed
+        for p in pool._pool:
+            if p.exitcode is None:
+                try:
+                    os.kill(p.pid, signal.SIGKILL)
+                except (ProcessLookupError, OSError):
+                    pass
+
+    watchdog = threading.Thread(target=_reaper, daemon=True)
+    watchdog.start()
+    try:
+        pool.terminate()
+        pool.join()
+    finally:
+        done.set()
+        watchdog.join()
+
+
+def create_pool(cores, total_proposals, label, log):
+    """Resolve the core count and fork the worker pool.
+
+    Must be called AFTER set_worker_globals so fork children inherit the
+    compiled logp function. Returns (pool_or_None, actual_cores); pool is
+    None in serial mode (actual_cores <= 1).
+    """
+    phys_cores = mp.cpu_count()
+    if cores is None:
+        # Fallback if called directly (not via run.py): same 75% formula.
+        cores = max(1, min(int(phys_cores * 0.75), phys_cores - 1))
+    actual_cores = min(cores, total_proposals)
+    if cores > phys_cores:
+        log.warning(
+            f"{label}: cores={cores} exceeds physical core count ({phys_cores}); "
+            f"over-subscription will slow sampling via context switching."
+        )
+    pool = (
+        mp.get_context("fork").Pool(actual_cores, initializer=_worker_init)
+        if actual_cores > 1
+        else None
+    )
+    return pool, actual_cores
+
+
+def recycle_pool(pool, actual_cores):
+    """Tear down a pool with a possibly-hung worker and fork a fresh one.
+
+    Terminated Pools sit in reference cycles (handler threads, worker
+    sentinels, queue pipes) that only the cyclic GC frees; without an
+    explicit collect each recycle leaks ~2 fds per worker until the process
+    hits EMFILE ("Too many open files") after enough timeouts.
+    """
+    _shutdown_pool(pool)
+    gc.collect()
+    return mp.get_context("fork").Pool(actual_cores, initializer=_worker_init)
+
+
+def warn_serial_eval_timeout(eval_timeout, pool, actual_cores, label, log):
+    """One-time startup warning: eval_timeout is unenforceable without a pool."""
+    if eval_timeout is not None and pool is None:
+        log.warning(
+            f"{label}: eval_timeout={eval_timeout:.0f}s has no effect with a "
+            f"single core (cores={actual_cores}) -- there is no worker process "
+            f"to enforce a wall-clock timeout against a hung logp call."
+        )
+
+
+def _map_logp(pool, proposals):
+    if pool is None:
+        return [_eval_logp(p) for p in proposals]
+    return pool.map(_eval_logp, proposals)
+
+
+def _map_logp_timeout(pool, proposals, timeout):
+    """Evaluate logps with a per-call wall-clock timeout.
+
+    Each proposal individually gets up to `timeout` seconds (not a deadline
+    shared across the whole batch -- a slow-but-legitimate early proposal must
+    not eat into the budget of proposals evaluated later in the same step).
+    A proposal that doesn't complete in time receives -inf, so the caller's
+    normal Metropolis accept/reject logic rejects it automatically.
+
+    A logp evaluation can call into external/compiled code that occasionally
+    enters a genuine infinite loop for some pathological parameter
+    combination. When that happens the worker process that drew the
+    timed-out proposal is stuck forever and never becomes available again;
+    this function has no way to kill a single worker without tearing down
+    the whole Pool, so the caller is responsible for recycling `pool`
+    whenever `timed_out` is non-empty. Without that, a long run slowly
+    bleeds workers, one per hang, until the pool is exhausted.
+
+    With no pool (single-core / serial mode), there is no subprocess to time
+    out, so `timeout` cannot be enforced -- proposals run to completion as
+    before. The caller should warn about this once at startup if cores<=1
+    (warn_serial_eval_timeout).
+
+    Returns (lps, timed_out) where timed_out is a list of indices into
+    `proposals`.
+    """
+    if pool is None:
+        return [_eval_logp(p) for p in proposals], []
+
+    async_results = [pool.apply_async(_eval_logp, (p,)) for p in proposals]
+    lps = []
+    timed_out = []
+    # Keep the timeout sentinel the same shape _eval_logp returns (a bare
+    # float, or (lp, elapsed) in collect_rung_timing diagnostic mode) so
+    # every entry in `lps` is uniformly typed for the caller to unpack.
+    timeout_val = (-np.inf, timeout) if _PTDE_COLLECT_TIMING else -np.inf
+    for idx, r in enumerate(async_results):
+        try:
+            lps.append(r.get(timeout=timeout))
+        except mp.TimeoutError:
+            lps.append(timeout_val)
+            timed_out.append(idx)
+    return lps, timed_out
+
+
+# ---------------------------------------------------------------------------
+# DE proposal construction
+# ---------------------------------------------------------------------------
+
+# ter Braak 2006 epsilon term: without it a DE proposal is a pure linear
+# combination of population states, so sampling is confined to the affine
+# hull of the initial T=1 starts FOREVER (swaps only exchange states within
+# the same hull). With the default n_chains = 2*n_params the hull is almost
+# surely full-rank and this never bites, but a user setting
+# n_chains <= n_params would otherwise silently explore a proper subspace
+# and get a wrong posterior. Raw (whitened) space has scales ~1 by
+# construction, so a fixed 1e-4 is small against any posterior width --
+# a correctness backstop, not a mixing mechanism (see
+# warn_if_population_degenerate for the mixing side).
+DE_JITTER = 1e-4
+
+
+def _pick_two(rng, n, exclude):
+    """Pick two distinct indices from [0, n) excluding `exclude`."""
+    idx = rng.choice(n - 1, 2, replace=False)
+    return tuple(int(i + (1 if i >= exclude else 0)) for i in idx)
+
+
+def de_proposal(rng, pop, i, gamma, keys, jitter=DE_JITTER):
+    """One ter Braak DE-MC proposal for population member `i`:
+    x_i + gamma * (x_j1 - x_j2) + jitter * N(0, 1), j1 != j2 != i.
+
+    THE single owner of the production proposal formula -- both samplers
+    call this so the move (and its epsilon term) cannot drift between them.
+    """
+    j1, j2 = _pick_two(rng, len(pop), i)
+    prop = {}
+    for key in keys:
+        step = gamma * (pop[j1][key] - pop[j2][key])
+        if jitter:
+            step = step + jitter * rng.standard_normal(np.shape(pop[i][key]))
+        prop[key] = pop[i][key] + step
+    return prop
+
+
+def warn_if_population_degenerate(n_chains, n_params, label, log):
+    """Warn when the DE population cannot span parameter space.
+
+    With n_chains < n_params + 2 the difference vectors span a proper
+    subspace, and the epsilon jitter (DE_JITTER) is the only escape from
+    it -- ergodic in principle, hopeless in practice. The default
+    n_chains = 2 * n_params never triggers this.
+    """
+    if n_chains < n_params + 2:
+        log.warning(
+            f"{label}: n_chains={n_chains} < n_params + 2 = {n_params + 2}; "
+            f"DE difference vectors cannot span parameter space and mixing "
+            f"across the missing directions relies on the tiny epsilon "
+            f"jitter alone. Raise n_chains (default 2 x n_params)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Compiled conversions (logp is compiled by the caller; see set_worker_globals)
+# ---------------------------------------------------------------------------
+
+
+def compile_conversions(model):
+    """Compile the raw -> physical conversion functions ONCE.
+
+    raw_to_phys is the single-sample form, kept for the (rare) eval_timeout
+    diagnostic log path, which converts exactly one proposal at a time.
+    raw_to_phys_batched vectorizes the same graph over an extra leading
+    sample axis (pytensor's vectorize_graph -- adds the batch dim to every
+    op in the graph rather than looping in Python) and is what the
+    ensemble-start-plot and final posterior conversions use, since those
+    can be tens of thousands to millions of samples: the free_RVs +
+    deterministics graph is pure elementwise/indexing math (each
+    Parameter's physical-unit conversion; verified empirically that no
+    deterministic here touches the magnification Ops, which only feed the
+    likelihood), so it vectorizes cleanly and cuts what was a
+    Python-level per-sample loop (dominant cost: interpreter + pytensor
+    call overhead, not the underlying math) down to a handful of batched
+    calls. See hpc_optimization.txt PROMPT 7.
+
+    Returns (raw_to_phys, raw_to_phys_batched, raw_var_names, out_var_names).
+    """
+    output_vars = model.free_RVs + model.deterministics
+    raw_to_phys = pytensor.function(
+        inputs=model.free_RVs,
+        outputs=output_vars,
+        on_unused_input="ignore",
+    )
+    batched_inputs = [
+        pt.tensor(
+            name=f"batched_{v.name}",
+            dtype=v.type.dtype,
+            shape=(None,) + v.type.shape,
+        )
+        for v in model.free_RVs
+    ]
+    raw_to_phys_batched = pytensor.function(
+        inputs=batched_inputs,
+        outputs=vectorize_graph(
+            output_vars, replace=dict(zip(model.free_RVs, batched_inputs))
+        ),
+        on_unused_input="ignore",
+    )
+    raw_var_names = [v.name for v in model.free_RVs]  # ordered input names
+    out_var_names = [v.name for v in output_vars]  # ordered output names
+    return raw_to_phys, raw_to_phys_batched, raw_var_names, out_var_names
+
+
+def describe_proposal(prop, raw_to_phys, raw_var_names, out_var_names):
+    """Render one raw proposal as (physical_params, raw_params) dicts of
+    plain lists, for the eval-timeout diagnostic log."""
+    raw_vals = [prop[k] for k in raw_var_names]
+    phys_vals = raw_to_phys(*raw_vals)
+    phys_params = {
+        name: np.asarray(val).tolist()
+        for name, val in zip(out_var_names, phys_vals)
+    }
+    raw_params = {k: np.asarray(v).tolist() for k, v in prop.items()}
+    return phys_params, raw_params
+
+
+# ---------------------------------------------------------------------------
+# Start-population generation + ensemble plots
+# ---------------------------------------------------------------------------
+
+
+def _make_starts(
+    n_chains,
+    raw_starts,
+    logp_fn,
+    rng,
+    seed_indices=None,
+    system=None,
+    raw_scales=None,
+):
+    """Generate n_chains starting points near one or more seeds (P4).
+
+    `raw_starts` is a single raw-start dict (legacy) or a LIST of K raw-start
+    dicts (multi-seed sampling). Chains are assigned to seeds round-robin
+    (chain j -> seed j % K); the first chain of each seed group starts exactly
+    at that seed's solved point, the rest jitter around their seed's center.
+
+    Mirrors EXOFASTv2: scatter chains by factor x scale where
+    factor = min(sqrt(500/n_params), 3), accept any finite logp (no proximity
+    threshold), and apply exponential decay only when proposals hit hard prior
+    boundaries (lp=-inf).  Raises RuntimeError if a chain cannot be initialized
+    within max_iter retries.
+
+    The scatter is delegated to `system.jitter_raw_start` when the system
+    provides it, which draws in physical space from a Gaussian truncated to
+    each parameter's bounds.  Scattering in raw space instead saturates the
+    logit transform and starts a large fraction of chains pinned at the bounds
+    (31.5% within 1% of a bound for a parameter whose logp is flat out to them,
+    against uniform's 2.0%); see System.jitter_raw_start.  Systems without that
+    method (minimal test stubs) fall back to the historical raw-space jitter.
+
+    ``raw_scales`` (optional) is the per-element dispersion scale in current
+    raw units, as measured by the startup whitening pass (run.py passes
+    whiten_report["raw_scales"]).  When given, the probe is skipped entirely
+    -- the model was just whitened against the very same start, so re-probing
+    would re-derive ~1.0 everywhere at n_elements x O(10) logp calls.  When
+    absent (measure_scales: false, or standalone use), the probe runs as
+    before.
+
+    Returns (starts, chain_seed_index) where chain_seed_index[j] is the original
+    seed index that chain j was drawn from (for trace-attr provenance).
+    """
+    if isinstance(raw_starts, dict):
+        raw_starts = [raw_starts]
+    K = len(raw_starts)
+    if seed_indices is None:
+        seed_indices = list(range(K))
+
+    if raw_scales is not None:
+        map_lp = float(logp_fn(raw_starts[0]))
+        scales = {
+            k: np.asarray(
+                raw_scales.get(k, np.ones_like(np.asarray(v, dtype=float))),
+                dtype=float,
+            ).reshape(np.shape(v))
+            for k, v in raw_starts[0].items()
+        }
+    else:
+        # Probe scales once from seed 0 (the canonical MAP-ish start); the same
+        # per-parameter jitter scale is reused around every seed.
+        map_lp, scales = _probe_scales(raw_starts[0], logp_fn)
+    n_params = sum(v.size for v in raw_starts[0].values())
+    factor = min(np.sqrt(500.0 / max(n_params, 1)), 3.0)
+    max_iter = 1000
+
+    _jitter = (
+        getattr(system, "jitter_raw_start", None)
+        if system is not None
+        else None
+    )
+    logger.info(
+        f"PTDE init: MAP lp={map_lp:.1f}, n_params={n_params}, factor={factor:.2f}, "
+        f"jitter={'physical (truncated)' if _jitter else 'raw (fallback)'}"
+        + (
+            f", {K} seeds (round-robin over {n_chains} chains)"
+            if K > 1
+            else ""
+        )
+    )
+
+    starts = []
+    chain_seed_index = []
+    seed_seen = set()
+    # Cap the number of chains that start EXACTLY at a seed. With K ~
+    # n_chains (a params.2-style posterior-draw seed set), every chain
+    # would otherwise start at a previous-run posterior draw with zero
+    # jitter -- and since the DE population's spread IS the proposal
+    # generator, the restart could then never explore beyond the previous
+    # posterior, entrenching whatever that run missed. At least half the
+    # chains always get the factor-scaled jitter.
+    max_exact = max(1, n_chains // 2)
+    n_exact = 0
+    if K > max_exact:
+        logger.info(
+            f"PTDE init: {K} seeds > {max_exact} exact-start budget "
+            f"(half the {n_chains} chains); the rest start jittered around "
+            f"their seed to keep restart overdispersion."
+        )
+    for j in range(n_chains):
+        s = j % K
+        center = raw_starts[s]
+        # First chain of each seed group starts exactly at the solved seed
+        # (up to the overdispersion budget above).
+        if s not in seed_seen and n_exact < max_exact:
+            lp0 = float(logp_fn(center))
+            if np.isfinite(lp0):
+                starts.append({k: v.copy() for k, v in center.items()})
+                chain_seed_index.append(seed_indices[s])
+                seed_seen.add(s)
+                n_exact += 1
+                logger.debug(
+                    f"PTDE init chain {j}: exact seed {seed_indices[s]} "
+                    f"(lp={lp0:.1f})"
+                )
+                continue
+            logger.warning(
+                f"PTDE init: seed {seed_indices[s]} exact start has non-finite "
+                f"lp; jittering to find a finite start."
+            )
+        for niter in range(max_iter):
+            eff = factor / np.exp(niter / 1000.0)
+            if _jitter is not None:
+                prop = _jitter(center, scales, eff, rng)
+            else:
+                prop = {
+                    k: v + eff * scales[k] * rng.standard_normal(v.shape)
+                    for k, v in center.items()
+                }
+            lp = float(logp_fn(prop))
+            if np.isfinite(lp):
+                starts.append(prop)
+                chain_seed_index.append(seed_indices[s])
+                seed_seen.add(s)
+                logger.debug(
+                    f"PTDE init chain {j} (seed {seed_indices[s]}): accepted after "
+                    f"{niter} retries (lp={lp:.1f}, dlp={lp - map_lp:.1f})"
+                )
+                break
+            if niter % 200 == 0 and niter > 0:
+                logger.warning(
+                    f"PTDE init chain {j}: {niter} retries still seeking finite lp "
+                    f"(eff={eff:.3g})"
+                )
+        else:
+            raise RuntimeError(
+                f"PTDE chain {j} initialization failed after {max_iter} retries. "
+                f"Check initval/bounds in your params.yaml -- a parameter may be "
+                f"starting outside its prior bounds."
+            )
+    return starts, chain_seed_index
+
+
+def resolve_start_population(
+    model,
+    system,
+    n_chains,
+    logp_fn,
+    rng,
+    raw_start,
+    initvals=None,
+    raw_starts=None,
+    seed_indices=None,
+    raw_scales=None,
+):
+    """Resolve the T=1 chain starts: explicit initvals, or multi-seed
+    round-robin via _make_starts (P4).
+
+    raw_starts/seed_indices come from run.py when available; else fall back
+    to system.get_raw_starts, and further to a bare raw_start (single start)
+    for minimal test/system stubs that don't implement get_raw_starts at all.
+
+    Returns (t1_starts, chain_seed_index).
+    """
+    if initvals is not None:
+        assert len(initvals) == n_chains, "len(initvals) must equal n_chains"
+        return initvals, [0] * n_chains
+    if raw_starts is None:
+        if hasattr(system, "get_raw_starts"):
+            raw_starts, seed_indices = system.get_raw_starts(model)
+        else:
+            raw_starts, seed_indices = [raw_start], [0]
+    return _make_starts(
+        n_chains,
+        raw_starts,
+        logp_fn,
+        rng,
+        seed_indices,
+        system=system,
+        raw_scales=raw_scales,
+    )
+
+
+def plot_start_ensemble(
+    system,
+    t1_starts,
+    raw_to_phys_batched,
+    raw_var_names,
+    out_var_names,
+    plot_prefix,
+    log,
+):
+    """Ensemble start plots (T=1 starts only; raw -> physical via the
+    batched fn). No-op when plot_prefix is None."""
+    if plot_prefix is None:
+        return
+    log.info("Generating ensemble start plots...")
+    batched_vals = raw_to_phys_batched(
+        *[np.stack([s[k] for s in t1_starts], axis=0) for k in raw_var_names]
+    )
+    internal_starts = [
+        {
+            name: np.asarray(val)[i]
+            for name, val in zip(out_var_names, batched_vals)
+        }
+        for i in range(len(t1_starts))
+    ]
+    for comp in system.active_components.values():
+        comp.plot(
+            system,
+            internal_starts,
+            filename_prefix=plot_prefix + "_start_ensemble",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Signal handling
+# ---------------------------------------------------------------------------
+
+
+def install_stop_handlers(handler):
+    """Route SIGINT/SIGTERM (and Windows SIGBREAK) to `handler`.
+
+    SIGTERM gets the same handler as SIGINT so a batch scheduler (e.g.
+    `qsig -s SIGTERM <job_id>` / `kill -TERM <pid>`) can request the same
+    graceful stop-after-this-step behavior as a Ctrl+C at a terminal,
+    instead of Python's default SIGTERM action (immediate termination,
+    discarding whatever draws were already collected).  Windows delivers
+    the GUI's stop request as CTRL_BREAK_EVENT, which arrives as SIGBREAK
+    rather than SIGINT (see gui/runner.py); without wiring it the request
+    is received and silently ignored.
+
+    Returns an opaque token for restore_stop_handlers.
+    """
+    old_sigint = signal.signal(signal.SIGINT, handler)
+    old_sigterm = signal.signal(signal.SIGTERM, handler)
+    old_sigbreak = (
+        signal.signal(signal.SIGBREAK, handler)
+        if hasattr(signal, "SIGBREAK")
+        else None
+    )
+    return old_sigint, old_sigterm, old_sigbreak
+
+
+def restore_stop_handlers(token):
+    old_sigint, old_sigterm, old_sigbreak = token
+    signal.signal(signal.SIGINT, old_sigint)
+    signal.signal(signal.SIGTERM, old_sigterm)
+    if old_sigbreak is not None:
+        signal.signal(signal.SIGBREAK, old_sigbreak)
+
+
+# ---------------------------------------------------------------------------
+# Runaway-lp guard
+# ---------------------------------------------------------------------------
+
+
+class LpPlausibilityGuard:
+    """Warn ONCE when a T=1 chain's accepted lp exceeds the plausibility
+    ceiling.
+
+    A T=1 chain's lp this large always indicates a model bug (an unbounded/
+    uncancelled logp term), never real physics -- no finite dataset's logp
+    reaches 1e12. PTDE accepts on lp_new > lp_old, so such a bug is a
+    ratchet: once a chain's lp is inflated this way it can only climb
+    further, wasting the rest of the run (see examples/DC2018_128, a real
+    occurrence of exactly this failure mode). Warn once so it's noticed
+    immediately rather than discovered post-hoc via identify_modes, which
+    rejects draws on the same ceiling (outputs.modes.DEFAULT_LP_ABS_MAX).
+    """
+
+    def __init__(self, ceiling, label, log):
+        self.ceiling = DEFAULT_LP_ABS_MAX if ceiling is None else ceiling
+        self.label = label
+        self.log = log
+        self.warned = False
+
+    def check(self, chain_i, lp):
+        """Call with every ACCEPTED T=1 (chain index, lp)."""
+        if self.warned or abs(lp) <= self.ceiling:
+            return
+        self.log.warning(
+            f"{self.label}: T=1 chain {chain_i} lp={lp:.3e} exceeds "
+            f"the plausibility ceiling "
+            f"(|lp| > {self.ceiling:g}); this "
+            "almost always means a model bug (e.g. an "
+            "unbounded logp term), not physics -- since "
+            "PTDE only accepts lp increases, this chain "
+            "will likely keep climbing for the rest of the "
+            "run. See outputs.modes.identify_modes, which "
+            "rejects draws on the same ceiling post-hoc."
+        )
+        self.warned = True
+
+
+# ---------------------------------------------------------------------------
+# Posterior assembly + diagnostics reports
+# ---------------------------------------------------------------------------
+
+
+def assemble_inference_data(
+    stored_raw,
+    stored_lp,
+    actual_draws,
+    n_chains,
+    raw_start,
+    raw_var_names,
+    out_var_names,
+    raw_to_phys_batched,
+    chain_seed_index,
+    label,
+    log,
+):
+    """Convert the stored T=1 raw draws to physical space and build the
+    arviz.InferenceData (posterior + sample_stats.lp + multi-seed attrs).
+
+    Flattens (n_chains, draws) -> (n_total,) per raw variable and runs the
+    batched converter in chunks (bounds memory for large n_params/draws;
+    chunk_size is independent of param count/shape, only of sample count).
+    """
+    log.info(
+        f"{label}: converting {n_chains} x {actual_draws} draws to "
+        f"physical space..."
+    )
+    n_total = n_chains * actual_draws
+    flat_raw = {
+        k: stored_raw[k][:, :actual_draws].reshape(
+            (n_total,) + raw_start[k].shape
+        )
+        for k in raw_var_names
+    }
+    chunk_size = 20000
+    out_chunks = {name: [] for name in out_var_names}
+    for start in range(0, n_total, chunk_size):
+        end = min(start + chunk_size, n_total)
+        chunk_out = raw_to_phys_batched(
+            *[flat_raw[k][start:end] for k in raw_var_names]
+        )
+        for name, val in zip(out_var_names, chunk_out):
+            out_chunks[name].append(np.asarray(val, dtype=float))
+
+    # assemble posterior dict: (n_chains, draws, ...) per variable
+    posterior_dict = {}
+    for name in out_var_names:
+        arr = np.concatenate(out_chunks[name], axis=0)  # (n_total, ...)
+        arr = arr.reshape((n_chains, actual_draws) + arr.shape[1:])
+        # old per-sample path ran every value through atleast_1d then squeezed
+        # a trailing dim-1 for scalar params -- match that convention here.
+        if arr.ndim > 2 and arr.shape[-1] == 1:
+            arr = arr.squeeze(-1)
+        posterior_dict[name] = arr
+
+    idata = az.from_dict(
+        {
+            "posterior": posterior_dict,
+            "sample_stats": {"lp": stored_lp[:, :actual_draws]},
+        }
+    )
+
+    # Multi-seed provenance (P4): record which solved seed each T=1 chain was
+    # started from.  With seeded starts, occupancy weights are initialization
+    # artifacts BY DESIGN unless chains mix, so downstream reporting must be
+    # able to say "chains 0-3 at seed 0, 4-7 at seed 1".
+    # TODO(P4): surface this in outputs/modes.py ModeReport once chains->modes
+    # attribution is wired; for now the per-chain attr is the source of truth.
+    idata.posterior.attrs["chain_seed_index"] = list(chain_seed_index)
+    if len(set(chain_seed_index)) > 1:
+        log.info(
+            f"{label} multi-seed provenance (chain -> seed): "
+            f"{list(chain_seed_index)}"
+        )
+    return idata
+
+
+def log_rung_timing(rung_times, temperatures, label, log):
+    """Per-rung logp wall-time summary (collect_rung_timing diagnostic)."""
+    log.info(f"{label} per-rung logp timing (seconds):")
+    for k, times in enumerate(rung_times):
+        if not times:
+            log.info(f"  rung {k} (T={temperatures[k]:.1f}): no calls")
+            continue
+        arr = np.asarray(times)
+        n_slow = int((arr > 0.1).sum())
+        log.info(
+            f"  rung {k} (T={temperatures[k]:.1f}): n={len(arr)}  "
+            f"median={np.median(arr):.3f}  mean={arr.mean():.3f}  "
+            f"p90={np.percentile(arr, 90):.3f}  max={arr.max():.3f}  "
+            f"n_slow(>0.1s)={n_slow}"
+        )

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -20,88 +20,63 @@ Fork-based parallelism: logp function is inherited by child processes via
 copy-on-write, avoiding the picklability constraint that blocks cloudpickle
 (PyMC's multiprocessing backend) from serializing PyTensor compiled functions.
 
+This is the SYNCHRONOUS dispatch loop: every chain advances in lockstep, so
+each step waits for the slowest of all n_temps*n_chains evaluations. The
+asynchronous variant (exozippy.samplers.ptde_async, sampler.method:
+"ptde_async") removes that barrier and is the recommended default for
+Op-based models; this module remains the reference implementation (fully
+up-to-date DE partner states) for A/B validation. The non-sampling
+scaffolding both share lives in exozippy.samplers._common.
+
 Returns arviz.InferenceData compatible with the EXOZIPPy pipeline.
 """
 
-import gc
 import logging
-import multiprocessing as mp
-import os
 import signal
-import threading
 import time
 
-import arviz as az
 import numpy as np
-import pytensor
-import pytensor.tensor as pt
-from pytensor.graph.replace import vectorize_graph
 
-# Force single-threaded BLAS/OMP in every forked worker.  Without this,
-# numpy (OpenBLAS/MKL) and C extensions (VBBinaryLensing) each spawn their
-# own thread pool, producing n_workers × n_blas_threads threads on a fixed
-# number of physical cores and causing catastrophic scheduler thrash -- and,
-# separately, each with a memory arena sized to the (over-subscribed) thread
-# count, which is what actually blows up h_vmem once forked N-ways.
-# exozippy/__init__.py already sets these before numpy/pytensor/pymc/arviz/
-# jax are imported at all -- the only point where it's effective, since a
-# native thread pool can't be shrunk after the fact by setting os.environ
-# once numpy et al. are already loaded (import exozippy always runs
-# __init__.py first, before this module). This block is redundant there;
-# kept as a guard for any environment that imports ptde.py without ever
-# importing the exozippy package proper.
-for _tvar in (
-    "OMP_NUM_THREADS",
-    "OPENBLAS_NUM_THREADS",
-    "MKL_NUM_THREADS",
-    "BLAS_NUM_THREADS",
-    "NUMEXPR_NUM_THREADS",
-    "VECLIB_MAXIMUM_THREADS",
-):
-    os.environ.setdefault(_tvar, "1")
+from exozippy.samplers import _common, convergence
+from exozippy.samplers._common import (  # noqa: F401
+    DE_JITTER,
+    LpPlausibilityGuard,
+    _eval_logp,
+    _make_starts,
+    _map_logp,
+    _map_logp_timeout,
+    _pick_two,
+    _shutdown_pool,
+    _worker_init,
+    de_proposal,
+)
+
+# Re-exported for compatibility: these historically lived here and are
+# imported by tests and by polish.py. The single owner is _common (shared
+# with ptde_async so the two samplers cannot drift).
+from exozippy.samplers._common import (  # noqa: F401
+    DEFAULT_LP_ABS_MAX as _DEFAULT_LP_ABS_MAX,
+)
 
 logger = logging.getLogger(__name__)
 
-# Shared with outputs.modes.identify_modes: |lp| above this is numerically
-# broken, not a real posterior mode (no realistic dataset's logp reaches
-# 1e12). Imported (not duplicated) so the two ceilings can't drift apart.
-from exozippy.outputs.modes import DEFAULT_LP_ABS_MAX as _DEFAULT_LP_ABS_MAX
-from exozippy.samplers import convergence
-
-# Module-level logp function: set in parent process before Pool.  Fork
-# children inherit the compiled PyTensor function via copy-on-write without
-# pickling.  Proposals (dicts of numpy arrays) are the only IPC payload.
-_PTDE_LOGP_FN = None
-
-# Diagnostic flag (see ptde_sample(collect_rung_timing=...) and
-# hpc_optimization.txt P13): set in the parent before forking, like
-# _PTDE_LOGP_FN, so workers inherit it via copy-on-write. When True,
-# _eval_logp times its own call and returns (lp, elapsed_seconds) instead of
-# a bare float, so the parent can attribute wall time to a rung via
-# prop_map -- resolves whether slow evaluations concentrate in a few
-# chains/rungs or spread across many, which determines how much benefit an
-# async dispatch redesign (P13) would realistically deliver.
-_PTDE_COLLECT_TIMING = False
-
-
-def _eval_logp(proposal):
-    """Worker: evaluate logp for one raw-space proposal dict.
-
-    Returns a bare float normally. When _PTDE_COLLECT_TIMING is set, returns
-    (lp, elapsed_seconds) instead (diagnostic mode; see module docstring
-    above _PTDE_COLLECT_TIMING).
-    """
-    if _PTDE_COLLECT_TIMING:
-        t0 = time.perf_counter()
-        try:
-            lp = float(_PTDE_LOGP_FN(proposal))
-        except Exception:
-            lp = -np.inf
-        return lp, time.perf_counter() - t0
-    try:
-        return float(_PTDE_LOGP_FN(proposal))
-    except Exception:
-        return -np.inf
+# The chain-initialization probe lives in exozippy.whitening now (it is also
+# the engine behind the data-driven whitening rescale done at model setup);
+# PTDE re-probes the already-whitened model, where every scale is ~1, so the
+# default (narrow) dynamic range is the right one here.  The old private
+# names are re-exported for compatibility.
+from exozippy.whitening import (
+    _PROBE_FLAT_SCALE,
+)
+from exozippy.whitening import (  # noqa: E402
+    PROBE_TARGET_DELTA as _PROBE_TARGET_DELTA,
+)
+from exozippy.whitening import (
+    probe_scales as _probe_scales,
+)
+from exozippy.whitening import (
+    probe_step_1d as _probe_step_1d,
+)
 
 
 def _geometric_ladder(n_temps, T_max):
@@ -171,25 +146,6 @@ def ladder_health_report(temperatures, n_swap_accept, n_swap_propose):
     return lam
 
 
-# The chain-initialization probe lives in exozippy.whitening now (it is also
-# the engine behind the data-driven whitening rescale done at model setup);
-# PTDE re-probes the already-whitened model, where every scale is ~1, so the
-# default (narrow) dynamic range is the right one here.  The old private
-# names are re-exported for compatibility.
-from exozippy.whitening import (
-    _PROBE_FLAT_SCALE,
-)
-from exozippy.whitening import (  # noqa: E402
-    PROBE_TARGET_DELTA as _PROBE_TARGET_DELTA,
-)
-from exozippy.whitening import (
-    probe_scales as _probe_scales,
-)
-from exozippy.whitening import (
-    probe_step_1d as _probe_step_1d,
-)
-
-
 def polish_seed_starts(
     raw_starts,
     logp_fn,
@@ -257,9 +213,9 @@ def polish_seed_starts(
                 prop = {
                     k: pop[i][k]
                     + gamma * (pop[j1][k] - pop[j2][k])
-                    + 1e-4 * scales[k] * rng.standard_normal(
-                        np.shape(pop[i][k])
-                    )
+                    + 1e-4
+                    * scales[k]
+                    * rng.standard_normal(np.shape(pop[i][k]))
                     for k in keys
                 }
                 lp = float(logp_fn(prop))
@@ -277,274 +233,6 @@ def polish_seed_starts(
     return polished, dlps
 
 
-def _make_starts(
-    n_chains,
-    raw_starts,
-    logp_fn,
-    rng,
-    seed_indices=None,
-    system=None,
-    raw_scales=None,
-    polish_steps=0,
-):
-    """Generate n_chains starting points near one or more seeds (P4).
-
-    `raw_starts` is a single raw-start dict (legacy) or a LIST of K raw-start
-    dicts (multi-seed sampling). Chains are assigned to seeds round-robin
-    (chain j -> seed j % K); the first chain of each seed group starts exactly
-    at that seed's solved point, the rest jitter around their seed's center.
-
-    Mirrors EXOFASTv2: scatter chains by factor x scale where
-    factor = min(sqrt(500/n_params), 3), accept any finite logp (no proximity
-    threshold), and apply exponential decay only when proposals hit hard prior
-    boundaries (lp=-inf).  Raises RuntimeError if a chain cannot be initialized
-    within max_iter retries.
-
-    The scatter is delegated to `system.jitter_raw_start` when the system
-    provides it, which draws in physical space from a Gaussian truncated to
-    each parameter's bounds.  Scattering in raw space instead saturates the
-    logit transform and starts a large fraction of chains pinned at the bounds
-    (31.5% within 1% of a bound for a parameter whose logp is flat out to them,
-    against uniform's 2.0%); see System.jitter_raw_start.  Systems without that
-    method (minimal test stubs) fall back to the historical raw-space jitter.
-
-    ``raw_scales`` (optional) is the per-element dispersion scale in current
-    raw units, as measured by the startup whitening pass (run.py passes
-    whiten_report["raw_scales"]).  When given, the probe is skipped entirely
-    -- the model was just whitened against the very same start, so re-probing
-    would re-derive ~1.0 everywhere at n_elements x O(10) logp calls.  When
-    absent (measure_scales: false, or standalone use), the probe runs as
-    before.
-
-    Returns (starts, chain_seed_index) where chain_seed_index[j] is the original
-    seed index that chain j was drawn from (for trace-attr provenance).
-    """
-    if isinstance(raw_starts, dict):
-        raw_starts = [raw_starts]
-    K = len(raw_starts)
-    if seed_indices is None:
-        seed_indices = list(range(K))
-
-    if raw_scales is not None:
-        map_lp = float(logp_fn(raw_starts[0]))
-        scales = {
-            k: np.asarray(
-                raw_scales.get(k, np.ones_like(np.asarray(v, dtype=float))),
-                dtype=float,
-            ).reshape(np.shape(v))
-            for k, v in raw_starts[0].items()
-        }
-    else:
-        # Probe scales once from seed 0 (the canonical MAP-ish start); the same
-        # per-parameter jitter scale is reused around every seed.
-        map_lp, scales = _probe_scales(raw_starts[0], logp_fn)
-    n_params = sum(v.size for v in raw_starts[0].values())
-    factor = min(np.sqrt(500.0 / max(n_params, 1)), 3.0)
-    max_iter = 1000
-
-    # Optional per-seed T=1 DE polish (run.py gates this on seed
-    # provenance: solution-estimate seeds only, never posterior-draw
-    # seed sets, which are already at their basin's equilibrium).
-    if polish_steps and int(polish_steps) > 0:
-        raw_starts, _dlps = polish_seed_starts(
-            raw_starts, logp_fn, rng, scales, n_steps=int(polish_steps)
-        )
-        map_lp = float(logp_fn(raw_starts[0]))
-
-    _jitter = (
-        getattr(system, "jitter_raw_start", None)
-        if system is not None
-        else None
-    )
-    logger.info(
-        f"PTDE init: MAP lp={map_lp:.1f}, n_params={n_params}, factor={factor:.2f}, "
-        f"jitter={'physical (truncated)' if _jitter else 'raw (fallback)'}"
-        + (
-            f", {K} seeds (round-robin over {n_chains} chains)"
-            if K > 1
-            else ""
-        )
-    )
-
-    starts = []
-    chain_seed_index = []
-    seed_seen = set()
-    # Cap the number of chains that start EXACTLY at a seed. With K ~
-    # n_chains (a params.2-style posterior-draw seed set), every chain
-    # would otherwise start at a previous-run posterior draw with zero
-    # jitter -- and since the DE population's spread IS the proposal
-    # generator, the restart could then never explore beyond the previous
-    # posterior, entrenching whatever that run missed. At least half the
-    # chains always get the factor-scaled jitter.
-    max_exact = max(1, n_chains // 2)
-    n_exact = 0
-    if K > max_exact:
-        logger.info(
-            f"PTDE init: {K} seeds > {max_exact} exact-start budget "
-            f"(half the {n_chains} chains); the rest start jittered around "
-            f"their seed to keep restart overdispersion."
-        )
-    for j in range(n_chains):
-        s = j % K
-        center = raw_starts[s]
-        # First chain of each seed group starts exactly at the solved seed
-        # (up to the overdispersion budget above).
-        if s not in seed_seen and n_exact < max_exact:
-            lp0 = float(logp_fn(center))
-            if np.isfinite(lp0):
-                starts.append({k: v.copy() for k, v in center.items()})
-                chain_seed_index.append(seed_indices[s])
-                seed_seen.add(s)
-                n_exact += 1
-                logger.debug(
-                    f"PTDE init chain {j}: exact seed {seed_indices[s]} "
-                    f"(lp={lp0:.1f})"
-                )
-                continue
-            logger.warning(
-                f"PTDE init: seed {seed_indices[s]} exact start has non-finite "
-                f"lp; jittering to find a finite start."
-            )
-        for niter in range(max_iter):
-            eff = factor / np.exp(niter / 1000.0)
-            if _jitter is not None:
-                prop = _jitter(center, scales, eff, rng)
-            else:
-                prop = {
-                    k: v + eff * scales[k] * rng.standard_normal(v.shape)
-                    for k, v in center.items()
-                }
-            lp = float(logp_fn(prop))
-            if np.isfinite(lp):
-                starts.append(prop)
-                chain_seed_index.append(seed_indices[s])
-                seed_seen.add(s)
-                logger.debug(
-                    f"PTDE init chain {j} (seed {seed_indices[s]}): accepted after "
-                    f"{niter} retries (lp={lp:.1f}, dlp={lp - map_lp:.1f})"
-                )
-                break
-            if niter % 200 == 0 and niter > 0:
-                logger.warning(
-                    f"PTDE init chain {j}: {niter} retries still seeking finite lp "
-                    f"(eff={eff:.3g})"
-                )
-        else:
-            raise RuntimeError(
-                f"PTDE chain {j} initialization failed after {max_iter} retries. "
-                f"Check initval/bounds in your params.yaml -- a parameter may be "
-                f"starting outside its prior bounds."
-            )
-    return starts, chain_seed_index
-
-
-def _worker_init():
-    """Pool worker: ignore SIGINT/SIGTERM so only the parent handles graceful
-    stop. A batch scheduler typically signals the whole process group, and a
-    worker that died mid pool.map() would break the parent's current step
-    (BrokenProcessPool) instead of letting it finish and wrap up cleanly."""
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-    signal.signal(signal.SIGTERM, signal.SIG_IGN)
-
-
-def _shutdown_pool(pool, grace=1.0):
-    """terminate() a Pool, escalating to SIGKILL for workers that outlive the
-    grace period.
-
-    _worker_init has the workers ignore SIGTERM (so a batch scheduler signalling
-    the whole process group cannot break the parent mid-step). But pool.terminate()
-    kills workers *by sending SIGTERM*, then joins them -- so a worker stuck in a
-    pathological logp evaluation ignores the terminate and the join blocks forever.
-    That is the "recycling worker pool" hang: a timed-out worker is exactly the
-    one that can never be reaped this way.
-
-    The SIGKILL is issued from a watchdog thread rather than up front, because it
-    must land only AFTER terminate() is past its _help_stuff_finish step. That
-    step drains inqueue while holding inqueue._rlock; a worker blocked in
-    inqueue.get() holds that same lock, so SIGKILLing it before terminate()
-    reaches _help_stuff_finish wedges the lock and deadlocks terminate() even
-    earlier. Waiting `grace` seconds lets a well-behaved terminate() finish
-    untouched (the escalation never fires), and only forces the issue when a
-    worker is genuinely wedged.
-    """
-    done = threading.Event()
-
-    def _reaper():
-        if done.wait(grace):
-            return  # terminate()/join() completed cleanly; no escalation needed
-        for p in pool._pool:
-            if p.exitcode is None:
-                try:
-                    os.kill(p.pid, signal.SIGKILL)
-                except (ProcessLookupError, OSError):
-                    pass
-
-    watchdog = threading.Thread(target=_reaper, daemon=True)
-    watchdog.start()
-    try:
-        pool.terminate()
-        pool.join()
-    finally:
-        done.set()
-        watchdog.join()
-
-
-def _map_logp(pool, proposals):
-    if pool is None:
-        return [_eval_logp(p) for p in proposals]
-    return pool.map(_eval_logp, proposals)
-
-
-def _map_logp_timeout(pool, proposals, timeout):
-    """Evaluate logps with a per-call wall-clock timeout.
-
-    Each proposal individually gets up to `timeout` seconds (not a deadline
-    shared across the whole batch — a slow-but-legitimate early proposal must
-    not eat into the budget of proposals evaluated later in the same step).
-    A proposal that doesn't complete in time receives -inf, so the caller's
-    normal Metropolis accept/reject logic rejects it automatically.
-
-    A logp evaluation can call into external/compiled code that occasionally
-    enters a genuine infinite loop for some pathological parameter
-    combination. When that happens the worker process that drew the
-    timed-out proposal is stuck forever and never becomes available again;
-    this function has no way to kill a single worker without tearing down
-    the whole Pool, so the caller is responsible for recycling `pool`
-    whenever `timed_out` is non-empty. Without that, a long run slowly
-    bleeds workers, one per hang, until the pool is exhausted.
-
-    With no pool (single-core / serial mode), there is no subprocess to time
-    out, so `timeout` cannot be enforced -- proposals run to completion as
-    before. The caller should warn about this once at startup if cores<=1.
-
-    Returns (lps, timed_out) where timed_out is a list of indices into
-    `proposals`.
-    """
-    if pool is None:
-        return [_eval_logp(p) for p in proposals], []
-
-    async_results = [pool.apply_async(_eval_logp, (p,)) for p in proposals]
-    lps = []
-    timed_out = []
-    # Keep the timeout sentinel the same shape _eval_logp returns (a bare
-    # float, or (lp, elapsed) in collect_rung_timing diagnostic mode) so
-    # every entry in `lps` is uniformly typed for the caller to unpack.
-    timeout_val = (-np.inf, timeout) if _PTDE_COLLECT_TIMING else -np.inf
-    for idx, r in enumerate(async_results):
-        try:
-            lps.append(r.get(timeout=timeout))
-        except mp.TimeoutError:
-            lps.append(timeout_val)
-            timed_out.append(idx)
-    return lps, timed_out
-
-
-def _pick_two(rng, n, exclude):
-    """Pick two distinct indices from [0, n) excluding `exclude`."""
-    idx = rng.choice(n - 1, 2, replace=False)
-    return tuple(int(i + (1 if i >= exclude else 0)) for i in idx)
-
-
 # ---------------------------------------------------------------------------
 # Deterministic Even-Odd (DEO) swap schedule + round-trip diagnostics
 # (Syed et al. 2022, JRSS-B, "Non-reversible parallel tempering"; reference
@@ -559,7 +247,7 @@ def _pick_two(rng, n, exclude):
 # ---------------------------------------------------------------------------
 
 
-def _deo_pairs(round_idx, n_temps, active_rungs=None):
+def _deo_pairs(round_idx, n_temps):
     """Adjacent rung pairs attempted simultaneously in one DEO swap round.
 
     Even rounds (round_idx even) attempt (0,1),(2,3),(4,5),...; odd rounds
@@ -567,17 +255,17 @@ def _deo_pairs(round_idx, n_temps, active_rungs=None):
     rung appears twice), so all can be attempted at once, and the alternating
     offset is what makes the index process non-reversible.
 
-    active_rungs : iterable[int] | None -- when given, any pair touching a
-        rung not in this set (e.g. one thinned out this round in ptde.py) is
-        dropped, rather than reverting to a random pairing, which would break
-        the non-reversible index flow. None -> every pair is returned.
+    Every pair is always returned -- in particular, rung thinning must NOT
+    filter this list. Swaps only exchange already-cached (state, logp) pairs
+    and need no fresh evaluation, and because the DEO round parity is
+    deterministically coupled to the step counter, filtering by the thinning
+    activity pattern permanently removed specific pairs from the schedule
+    (e.g. rung_thin_factor=2, swap_interval=1, n_temps=8, thin_start=4 never
+    attempted (3,4) or (5,6)), disconnecting the ladder
+    (notes/code_review_20260808.txt bug 1.14).
     """
     start = 0 if round_idx % 2 == 0 else 1
-    pairs = [(k, k + 1) for k in range(start, n_temps - 1, 2)]
-    if active_rungs is not None:
-        active = set(active_rungs)
-        pairs = [(a, b) for (a, b) in pairs if a in active and b in active]
-    return pairs
+    return [(k, k + 1) for k in range(start, n_temps - 1, 2)]
 
 
 def _deo_pair_sequence(n_temps):
@@ -769,10 +457,10 @@ def ptde_sample(
     raw_starts=None,
     seed_indices=None,
     raw_scales=None,
-    seed_polish_steps=0,
     gamma=None,
     target_accept=0.20,
     adapt_gamma=True,
+    de_jitter=DE_JITTER,
     swap_interval=1,
     swap_schedule="deo",
     target_swap_rate=None,
@@ -815,6 +503,12 @@ def ptde_sample(
     gamma : float   — DE proposal scale; None → 2.38 / sqrt(2 × n_params)
     target_accept : float  — T=1 acceptance rate target for gamma adaptation (default 0.20)
     adapt_gamma : bool     — scale gamma toward target_accept during tune (default True)
+    de_jitter : float  — epsilon term of the ter Braak 2006 DE move, in raw
+               (whitened) units where every scale is ~1 (default
+               _common.DE_JITTER = 1e-4; 0 disables). Without it, sampling
+               is confined to the affine hull of the initial T=1 starts,
+               which silently truncates the posterior when
+               n_chains <= n_params.
     swap_interval : int  — attempt temperature swaps every N steps
     swap_schedule : {"deo", "random"}  — "deo" (default) uses the
                Deterministic Even-Odd non-reversible schedule (Syed et al.
@@ -884,11 +578,7 @@ def ptde_sample(
     -------
     arviz.InferenceData with posterior and sample_stats["lp"] from T=1 chains.
     """
-    global _PTDE_LOGP_FN, _PTDE_COLLECT_TIMING
-    _PTDE_COLLECT_TIMING = collect_rung_timing
-    if lp_plausibility_ceiling is None:
-        lp_plausibility_ceiling = _DEFAULT_LP_ABS_MAX
-    warned_implausible_lp = False
+    lp_guard = LpPlausibilityGuard(lp_plausibility_ceiling, "PTDE", logger)
 
     if swap_schedule not in ("deo", "random"):
         raise ValueError(
@@ -916,48 +606,16 @@ def ptde_sample(
             f"(of {n_temps}) propose every {_rung_thin_factor} steps"
         )
 
-    # compile logp ONCE; store in module global BEFORE forking workers
+    # compile logp ONCE; install in _common BEFORE forking workers so fork
+    # children inherit it (copy-on-write; see _common.set_worker_globals)
     logp_fn = model.compile_logp()
-    _PTDE_LOGP_FN = logp_fn
+    _common.set_worker_globals(logp_fn, collect_rung_timing)
 
-    # compile raw→physical function ONCE for the final output conversion.
-    # raw_to_phys is the single-sample form, kept for the (rare) eval_timeout
-    # diagnostic log path, which converts exactly one proposal at a time.
-    # raw_to_phys_batched vectorizes the same graph over an extra leading
-    # sample axis (pytensor's vectorize_graph -- adds the batch dim to every
-    # op in the graph rather than looping in Python) and is what the
-    # ensemble-start-plot and final posterior conversions use, since those
-    # can be tens of thousands to millions of samples: the free_RVs +
-    # deterministics graph is pure elementwise/indexing math (each
-    # Parameter's physical-unit conversion; verified empirically that no
-    # deterministic here touches the magnification Ops, which only feed the
-    # likelihood), so it vectorizes cleanly and cuts what was a
-    # Python-level per-sample loop (dominant cost: interpreter + pytensor
-    # call overhead, not the underlying math) down to a handful of batched
-    # calls. See hpc_optimization.txt PROMPT 7.
-    output_vars = model.free_RVs + model.deterministics
-    raw_to_phys = pytensor.function(
-        inputs=model.free_RVs,
-        outputs=output_vars,
-        on_unused_input="ignore",
+    # compile raw -> physical conversions ONCE (single-sample and batched;
+    # see _common.compile_conversions for the rationale).
+    raw_to_phys, raw_to_phys_batched, raw_var_names, out_var_names = (
+        _common.compile_conversions(model)
     )
-    _batched_inputs = [
-        pt.tensor(
-            name=f"batched_{v.name}",
-            dtype=v.type.dtype,
-            shape=(None,) + v.type.shape,
-        )
-        for v in model.free_RVs
-    ]
-    raw_to_phys_batched = pytensor.function(
-        inputs=_batched_inputs,
-        outputs=vectorize_graph(
-            output_vars, replace=dict(zip(model.free_RVs, _batched_inputs))
-        ),
-        on_unused_input="ignore",
-    )
-    raw_var_names = [v.name for v in model.free_RVs]  # ordered input names
-    out_var_names = [v.name for v in output_vars]  # ordered output names
 
     if n_chains is None:
         n_chains = 2 * n_params  # standard DE minimum for good mixing
@@ -966,56 +624,32 @@ def ptde_sample(
     logger.info(
         f"PTDE: {n_params} params, {n_chains} chains/rung, γ={gamma:.4f}"
     )
+    _common.warn_if_population_degenerate(n_chains, n_params, "PTDE", logger)
 
     # initialize populations
-    if initvals is not None:
-        assert len(initvals) == n_chains, "len(initvals) must equal n_chains"
-        t1_starts = initvals
-        chain_seed_index = [0] * n_chains
-    else:
-        # Multi-seed starts (P4): round-robin the chain population across every
-        # solved seed. raw_starts/seed_indices come from run.py when available;
-        # else fall back to system.get_raw_starts, and further to a bare
-        # get_raw_start (single start) for minimal test/system stubs that don't
-        # implement get_raw_starts at all.
-        if raw_starts is None:
-            if hasattr(system, "get_raw_starts"):
-                raw_starts, seed_indices = system.get_raw_starts(model)
-            else:
-                raw_starts, seed_indices = [raw_start], [0]
-        t1_starts, chain_seed_index = _make_starts(
-            n_chains,
-            raw_starts,
-            logp_fn,
-            rng,
-            seed_indices,
-            system=system,
-            raw_scales=raw_scales,
-            polish_steps=seed_polish_steps,
-        )
+    t1_starts, chain_seed_index = _common.resolve_start_population(
+        model,
+        system,
+        n_chains,
+        logp_fn,
+        rng,
+        raw_start,
+        initvals=initvals,
+        raw_starts=raw_starts,
+        seed_indices=seed_indices,
+        raw_scales=raw_scales,
+    )
 
     # ensemble start plots (T=1 starts only; raw→physical via the batched fn)
-    if plot_prefix is not None:
-        logger.info("Generating ensemble start plots...")
-        batched_vals = raw_to_phys_batched(
-            *[
-                np.stack([s[k] for s in t1_starts], axis=0)
-                for k in raw_var_names
-            ]
-        )
-        internal_starts = [
-            {
-                name: np.asarray(val)[i]
-                for name, val in zip(out_var_names, batched_vals)
-            }
-            for i in range(len(t1_starts))
-        ]
-        for comp in system.active_components.values():
-            comp.plot(
-                system,
-                internal_starts,
-                filename_prefix=plot_prefix + "_start_ensemble",
-            )
+    _common.plot_start_ensemble(
+        system,
+        t1_starts,
+        raw_to_phys_batched,
+        raw_var_names,
+        out_var_names,
+        plot_prefix,
+        logger,
+    )
 
     # Replicate T=1 starts to all rungs; hotter chains spread quickly during tune
     populations = [
@@ -1026,35 +660,19 @@ def ptde_sample(
         for _ in range(n_temps)
     ]
 
-    # start pool AFTER _PTDE_LOGP_FN is set so fork children inherit it
+    # start pool AFTER set_worker_globals so fork children inherit the logp fn
     total_proposals = n_temps * n_chains
-    phys_cores = mp.cpu_count()
-    if cores is None:
-        # Fallback if called directly (not via run.py): same 75% formula
-        cores = max(1, min(int(phys_cores * 0.75), phys_cores - 1))
-    actual_cores = min(cores, total_proposals)
-    if cores > phys_cores:
-        logger.warning(
-            f"PTDE: cores={cores} exceeds physical core count ({phys_cores}); "
-            f"over-subscription will slow sampling via context switching."
-        )
+    pool, actual_cores = _common.create_pool(
+        cores, total_proposals, "PTDE", logger
+    )
     logger.info(
         f"PTDE: {n_temps} rungs × {n_chains} chains = {total_proposals} proposals/step, "
         f"{actual_cores} cores  "
         f"T=[{', '.join(f'{t:.1f}' for t in temperatures)}]"
     )
-    pool = (
-        mp.get_context("fork").Pool(actual_cores, initializer=_worker_init)
-        if actual_cores > 1
-        else None
+    _common.warn_serial_eval_timeout(
+        eval_timeout, pool, actual_cores, "PTDE", logger
     )
-
-    if eval_timeout is not None and pool is None:
-        logger.warning(
-            f"PTDE: eval_timeout={eval_timeout:.0f}s has no effect with a single "
-            f"core (cores={actual_cores}) — there is no worker process to enforce "
-            f"a wall-clock timeout against a hung logp call."
-        )
 
     # Early-stop state: mutable list so the closure can write back to us.
     stop_requested = [False]
@@ -1086,7 +704,7 @@ def ptde_sample(
         nonlocal pool
         if eval_timeout is None:
             raw = _map_logp(pool, proposals)
-            if _PTDE_COLLECT_TIMING:
+            if collect_rung_timing:
                 lps = [r[0] for r in raw]
                 if rungs is not None:
                     for r, k in zip(raw, rungs):
@@ -1098,16 +716,9 @@ def ptde_sample(
         if timed_out:
             n_eval_timeouts[0] += len(timed_out)
             for idx in timed_out:
-                raw_vals = [proposals[idx][k] for k in raw_var_names]
-                phys_vals = raw_to_phys(*raw_vals)
-                phys_params = {
-                    name: np.asarray(val).tolist()
-                    for name, val in zip(out_var_names, phys_vals)
-                }
-                raw_params = {
-                    k: np.asarray(v).tolist()
-                    for k, v in proposals[idx].items()
-                }
+                phys_params, raw_params = _common.describe_proposal(
+                    proposals[idx], raw_to_phys, raw_var_names, out_var_names
+                )
                 who = (
                     index_labels[idx]
                     if index_labels is not None
@@ -1125,18 +736,8 @@ def ptde_sample(
                     f"timeout(s) at {step_label} — a hung worker never "
                     f"rejoins the pool on its own."
                 )
-                _shutdown_pool(pool)
-                # Terminated Pools sit in reference cycles (handler threads,
-                # worker sentinels, queue pipes) that only the cyclic GC
-                # frees; without an explicit collect each recycle leaks
-                # ~2 fds per worker until the process hits EMFILE
-                # ("Too many open files") after enough timeouts.
-                pool = None
-                gc.collect()
-                pool = mp.get_context("fork").Pool(
-                    actual_cores, initializer=_worker_init
-                )
-        if _PTDE_COLLECT_TIMING:
+                pool = _common.recycle_pool(pool, actual_cores)
+        if collect_rung_timing:
             if rungs is not None:
                 for r, k in zip(lps, rungs):
                     rung_times[k].append(r[1])
@@ -1158,21 +759,7 @@ def ptde_sample(
             "current step (send the signal again to abort immediately)"
         )
 
-    # SIGTERM gets the same handler as SIGINT so a batch scheduler (e.g.
-    # `qsig -s SIGTERM <job_id>` / `kill -TERM <pid>`) can request the same
-    # graceful stop-after-this-step behavior as a Ctrl+C at a terminal,
-    # instead of Python's default SIGTERM action (immediate termination,
-    # discarding whatever draws were already collected).
-    old_sigint = signal.signal(signal.SIGINT, _stop_handler)
-    old_sigterm = signal.signal(signal.SIGTERM, _stop_handler)
-    # Windows delivers the GUI's stop request as CTRL_BREAK_EVENT, which
-    # arrives here as SIGBREAK rather than SIGINT (see gui/runner.py).
-    # Without this the request is received and silently ignored.
-    old_sigbreak = (
-        signal.signal(signal.SIGBREAK, _stop_handler)
-        if hasattr(signal, "SIGBREAK")
-        else None
-    )
+    _sig_token = _common.install_stop_handlers(_stop_handler)
     try:
         # initial logp evaluations
         flat_starts = [
@@ -1236,13 +823,11 @@ def ptde_sample(
             ):
                 pop_k = populations[k]
                 for i in range(n_chains):
-                    j1, j2 = _pick_two(rng, n_chains, i)
-                    prop = {
-                        key: pop_k[i][key]
-                        + gamma * (pop_k[j1][key] - pop_k[j2][key])
-                        for key in model_keys
-                    }
-                    props_flat.append(prop)
+                    props_flat.append(
+                        de_proposal(
+                            rng, pop_k, i, gamma, model_keys, jitter=de_jitter
+                        )
+                    )
                     prop_map.append((k, i))
             _t_build = time.time()
 
@@ -1267,51 +852,21 @@ def ptde_sample(
                     populations[k][i] = props_flat[idx]
                     logps[k][i] = lp_new
                     n_accept[k] += 1
-                    # A T=1 chain's lp this large always indicates a model
-                    # bug (an unbounded/uncancelled logp term), never real
-                    # physics -- no finite dataset's logp reaches 1e12. PTDE
-                    # accepts on lp_new > lp_old, so such a bug is a ratchet:
-                    # once a chain's lp is inflated this way it can only
-                    # climb further, wasting the rest of the run (see
-                    # examples/DC2018_128, a real occurrence of exactly this
-                    # failure mode). Warn once so it's noticed immediately
-                    # rather than discovered post-hoc via identify_modes.
-                    if (
-                        k == 0
-                        and not warned_implausible_lp
-                        and abs(lp_new) > lp_plausibility_ceiling
-                    ):
-                        logger.warning(
-                            f"PTDE: T=1 chain {i} lp={lp_new:.3e} exceeds "
-                            f"the plausibility ceiling "
-                            f"(|lp| > {lp_plausibility_ceiling:g}); this "
-                            "almost always means a model bug (e.g. an "
-                            "unbounded logp term), not physics -- since "
-                            "PTDE only accepts lp increases, this chain "
-                            "will likely keep climbing for the rest of the "
-                            "run. See outputs.modes.identify_modes, which "
-                            "rejects draws on the same ceiling post-hoc."
-                        )
-                        warned_implausible_lp = True
+                    # Runaway-lp early detection (see LpPlausibilityGuard).
+                    if k == 0:
+                        lp_guard.check(i, lp_new)
 
             # 4. temperature swaps. DEO (deterministic even-odd) schedule by
             #    default -- see _deo_pairs / _record_round_trips. Each pairwise
             #    swap below is the exact same Metropolis test as the legacy
             #    random schedule, so PT invariance is untouched; only WHICH
-            #    pairs (and how many) are attempted changes.
+            #    pairs (and how many) are attempted changes. Swaps are never
+            #    filtered by rung thinning: they exchange cached (state, logp)
+            #    pairs and need no fresh evaluation (bug 1.14 -- filtering by
+            #    the thinning pattern permanently disconnected the ladder).
             if n_temps > 1 and (step + 1) % swap_interval == 0:
                 if swap_schedule == "deo":
-                    active = _active_rungs(
-                        step, n_temps, _rung_thin_start, _rung_thin_factor
-                    )
-                    deo_pairs = _deo_pairs(swap_round, n_temps, active)
-                    if _rung_thin_factor > 1 and len(deo_pairs) < len(
-                        _deo_pairs(swap_round, n_temps)
-                    ):
-                        logger.debug(
-                            "PTDE DEO: some swap pairs skipped this round "
-                            "(rung thinned inactive)"
-                        )
+                    deo_pairs = _deo_pairs(swap_round, n_temps)
                     # Fresh random chain pairing each round: rung-k chain i is
                     # swapped with rung-(k+1) chain perm[i]. Any fixed or
                     # randomized pairing is valid (each pairwise swap satisfies
@@ -1515,10 +1070,7 @@ def ptde_sample(
                     break
 
     finally:
-        signal.signal(signal.SIGINT, old_sigint)
-        signal.signal(signal.SIGTERM, old_sigterm)
-        if old_sigbreak is not None:
-            signal.signal(signal.SIGBREAK, old_sigbreak)
+        _common.restore_stop_handlers(_sig_token)
         if pool is not None:
             pool.close()
             pool.join()
@@ -1533,59 +1085,19 @@ def ptde_sample(
             f"PTDE: early stop — {actual_draws}/{draws} draws collected"
         )
 
-    logger.info(
-        f"PTDE: converting {n_chains} × {actual_draws} draws to physical space…"
+    idata = _common.assemble_inference_data(
+        stored_raw,
+        stored_lp,
+        actual_draws,
+        n_chains,
+        raw_start,
+        raw_var_names,
+        out_var_names,
+        raw_to_phys_batched,
+        chain_seed_index,
+        "PTDE",
+        logger,
     )
-
-    # Flatten (n_chains, draws) -> (n_total,) per raw variable and run the
-    # batched converter in chunks (bounds memory for large n_params/draws;
-    # chunk_size is independent of param count/shape, only of sample count).
-    n_total = n_chains * actual_draws
-    flat_raw = {
-        k: stored_raw[k][:, :actual_draws].reshape(
-            (n_total,) + raw_start[k].shape
-        )
-        for k in raw_var_names
-    }
-    chunk_size = 20000
-    out_chunks = {name: [] for name in out_var_names}
-    for start in range(0, n_total, chunk_size):
-        end = min(start + chunk_size, n_total)
-        chunk_out = raw_to_phys_batched(
-            *[flat_raw[k][start:end] for k in raw_var_names]
-        )
-        for name, val in zip(out_var_names, chunk_out):
-            out_chunks[name].append(np.asarray(val, dtype=float))
-
-    # assemble posterior dict: (n_chains, draws, ...) per variable
-    posterior_dict = {}
-    for name in out_var_names:
-        arr = np.concatenate(out_chunks[name], axis=0)  # (n_total, ...)
-        arr = arr.reshape((n_chains, actual_draws) + arr.shape[1:])
-        # old per-sample path ran every value through atleast_1d then squeezed
-        # a trailing dim-1 for scalar params -- match that convention here.
-        if arr.ndim > 2 and arr.shape[-1] == 1:
-            arr = arr.squeeze(-1)
-        posterior_dict[name] = arr
-
-    idata = az.from_dict(
-        {
-            "posterior": posterior_dict,
-            "sample_stats": {"lp": stored_lp[:, :actual_draws]},
-        }
-    )
-
-    # Multi-seed provenance (P4): record which solved seed each T=1 chain was
-    # started from.  With seeded starts, occupancy weights are initialization
-    # artifacts BY DESIGN unless chains mix, so downstream reporting must be
-    # able to say "chains 0-3 at seed 0, 4-7 at seed 1".
-    # TODO(P4): surface this in outputs/modes.py ModeReport once chains->modes
-    # attribution is wired; for now the per-chain attr is the source of truth.
-    idata.posterior.attrs["chain_seed_index"] = list(chain_seed_index)
-    if len(set(chain_seed_index)) > 1:
-        logger.info(
-            f"PTDE multi-seed provenance (chain -> seed): {list(chain_seed_index)}"
-        )
 
     ar_T1 = float(n_accept[0] / max(n_propose[0], 1))
     sr_all = n_swap_accept / np.maximum(n_swap_propose, 1)
@@ -1610,19 +1122,6 @@ def ptde_sample(
     ladder_health_report(temperatures, n_swap_accept, n_swap_propose)
 
     if collect_rung_timing:
-        logger.info("PTDE per-rung logp timing (seconds):")
-        for k in range(n_temps):
-            times = rung_times[k]
-            if not times:
-                logger.info(f"  rung {k} (T={temperatures[k]:.1f}): no calls")
-                continue
-            arr = np.asarray(times)
-            n_slow = int((arr > 0.1).sum())
-            logger.info(
-                f"  rung {k} (T={temperatures[k]:.1f}): n={len(arr)}  "
-                f"median={np.median(arr):.3f}  mean={arr.mean():.3f}  "
-                f"p90={np.percentile(arr, 90):.3f}  max={arr.max():.3f}  "
-                f"n_slow(>0.1s)={n_slow}"
-            )
+        _common.log_rung_timing(rung_times, temperatures, "PTDE", logger)
 
     return idata

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -1,10 +1,12 @@
 """
 Asynchronous (non-blocking) Parallel Tempering + Differential Evolution sampler.
 
-EXPERIMENTAL -- see hpc_optimization.txt PROMPT 13. Kept as a fully separate
-sampler module (YAML: sampler.method: "ptde_async") so the validated
-synchronous PTDE in ptde.py is never modified or put at risk. Pick this
-sampler explicitly; ptde.py's "ptde" remains the default/recommended choice.
+The production default for Op-based (non-differentiable) models (YAML:
+sampler.method: "ptde_async"; see hpc_optimization.txt PROMPT 13). Kept as a
+separate sampler module so the synchronous PTDE in ptde.py -- the reference
+implementation with fully up-to-date DE partner states -- stays available for
+A/B validation. The non-sampling scaffolding both share lives in
+exozippy.samplers._common.
 
 MOTIVATION: ptde.py's synchronous design must wait for the SLOWEST of all
 n_temps*n_chains proposals before ANY chain can advance to its next step,
@@ -31,12 +33,18 @@ balance argument relative to the synchronous version in ptde.py, which always
 uses each rung's fully up-to-date population. Swap moves are NOT affected by
 this staleness concern -- logp(x) does not depend on when x was last
 computed, only on x itself, and a swap always compares one (state, logp) pair
-against another self-consistent pair -- so swaps here remain as rigorous as
-in ptde.py. Before trusting a production posterior from this sampler,
-validate against a synchronous PTDE run on the same model (see
+against another self-consistent pair. A swap CAN, however, replace a slot's
+state while that slot's own DE proposal is in flight; accepting/rejecting
+that proposal against the swapped-in state would violate detailed balance,
+so every submission is stamped with its slot's state generation and a result
+whose generation no longer matches (the state was swapped away underneath
+it) is DISCARDED without an accept/reject transition and the slot resubmits
+from its new state (the discard decision depends only on the swap event,
+never on the proposal's logp, so it is a valid "do nothing" kernel mixture).
+Before trusting a production posterior from this sampler on a new class of
+model, validate against a synchronous PTDE run on the same model (see
 tests/test_ptde_async.py for the toy-Gaussian recovery check this module
-ships with, and consider running both samplers on your real model and
-comparing posterior means/std/ESS before relying on ptde_async alone).
+ships with).
 
 Storage differs from ptde.py because chains are no longer synchronized on a
 shared step counter: each T=1 chain accumulates its own `draws` post-tune
@@ -50,31 +58,27 @@ min(per_chain_draws) across chains (the simplest correct option per
 hpc_optimization.txt PROMPT 13 item 4).
 """
 
-import gc
 import logging
-import multiprocessing as mp
 import queue
 import signal
 import time
 
-import arviz as az
 import numpy as np
-import pytensor
-import pytensor.tensor as pt
-from pytensor.graph.replace import vectorize_graph
 
-from exozippy.samplers import ptde as _ptde
+from exozippy.samplers import _common
+from exozippy.samplers._common import (
+    DE_JITTER,
+    LpPlausibilityGuard,
+    _eval_logp,
+    de_proposal,
+)
 from exozippy.samplers.ptde import (
     _check_convergence,
     _convergence_check_schedule,
     _deo_pair_sequence,
-    _eval_logp,
     _geometric_ladder,
-    _make_starts,
-    _pick_two,
     _record_round_trips,
     _safe_progress,
-    _worker_init,
     ladder_health_report,
     resolve_n_temps,
 )
@@ -96,11 +100,11 @@ def ptde_async_sample(
     raw_starts=None,
     seed_indices=None,
     raw_scales=None,
-    seed_polish_steps=0,
     gamma=None,
     target_accept=0.20,
     adapt_gamma=True,
     gamma_adapt_window=None,
+    de_jitter=DE_JITTER,
     swap_interval=None,
     swap_schedule="deo",
     seed=None,
@@ -110,6 +114,7 @@ def ptde_async_sample(
     max_rhat=1.01,
     maxtime=None,
     eval_timeout=None,
+    lp_plausibility_ceiling=None,
     collect_rung_timing=False,
     progress_callback=None,
     store_hot_chains=False,
@@ -138,14 +143,16 @@ def ptde_async_sample(
                completed T=1 proposals still within their own chain's tune
                phase. None -> max(n_chains, (tune * n_chains) // 20), i.e.
                roughly 20 adaptations over tune, matching ptde.py's cadence.
-    progress_callback : callable | None -- optional GUI progress hook; see
-               exozippy.samplers.ptde.ptde_sample for the state-dict contract.
-               Invoked at each geometric convergence check; exceptions are
-               logged and swallowed (_safe_progress) so it can never abort the
-               fit.
-
-    Returns
-    -------
+               Adaptation FREEZES the moment the first T=1 chain enters its
+               draw phase: chains record at their own pace here, and a
+               recorded draw must never come from a kernel a slower chain's
+               tune-phase proposals are still mutating.
+    log_interval : int | None -- steps between progress log lines, where one
+               async "step" is n_slots (= n_temps x n_chains) completed
+               evaluations -- the same amount of work as one ptde.py step, so
+               the knob means the same thing for both samplers. None -> 5%.
+    lp_plausibility_ceiling : float | None -- same runaway-lp warning as
+               ptde.py (None -> outputs.modes.DEFAULT_LP_ABS_MAX).
     store_hot_chains : False | True | int -- keep THINNED draws from the
                hot rungs (T > 1) as an extra ``posterior_hot`` group on the
                returned InferenceData: every int-th post-tune iteration of
@@ -168,7 +175,9 @@ def ptde_async_sample(
             f"swap_schedule must be 'deo' or 'random', got {swap_schedule!r}"
         )
 
-    _ptde._PTDE_COLLECT_TIMING = collect_rung_timing
+    lp_guard = LpPlausibilityGuard(
+        lp_plausibility_ceiling, "PTDE-async", logger
+    )
 
     rng = np.random.default_rng(seed)
 
@@ -180,38 +189,16 @@ def ptde_async_sample(
     n_temps = resolve_n_temps(n_temps, n_params, T_max)
     temperatures = _geometric_ladder(n_temps, T_max)
 
-    # compile logp ONCE; store in ptde.py's module global BEFORE forking
-    # workers -- _eval_logp (imported from ptde.py) reads it from ptde.py's
-    # own module namespace, not this module's, since that is where the
-    # function object's __globals__ point.
+    # compile logp ONCE; install in _common BEFORE forking workers so fork
+    # children inherit it (copy-on-write; see _common.set_worker_globals)
     logp_fn = model.compile_logp()
-    _ptde._PTDE_LOGP_FN = logp_fn
+    _common.set_worker_globals(logp_fn, collect_rung_timing)
 
-    # compile raw -> physical functions ONCE (single-sample and batched);
-    # see ptde.py's matching block for the rationale (PROMPT 7).
-    output_vars = model.free_RVs + model.deterministics
-    raw_to_phys = pytensor.function(
-        inputs=model.free_RVs,
-        outputs=output_vars,
-        on_unused_input="ignore",
+    # compile raw -> physical conversions ONCE (single-sample and batched;
+    # see _common.compile_conversions for the rationale).
+    raw_to_phys, raw_to_phys_batched, raw_var_names, out_var_names = (
+        _common.compile_conversions(model)
     )
-    _batched_inputs = [
-        pt.tensor(
-            name=f"batched_{v.name}",
-            dtype=v.type.dtype,
-            shape=(None,) + v.type.shape,
-        )
-        for v in model.free_RVs
-    ]
-    raw_to_phys_batched = pytensor.function(
-        inputs=_batched_inputs,
-        outputs=vectorize_graph(
-            output_vars, replace=dict(zip(model.free_RVs, _batched_inputs))
-        ),
-        on_unused_input="ignore",
-    )
-    raw_var_names = [v.name for v in model.free_RVs]
-    out_var_names = [v.name for v in output_vars]
 
     if n_chains is None:
         n_chains = 2 * n_params
@@ -220,52 +207,32 @@ def ptde_async_sample(
     logger.info(
         f"PTDE-async: {n_params} params, {n_chains} chains/rung, gamma={gamma:.4f}"
     )
+    _common.warn_if_population_degenerate(
+        n_chains, n_params, "PTDE-async", logger
+    )
 
-    if initvals is not None:
-        assert len(initvals) == n_chains, "len(initvals) must equal n_chains"
-        t1_starts = initvals
-        chain_seed_index = [0] * n_chains
-    else:
-        # Multi-seed starts (P4): round-robin the chain population across seeds.
-        # Fall back to a single start for minimal system stubs that don't
-        # implement get_raw_starts.
-        if raw_starts is None:
-            if hasattr(system, "get_raw_starts"):
-                raw_starts, seed_indices = system.get_raw_starts(model)
-            else:
-                raw_starts, seed_indices = [raw_start], [0]
-        t1_starts, chain_seed_index = _make_starts(
-            n_chains,
-            raw_starts,
-            logp_fn,
-            rng,
-            seed_indices,
-            system=system,
-            raw_scales=raw_scales,
-            polish_steps=seed_polish_steps,
-        )
+    t1_starts, chain_seed_index = _common.resolve_start_population(
+        model,
+        system,
+        n_chains,
+        logp_fn,
+        rng,
+        raw_start,
+        initvals=initvals,
+        raw_starts=raw_starts,
+        seed_indices=seed_indices,
+        raw_scales=raw_scales,
+    )
 
-    if plot_prefix is not None:
-        logger.info("Generating ensemble start plots...")
-        batched_vals = raw_to_phys_batched(
-            *[
-                np.stack([s[k] for s in t1_starts], axis=0)
-                for k in raw_var_names
-            ]
-        )
-        internal_starts = [
-            {
-                name: np.asarray(val)[i]
-                for name, val in zip(out_var_names, batched_vals)
-            }
-            for i in range(len(t1_starts))
-        ]
-        for comp in system.active_components.values():
-            comp.plot(
-                system,
-                internal_starts,
-                filename_prefix=plot_prefix + "_start_ensemble",
-            )
+    _common.plot_start_ensemble(
+        system,
+        t1_starts,
+        raw_to_phys_batched,
+        raw_var_names,
+        out_var_names,
+        plot_prefix,
+        logger,
+    )
 
     # Per-(rung, chain) slot state. current_lp[k][i] is None until that
     # slot's first evaluation completes -- doubles as "still initializing".
@@ -278,37 +245,28 @@ def ptde_async_sample(
     ]
     current_lp = [[None] * n_chains for _ in range(n_temps)]
     iter_count = [[0] * n_chains for _ in range(n_temps)]
+    # state_gen[k][i] counts the swaps that have replaced slot (k, i)'s
+    # state. Every submission is stamped with it; a result whose stamp no
+    # longer matches was proposed FROM a state that a swap has since moved
+    # elsewhere, so accept/rejecting it would compare apples to oranges
+    # (the detailed-balance violation of code_review_20260808.txt 1.15a).
+    # Such results are discarded and the slot resubmits from its new state.
+    state_gen = [[0] * n_chains for _ in range(n_temps)]
 
     slot_list = [(k, i) for k in range(n_temps) for i in range(n_chains)]
     n_slots = len(slot_list)
 
-    total_proposals = n_slots
-    phys_cores = mp.cpu_count()
-    if cores is None:
-        cores = max(1, min(int(phys_cores * 0.75), phys_cores - 1))
-    actual_cores = min(cores, total_proposals)
-    if cores > phys_cores:
-        logger.warning(
-            f"PTDE-async: cores={cores} exceeds physical core count ({phys_cores}); "
-            f"over-subscription will slow sampling via context switching."
-        )
+    pool, actual_cores = _common.create_pool(
+        cores, n_slots, "PTDE-async", logger
+    )
     logger.info(
-        f"PTDE-async: {n_temps} rungs x {n_chains} chains = {total_proposals} slots, "
+        f"PTDE-async: {n_temps} rungs x {n_chains} chains = {n_slots} slots, "
         f"{actual_cores} cores  "
         f"T=[{', '.join(f'{t:.1f}' for t in temperatures)}]"
     )
-    pool = (
-        mp.get_context("fork").Pool(actual_cores, initializer=_worker_init)
-        if actual_cores > 1
-        else None
+    _common.warn_serial_eval_timeout(
+        eval_timeout, pool, actual_cores, "PTDE-async", logger
     )
-
-    if eval_timeout is not None and pool is None:
-        logger.warning(
-            f"PTDE-async: eval_timeout={eval_timeout:.0f}s has no effect with a "
-            f"single core (cores={actual_cores}) — there is no worker process to "
-            f"enforce a wall-clock timeout against a hung logp call."
-        )
 
     swap_interval = (
         max(1, int(swap_interval)) if swap_interval else max(1, n_chains)
@@ -318,8 +276,13 @@ def ptde_async_sample(
         if gamma_adapt_window
         else max(n_chains, (tune * n_chains) // 20)
     )
-    log_every_evals = log_interval or max(
-        n_slots, (n_slots * (tune + draws)) // 20
+    # One async "step" = n_slots completed evaluations, the work of one
+    # synchronous ptde.py step -- so log_interval means the same thing in
+    # both samplers' configs.
+    log_every_evals = (
+        max(1, int(log_interval)) * n_slots
+        if log_interval
+        else max(n_slots, (n_slots * (tune + draws)) // 20)
     )
 
     # storage: raw values from T=1 chains only; each chain records exactly
@@ -355,6 +318,7 @@ def ptde_async_sample(
     n_swap_accept = np.zeros(max(n_temps - 1, 1))
     n_swap_propose = np.zeros(max(n_temps - 1, 1))
     n_eval_timeouts = [0]
+    n_swap_discards = [0]  # in-flight proposals invalidated by a swap
     rung_times = [[] for _ in range(n_temps)]
 
     # DEO schedule + round-trip diagnostics. direction[k][i] tags the config
@@ -369,6 +333,7 @@ def ptde_async_sample(
     _deo_pos = [0]
 
     gamma_box = [gamma]
+    gamma_frozen = [False]
     n_propose_T1_window = [0]
     n_accept_T1_window = [0]
     n_completed_total = [0]
@@ -385,65 +350,55 @@ def ptde_async_sample(
             "in-flight evaluations (send the signal again to abort immediately)"
         )
 
-    old_sigint = signal.signal(signal.SIGINT, _stop_handler)
-    old_sigterm = signal.signal(signal.SIGTERM, _stop_handler)
-    # Windows delivers the GUI's stop request as CTRL_BREAK_EVENT, which
-    # arrives here as SIGBREAK rather than SIGINT (see gui/runner.py).
-    old_sigbreak = (
-        signal.signal(signal.SIGBREAK, _stop_handler)
-        if hasattr(signal, "SIGBREAK")
-        else None
-    )
+    _sig_token = _common.install_stop_handlers(_stop_handler)
 
     result_q = queue.Queue()
-    submitted_at = {}  # (k, i) -> submission time, only while in flight
-    in_flight_props = {}  # (k, i) -> proposal dict, only while in flight
+    # One record per live submission, keyed by a unique submission id:
+    # sub_id -> (k, i, prop, t_submitted, state_gen_at_submit). A result
+    # whose sub_id is no longer here was written off by the eval-timeout
+    # recovery below; if it arrives anyway (it raced the write-off through
+    # the queue) it is dropped on the floor, so one submission can never be
+    # double-processed (code_review_20260808.txt 1.15b).
+    in_flight_meta = {}
     in_flight = [0]
+    _sub_seq = [0]
 
     def _build_proposal(k, i):
         if current_lp[k][i] is None:
             # First evaluation for this slot: evaluate the start state itself.
             return {key: v.copy() for key, v in current_state[k][i].items()}
-        j1, j2 = _pick_two(rng, n_chains, i)
-        pop_k = current_state[k]
-        return {
-            key: pop_k[i][key]
-            + gamma_box[0] * (pop_k[j1][key] - pop_k[j2][key])
-            for key in model_keys
-        }
+        return de_proposal(
+            rng,
+            current_state[k],
+            i,
+            gamma_box[0],
+            model_keys,
+            jitter=de_jitter,
+        )
 
     def _submit(k, i):
         prop = _build_proposal(k, i)
-        submitted_at[(k, i)] = time.time()
-        in_flight_props[(k, i)] = prop
+        _sub_seq[0] += 1
+        sub_id = _sub_seq[0]
+        in_flight_meta[sub_id] = (k, i, prop, time.time(), state_gen[k][i])
         in_flight[0] += 1
         if pool is None:
             # Serial fallback: no real concurrency, evaluate immediately.
-            result_q.put((k, i, prop, _eval_logp(prop)))
+            result_q.put((sub_id, _eval_logp(prop)))
             return
 
-        def _cb(result, k=k, i=i, prop=prop):
-            result_q.put((k, i, prop, result))
+        def _cb(result, sub_id=sub_id):
+            result_q.put((sub_id, result))
 
-        def _ecb(exc, k=k, i=i, prop=prop):
+        def _ecb(exc, sub_id=sub_id, k=k, i=i):
             logger.error(
                 f"PTDE-async: worker exception at rung {k} chain {i}: {exc}"
             )
-            failure = (-np.inf, 0.0) if _ptde._PTDE_COLLECT_TIMING else -np.inf
-            result_q.put((k, i, prop, failure))
+            failure = (-np.inf, 0.0) if collect_rung_timing else -np.inf
+            result_q.put((sub_id, failure))
 
         pool.apply_async(
             _eval_logp, (prop,), callback=_cb, error_callback=_ecb
-        )
-
-    def _recycle_pool(reason):
-        nonlocal pool
-        logger.warning(f"PTDE-async: recycling worker pool ({reason})")
-        _ptde._shutdown_pool(pool)
-        pool = None
-        gc.collect()
-        pool = mp.get_context("fork").Pool(
-            actual_cores, initializer=_worker_init
         )
 
     def _attempt_swap():
@@ -476,6 +431,11 @@ def ptde_async_sample(
                 direction[k + 1][j],
                 direction[k][i],
             )
+            # Invalidate any in-flight DE proposal generated from the states
+            # that just moved: its accept/reject would otherwise run against
+            # the swapped-in state (1.15a; see state_gen above).
+            state_gen[k][i] += 1
+            state_gen[k + 1][j] += 1
             n_swap_accept[k] += 1
         # Update round-trip tags after every swap event (idempotent): a config
         # sitting at either extreme rung is tagged accordingly and a completed
@@ -491,7 +451,7 @@ def ptde_async_sample(
 
     stopping = [False]
     stop_reason = [None]  # human-readable, for logging
-    stop_category = [None]  # one of "no_draws_ok", "no_draws_abort" -- used
+    stop_category = [None]  # "abort" (user/maxtime) vs "complete" -- used
     # below to decide whether an empty run should
     # raise KeyboardInterrupt (user/time abort) or
     # just fall through to the "no draws" RuntimeError.
@@ -556,7 +516,7 @@ def ptde_async_sample(
 
         while in_flight[0] > 0:
             try:
-                k, i, prop, result = result_q.get(timeout=poll_timeout)
+                sub_id, result = result_q.get(timeout=poll_timeout)
             except queue.Empty:
                 # eval_timeout enforcement: scan for stale in-flight slots.
                 # There is no way to kill a single hung worker in a
@@ -566,24 +526,20 @@ def ptde_async_sample(
                 # and immediately resubmitted with a fresh proposal.
                 now = time.time()
                 stale = [
-                    slot
-                    for slot, t0 in submitted_at.items()
+                    sid
+                    for sid, (_, _, _, t0, _) in in_flight_meta.items()
                     if now - t0 > eval_timeout
                 ]
                 if stale:
                     n_eval_timeouts[0] += len(stale)
-                    for sk, si in stale:
-                        stale_prop = in_flight_props.get((sk, si))
-                        raw_vals = [stale_prop[name] for name in raw_var_names]
-                        phys_vals = raw_to_phys(*raw_vals)
-                        phys_params = {
-                            name: np.asarray(val).tolist()
-                            for name, val in zip(out_var_names, phys_vals)
-                        }
-                        raw_params = {
-                            name: np.asarray(val).tolist()
-                            for name, val in stale_prop.items()
-                        }
+                    for sid in stale:
+                        sk, si, stale_prop, _, _ = in_flight_meta[sid]
+                        phys_params, raw_params = _common.describe_proposal(
+                            stale_prop,
+                            raw_to_phys,
+                            raw_var_names,
+                            out_var_names,
+                        )
                         logger.error(
                             f"PTDE-async: logp call exceeded "
                             f"eval_timeout={eval_timeout:.0f}s at rung {sk} "
@@ -591,28 +547,47 @@ def ptde_async_sample(
                             f"  physical params: {phys_params}\n"
                             f"  raw params: {raw_params}"
                         )
-                    lost_slots = list(submitted_at.keys())
-                    submitted_at.clear()
-                    in_flight_props.clear()
-                    in_flight[0] -= len(lost_slots)
-                    _recycle_pool(f"{len(stale)} timeout(s)")
+                    # Write off EVERY in-flight submission (the pool recycle
+                    # kills the workers running them). A written-off result
+                    # that nevertheless arrives (it raced us through the
+                    # queue) finds its sub_id gone and is dropped, so it can
+                    # never be double-processed (1.15b).
+                    lost = list(in_flight_meta.items())
+                    in_flight_meta.clear()
+                    in_flight[0] -= len(lost)
+                    logger.warning(
+                        f"PTDE-async: recycling worker pool "
+                        f"({len(stale)} timeout(s))"
+                    )
+                    pool = _common.recycle_pool(pool, actual_cores)
                     if not stopping[0]:
-                        for sk, si in lost_slots:
+                        for _, (sk, si, _, _, _) in lost:
                             _submit(sk, si)
                 continue
 
-            submitted_at.pop((k, i), None)
-            in_flight_props.pop((k, i), None)
+            meta = in_flight_meta.pop(sub_id, None)
+            if meta is None:
+                # Already written off by the timeout recovery above; the
+                # bookkeeping (in_flight, resubmission) happened there.
+                continue
+            k, i, prop, _, gen_at_submit = meta
             in_flight[0] -= 1
 
-            if _ptde._PTDE_COLLECT_TIMING:
+            if collect_rung_timing:
                 lp, elapsed = result
                 rung_times[k].append(elapsed)
             else:
                 lp = result
 
-            is_init = current_lp[k][i] is None
-            if is_init:
+            if gen_at_submit != state_gen[k][i]:
+                # A swap replaced this slot's state while the proposal was in
+                # flight; the proposal no longer has a valid reference state
+                # for an accept/reject. Discard it (1.15a) and resubmit from
+                # the swapped-in state below. No counters advance: no MH
+                # transition happened for this slot.
+                n_swap_discards[0] += 1
+            elif current_lp[k][i] is None:
+                # First evaluation for this slot: the start state itself.
                 current_state[k][i] = prop
                 current_lp[k][i] = lp
             else:
@@ -629,7 +604,24 @@ def ptde_async_sample(
                     current_state[k][i] = prop
                     current_lp[k][i] = lp
                     n_accept[k] += 1
+                    # Runaway-lp early detection (see LpPlausibilityGuard).
+                    if k == 0:
+                        lp_guard.check(i, lp)
                 iter_count[k][i] += 1
+
+                # Freeze gamma the moment the first T=1 chain finishes its
+                # tune phase: from here on some chain may be RECORDING, and a
+                # recorded draw must come from a fixed kernel -- slower
+                # chains' tune-phase proposals must not keep mutating
+                # gamma_box under it (1.15c). Their remaining tune iterations
+                # simply run at the frozen gamma.
+                if k == 0 and not gamma_frozen[0] and iter_count[k][i] >= tune:
+                    gamma_frozen[0] = True
+                    if adapt_gamma:
+                        logger.info(
+                            f"PTDE-async gamma: frozen at {gamma_box[0]:.4f} "
+                            f"(chain {i} entered its draw phase)"
+                        )
 
                 # store T=1 post-tune draws (each chain caps at `draws`)
                 if (
@@ -664,7 +656,11 @@ def ptde_async_sample(
             if n_completed_total[0] % swap_interval == 0:
                 _attempt_swap()
 
-            if adapt_gamma and n_propose_T1_window[0] >= gamma_adapt_window:
+            if (
+                adapt_gamma
+                and not gamma_frozen[0]
+                and n_propose_T1_window[0] >= gamma_adapt_window
+            ):
                 ar_T1 = n_accept_T1_window[0] / max(n_propose_T1_window[0], 1)
                 if ar_T1 > 0:
                     scale = (ar_T1 / target_accept) ** 0.5
@@ -718,10 +714,7 @@ def ptde_async_sample(
             raise KeyboardInterrupt
 
     finally:
-        signal.signal(signal.SIGINT, old_sigint)
-        signal.signal(signal.SIGTERM, old_sigterm)
-        if old_sigbreak is not None:
-            signal.signal(signal.SIGBREAK, old_sigbreak)
+        _common.restore_stop_handlers(_sig_token)
         if pool is not None:
             # terminate() (not close()) at shutdown: close() waits for any
             # in-flight eval to finish, so a worker still stuck on a slow
@@ -729,7 +722,7 @@ def ptde_async_sample(
             # would hang here. Stored draws are already saved; discard the
             # in-flight result. _shutdown_pool SIGKILLs a worker that is
             # wedged past the grace period so join() cannot block forever.
-            _ptde._shutdown_pool(pool)
+            _common._shutdown_pool(pool)
 
     actual_draws = int(per_chain_draws.min())
     if actual_draws == 0:
@@ -743,45 +736,19 @@ def ptde_async_sample(
             f"(some chains ran ahead: max={per_chain_draws.max()})"
         )
 
-    logger.info(
-        f"PTDE-async: converting {n_chains} x {actual_draws} draws to physical space..."
+    idata = _common.assemble_inference_data(
+        stored_raw,
+        stored_lp,
+        actual_draws,
+        n_chains,
+        raw_start,
+        raw_var_names,
+        out_var_names,
+        raw_to_phys_batched,
+        chain_seed_index,
+        "PTDE-async",
+        logger,
     )
-
-    n_total = n_chains * actual_draws
-    flat_raw = {
-        k: stored_raw[k][:, :actual_draws].reshape(
-            (n_total,) + raw_start[k].shape
-        )
-        for k in raw_var_names
-    }
-    chunk_size = 20000
-    out_chunks = {name: [] for name in out_var_names}
-    for start in range(0, n_total, chunk_size):
-        end = min(start + chunk_size, n_total)
-        chunk_out = raw_to_phys_batched(
-            *[flat_raw[k][start:end] for k in raw_var_names]
-        )
-        for name, val in zip(out_var_names, chunk_out):
-            out_chunks[name].append(np.asarray(val, dtype=float))
-
-    posterior_dict = {}
-    for name in out_var_names:
-        arr = np.concatenate(out_chunks[name], axis=0)
-        arr = arr.reshape((n_chains, actual_draws) + arr.shape[1:])
-        if arr.ndim > 2 and arr.shape[-1] == 1:
-            arr = arr.squeeze(-1)
-        posterior_dict[name] = arr
-
-    idata = az.from_dict(
-        {
-            "posterior": posterior_dict,
-            "sample_stats": {"lp": stored_lp[:, :actual_draws]},
-        }
-    )
-
-    # Multi-seed provenance (P4): which solved seed each T=1 chain started from.
-    # TODO(P4): surface in outputs/modes.py ModeReport; per-chain attr for now.
-    idata.posterior.attrs["chain_seed_index"] = list(chain_seed_index)
 
     if hot_thin:
         import xarray as xr
@@ -827,11 +794,6 @@ def ptde_async_sample(
                 "PTDE-async: store_hot_chains was set but no hot draws "
                 "accumulated (draws too small for the thinning factor?)"
             )
-    if len(set(chain_seed_index)) > 1:
-        logger.info(
-            f"PTDE-async multi-seed provenance (chain -> seed): "
-            f"{list(chain_seed_index)}"
-        )
 
     ar_T1 = float(n_accept[0] / max(n_propose[0], 1))
     sr_all = n_swap_accept / np.maximum(n_swap_propose, 1)
@@ -846,6 +808,11 @@ def ptde_async_sample(
             else ""
         )
         + (
+            f"  swap_discards={n_swap_discards[0]}"
+            if n_swap_discards[0]
+            else ""
+        )
+        + (
             f"  eval_timeouts={n_eval_timeouts[0]}"
             if n_eval_timeouts[0]
             else ""
@@ -856,19 +823,6 @@ def ptde_async_sample(
     ladder_health_report(temperatures, n_swap_accept, n_swap_propose)
 
     if collect_rung_timing:
-        logger.info("PTDE-async per-rung logp timing (seconds):")
-        for k in range(n_temps):
-            times = rung_times[k]
-            if not times:
-                logger.info(f"  rung {k} (T={temperatures[k]:.1f}): no calls")
-                continue
-            arr = np.asarray(times)
-            n_slow = int((arr > 0.1).sum())
-            logger.info(
-                f"  rung {k} (T={temperatures[k]:.1f}): n={len(arr)}  "
-                f"median={np.median(arr):.3f}  mean={arr.mean():.3f}  "
-                f"p90={np.percentile(arr, 90):.3f}  max={arr.max():.3f}  "
-                f"n_slow(>0.1s)={n_slow}"
-            )
+        _common.log_rung_timing(rung_times, temperatures, "PTDE-async", logger)
 
     return idata

--- a/tests/test_mulens_review_fixes.py
+++ b/tests/test_mulens_review_fixes.py
@@ -510,7 +510,7 @@ def test_binary_lens_requires_ptde_and_rejects_gradient_samplers():
     Given a binary lens (two lens bodies — uses the MulensModel Op),
     When sampler_requirements is called,
     Then the returned dict marks 'nuts', 'numpyro', and 'blackjax' as
-      incompatible and recommends 'ptde', because the Op is not
+      incompatible and recommends 'ptde_async', because the Op is not
       differentiable and gradient-based samplers produce invalid results.
     """
     lens = Lens(
@@ -522,14 +522,15 @@ def test_binary_lens_requires_ptde_and_rejects_gradient_samplers():
 
     assert "incompatible" in reqs
     assert {"nuts", "numpyro", "blackjax"} <= reqs["incompatible"]
-    assert reqs.get("recommended") == "ptde"
+    assert reqs.get("recommended") == "ptde_async"
 
 
 def test_pspl_finite_source_requires_ptde():
     """
     Given a PSPL lens with finite_source: True (also uses the MulensModel Op),
     When sampler_requirements is called,
-    Then gradient-based samplers are marked incompatible and 'ptde' is recommended.
+    Then gradient-based samplers are marked incompatible and 'ptde_async'
+      is recommended.
     """
     lens = Lens(
         [{"lenses": ["star.0"], "sources": ["star.1"], "finite_source": True}],
@@ -537,7 +538,7 @@ def test_pspl_finite_source_requires_ptde():
     )
     reqs = lens.sampler_requirements()
     assert "nuts" in reqs.get("incompatible", set())
-    assert reqs.get("recommended") == "ptde"
+    assert reqs.get("recommended") == "ptde_async"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ptde_async.py
+++ b/tests/test_ptde_async.py
@@ -1,11 +1,11 @@
 """Tests for the asynchronous PTDE sampler (ptde_async.py, hpc_optimization.txt PROMPT 13).
 
 Mirrors tests/test_ptde.py's structure and toy model so the two samplers'
-behavior can be compared directly. ptde_async is experimental (see its module
-docstring's statistical caveat on stale DE partners); these tests validate
-that it (a) produces well-formed output, (b) recovers known posterior
-moments on a toy model, and (c) survives edge cases (single core, eval
-timeouts, rung timing) without crashing or deadlocking.
+behavior can be compared directly. ptde_async is the recommended default for
+Op-based models (see its module docstring for the stale-DE-partner caveat);
+these tests validate that it (a) produces well-formed output, (b) recovers
+known posterior moments on a toy model, and (c) survives edge cases (single
+core, eval timeouts, rung timing) without crashing or deadlocking.
 """
 
 import multiprocessing as mp
@@ -273,3 +273,74 @@ def test_ptde_async_early_stop_via_maxtime():
     )
     assert idata.posterior.sizes["draw"] >= 1
     assert idata.posterior.sizes["draw"] <= 5000
+
+
+def test_ptde_async_warns_once_when_t1_lp_exceeds_plausibility_ceiling(
+    caplog,
+):
+    """
+    Given a plausibility ceiling set far below any lp this model can
+    legitimately reach,
+    When ptde_async_sample runs and a T=1 chain's accepted lp exceeds it,
+    Then a single loud warning is logged (not one per evaluation) naming the
+      offending chain and lp -- the same runaway-lp early-detection guard
+      the synchronous sampler has (the two used to drift here: sync had the
+      check, async silently lacked it; code_review_20260808.txt 1.15/sec 4).
+    """
+    model = _simple_model()
+    system = _MinimalSystem()
+    with caplog.at_level("WARNING", logger="exozippy.samplers.ptde_async"):
+        ptde_async_sample(
+            model,
+            system,
+            draws=20,
+            tune=20,
+            n_temps=2,
+            T_max=2.0,
+            n_chains=4,
+            cores=1,
+            seed=1,
+            log_interval=100,
+            lp_plausibility_ceiling=0.1,
+        )
+    warnings = [
+        r.message
+        for r in caplog.records
+        if "plausibility ceiling" in r.message
+    ]
+    assert len(warnings) == 1, (
+        f"expected exactly one plausibility-ceiling warning, got "
+        f"{len(warnings)}: {warnings}"
+    )
+    assert "T=1 chain" in warnings[0]
+
+
+def test_ptde_async_freezes_gamma_when_first_chain_starts_recording(caplog):
+    """
+    Given adapt_gamma=True (the default) and asynchronous per-chain pacing,
+    When the first T=1 chain finishes its tune phase,
+    Then gamma is frozen (logged once) so recorded draws never come from a
+      kernel that slower chains' tune-phase proposals are still mutating
+      (code_review_20260808.txt 1.15c).
+    """
+    model = _simple_model()
+    system = _MinimalSystem()
+    with caplog.at_level("INFO", logger="exozippy.samplers.ptde_async"):
+        ptde_async_sample(
+            model,
+            system,
+            draws=30,
+            tune=30,
+            n_temps=2,
+            T_max=2.0,
+            n_chains=4,
+            cores=1,
+            seed=2,
+            log_interval=1000,
+        )
+    freeze_msgs = [
+        r.message for r in caplog.records if "gamma: frozen at" in r.message
+    ]
+    assert len(freeze_msgs) == 1, (
+        f"expected exactly one gamma-freeze message, got {freeze_msgs}"
+    )

--- a/tests/test_ptde_deo.py
+++ b/tests/test_ptde_deo.py
@@ -158,17 +158,25 @@ def test_deo_pairs_odd_ladder_drops_dangling_rung():
     assert _deo_pairs(0, 7) == [(0, 1), (2, 3), (4, 5)]
 
 
-def test_deo_pairs_skips_thinned_inactive_rungs():
+def test_deo_pairs_ignore_rung_thinning():
     """
-    Given a set of active rungs that excludes some thinned (inactive) rungs,
-    When _deo_pairs is called with active_rungs,
-    Then any pair touching an inactive rung is dropped rather than reverting
-      to a random pairing (preserving the non-reversible index flow).
+    Given a rung-thinned sampler configuration,
+    When the DEO swap schedule is generated,
+    Then every adjacent pair is still attempted -- swaps exchange cached
+      (state, logp) pairs and need no fresh evaluation, so thinning must
+      never filter them. Filtering by the thinning activity pattern used to
+      permanently disconnect the ladder because the DEO round parity is
+      deterministically coupled to the step counter (e.g. thin_factor=2,
+      swap_interval=1, n_temps=8, thin_start=4 never attempted (3,4) or
+      (5,6)) -- notes/code_review_20260808.txt bug 1.14.
     """
-    # Only rungs 0-3 active: on an even round, (4,5) and (6,7) must drop.
-    assert _deo_pairs(0, 8, active_rungs={0, 1, 2, 3}) == [(0, 1), (2, 3)]
-    # A pair with only one active endpoint is also dropped.
-    assert _deo_pairs(0, 8, active_rungs={0, 1, 2}) == [(0, 1)]
+    import inspect
+
+    # The schedule generator has no filtering hook at all any more.
+    assert "active_rungs" not in inspect.signature(_deo_pairs).parameters
+    # Over any two consecutive rounds, every adjacent pair is attempted.
+    attempted = set(_deo_pairs(0, 8)) | set(_deo_pairs(1, 8))
+    assert attempted == {(k, k + 1) for k in range(7)}
 
 
 def test_deo_pair_sequence_even_pairs_before_odd():

--- a/tests/test_whitening.py
+++ b/tests/test_whitening.py
@@ -285,13 +285,14 @@ def test_make_starts_skips_probe_when_raw_scales_given(monkeypatch):
     Then the probe is never called (the model was whitened against the
     same start) and the provided scales disperse the chains.
     """
-    # Arrange
-    from exozippy.samplers import ptde
+    # Arrange -- patch the probe where _make_starts actually resolves it
+    # (samplers._common, the shared scaffolding module; ptde re-exports it).
+    from exozippy.samplers import _common, ptde
 
     def _boom(*a, **k):
         raise AssertionError("probe should not run")
 
-    monkeypatch.setattr(ptde, "_probe_scales", _boom)
+    monkeypatch.setattr(_common, "_probe_scales", _boom)
     rng = np.random.default_rng(0)
     start = {"a": np.zeros(2)}
 


### PR DESCRIPTION
## Summary

Works through all the ptde vs ptde_async duplication/drift/bug items from the 2026-08-08 code review (sections 1.14-1.16, 4, 5, 7).

**Anti-drift refactor**: the ~450 lines of near-verbatim non-sampling scaffolding shared by `ptde.py` and `ptde_async.py` (worker globals/`_eval_logp`, pool lifecycle, compiled raw->physical conversions, start-population generation, ensemble plots, signal handlers, timeout diagnostics, posterior assembly, rung-timing report) now live once in `samplers/_common.py`. The sampling loops stay separate by design; `ptde.py` re-exports the old names for compatibility.

**Bug fixes**:
- **1.14** (sync): `_deo_pairs` no longer accepts `active_rungs` -- rung thinning can never filter swap pairs (swaps exchange cached `(state, logp)` pairs and need no fresh evaluation). Because DEO round parity is locked to the step counter, the old filter permanently disconnected ladder segments for real configs.
- **1.15a** (async): submissions are stamped with a per-slot state generation; a swap that replaces a slot's state invalidates its in-flight proposal, which is discarded on arrival instead of being accept/rejected against the swapped-in state (detailed-balance violation). Discards are counted (`swap_discards=` in the done line).
- **1.15b** (async): unique submission ids -- a result written off by the eval-timeout recovery that arrives late anyway is dropped, not double-processed.
- **1.15c** (async): gamma freezes once the first T=1 chain enters its draw phase, so recorded draws never come from a kernel still being adapted.
- **1.16** (both): shared `de_proposal` adds the ter Braak 2006 epsilon term (`de_jitter`, 1e-4 raw units) so sampling is not confined to the affine hull of the starts; startup warning when `n_chains < n_params + 2`.

**Drift repairs**: async gains the `lp_plausibility_ceiling` runaway-lp guard; async `log_interval` now means steps (`n_slots` completed evals) like sync; dead `seed_polish_steps` deleted from both samplers.

**Default**: `ptde_async` is now the recommended sampler for Op-based models (`Lens.sampler_requirements`, run.py fallback); `method: ptde` stays available as the synchronous A/B reference.

Note: the epsilon jitter and the async discard/freeze changes mean seeded runs will not reproduce old traces bit-for-bit; posteriors are unaffected.

## Test plan
- Updated: DEO test that pinned the buggy swap filtering; `recommended == "ptde_async"` assertions; whitening probe monkeypatch target.
- Added: async lp-ceiling warn-once test; async gamma-freeze test.
- Full suite: 1008 passed (also re-run by the pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)