### PR TITLE
Galactic prior: normalization fixes (review 1.3/1.4), genulens fidelity upgrade, and geocentric mu_rel frame fix

### DIFF
--- a/src/exozippy/components/galacticmodel/galacticmodel.py
+++ b/src/exozippy/components/galacticmodel/galacticmodel.py
@@ -2,21 +2,24 @@ import astropy.units as u
 import numpy as np
 import pymc as pm
 import pytensor.tensor as pt
-from astropy.coordinates import Galactocentric, SkyCoord
+from astropy.coordinates import CartesianDifferential, Galactocentric, SkyCoord
 
 from exozippy.components.component import Component
 from exozippy.constants import (
     BULGE_BAR_ANGLE,
-    BULGE_DENSITY_RHO0,
+    BULGE_CENTRAL_NUMBER_DENSITY,
     BULGE_DENSITY_X_0,
     BULGE_DENSITY_Y_0,
     BULGE_DENSITY_Z_0,
     BULGE_GAMMA,
+    BULGE_RC,
+    BULGE_RC_WIDTH,
     BULGE_ROTATION_ANGULAR_VELOCITY,
     BULGE_VELOCITY_SIGMA_1,
     BULGE_VELOCITY_SIGMA_2,
     BULGE_VELOCITY_SIGMA_3,
-    DISK_DENSITY_RHO0,
+    DISK_LOCAL_NUMBER_DENSITY,
+    DISK_RDBREAK,
     DISK_ROTATION_VELOCITY,
     DISK_SCALE_HEIGHT,
     DISK_SCALE_LENGTH,
@@ -26,15 +29,48 @@ from exozippy.constants import (
     K_VEL_CONVERSION,
     KROUPA_IMF_SLOPE,
     SALPETER_IMF_SLOPE,
+    SUN_GALCEN_V,
     SUN_GC_DISTANCE,
+    SUN_Z_OFFSET,
+    THICK_DISK_LOCAL_NUMBER_DENSITY,
+    THICK_DISK_ROTATION_VELOCITY,
+    THICK_DISK_SCALE_HEIGHT,
+    THICK_DISK_SCALE_LENGTH,
+    THICK_DISK_VELOCITY_SIGMA_U,
+    THICK_DISK_VELOCITY_SIGMA_V,
+    THICK_DISK_VELOCITY_SIGMA_W,
 )
 
 """
-This class implements a mixture model of the bulge and disk, enforcing the kinematics and density of the galaxy 
-It's a simplified version of the model defined in https://ui.adsabs.harvard.edu/abs/2021ApJ...917...78K/abstract. 
-and codified here https://github.com/nkoshimoto/genulens 
+This class implements a mixture model of the thin disk, thick disk, and
+bulge/bar, enforcing the kinematics and density of the galaxy.
+It's a simplified version of the model defined in https://ui.adsabs.harvard.edu/abs/2021ApJ...917...78K/abstract.
+and codified here https://github.com/nkoshimoto/genulens
 This class distills genulens's core functionality into a component for EXOZIPPy
+
+Fidelity notes (vs genulens, reviewed 2026-08): the thin disk collapses
+genulens's 7 age bins into one exponential layer with its B14disk-mode
+(Bennett et al. 2014) kinematics instead of the Shu DF; the bar keeps a
+plain-ellipsoid exp(-r_s/2) profile (not the K21 super-ellipsoid + X-shape)
+but carries genulens's outer cylindrical cutoff and VVV-box-budget
+normalization; NSD, stellar halo, and the bar's spatial sigma gradients /
+streaming motion are omitted.  All three branch weights are genulens's
+NUMBER-density channel on one absolute scale, so the logsumexp mixture
+weight is physical.  The event-rate selection factor (theta_E * mu_rel) is
+deliberately NOT here -- it lives in the lens component, so this prior
+stays microlensing-agnostic.
 """
+
+# One consistent galactocentric frame for the velocity transform, matching
+# the density grid's R0/z_sun (genulens: R0 = 8160 pc, zsun = 25 pc,
+# vsun = (10, 243, 7) km/s toward-GC/rotation/up).  Astropy's default
+# Galactocentric (R0 = 8.122 kpc) would put the velocities in a slightly
+# different frame than the densities.
+GALACTOCENTRIC_FRAME = Galactocentric(
+    galcen_distance=SUN_GC_DISTANCE * u.kpc,
+    z_sun=SUN_Z_OFFSET * u.kpc,
+    galcen_v_sun=CartesianDifferential(list(SUN_GALCEN_V) * (u.km / u.s)),
+)
 
 
 class GalacticModel(Component):
@@ -104,10 +140,10 @@ class GalacticModel(Component):
                 radial_velocity=1 * u.km / u.s,
             )
 
-            gal0 = sc0.transform_to(Galactocentric())
-            gal1 = sc1.transform_to(Galactocentric())
-            gal2 = sc2.transform_to(Galactocentric())
-            gal3 = sc3.transform_to(Galactocentric())
+            gal0 = sc0.transform_to(GALACTOCENTRIC_FRAME)
+            gal1 = sc1.transform_to(GALACTOCENTRIC_FRAME)
+            gal2 = sc2.transform_to(GALACTOCENTRIC_FRAME)
+            gal3 = sc3.transform_to(GALACTOCENTRIC_FRAME)
 
             v0_arr = np.array([gal0.v_x.value, gal0.v_y.value, gal0.v_z.value])
             v1 = (
@@ -151,9 +187,14 @@ class GalacticModel(Component):
             return v0 + v_gal_offset
 
         def get_galactic_xyz(dist):
+            # genulens Dlb2xyz: the Sun sits SUN_Z_OFFSET above the plane,
+            # handled as a small rotation of z by bsun = z_sun/R0 (so a
+            # star at d=0 lands at z = +z_sun).  x and y keep the flat
+            # convention (Sun at x = +R0, GC at the origin).
             x = SUN_GC_DISTANCE - dist * cosl_cosb
             y = dist * sinl_cosb
-            z = dist * sinb
+            bsun = SUN_Z_OFFSET / SUN_GC_DISTANCE
+            z = dist * sinb * np.cos(bsun) + x * np.sin(bsun)
             return x, y, z
 
         def get_polar_velocity(x, y, r, v_x, v_y):
@@ -209,7 +250,23 @@ class GalacticModel(Component):
         x_bar = x * cos_bar + y * sin_bar
         y_bar = -x * sin_bar + y * cos_bar
 
-        # 1. Compute Disk Likelihood (Spatial + Kinematic)
+        def hinge(t):
+            # Smooth max(t, 0) (C-infinity), transition width ~50 pc in
+            # kpc units -- keeps the plateau/cutoff kinks differentiable.
+            return 0.5 * (t + pt.sqrt(t * t + 0.0025))
+
+        # Each mixture branch must carry its own normalization: constants
+        # cancel within a single Potential but NOT across the logsumexp.
+        # Velocity Gaussians contribute -log(sigma1*sigma2*sigma3) (the
+        # shared (2*pi)^(3/2) is identical in all branches and dropped);
+        # the density anchors (stars/pc^3, genulens's number-density
+        # channel, see constants.py) set the physical population ratios.
+
+        # 1. Thin disk (Spatial + Kinematic)
+        # Radial profile: exponential with Rd = 2.6 kpc, held FLAT inside
+        # R = DISK_RDBREAK (genulens's DISK=2 inner plateau) -- a plain
+        # exponential over-weights near-GC disk lenses by ~3x at R = 1
+        # kpc.  Anchored to the local (R0, midplane) number density.
         # Galactic rotation is AZIMUTHAL: the circular-speed offset belongs
         # on v_phi (paired with the azimuthal dispersion sigma_V) and the
         # radial component v_r is zero-centered (sigma_U). These centers
@@ -223,37 +280,69 @@ class GalacticModel(Component):
         # get_polar_velocity is positive for co-rotation at every position
         # (verified against astropy Galactocentric), so the center is
         # +DISK_ROTATION_VELOCITY.
-        log_dens_disk = (-1.0 / DISK_SCALE_LENGTH) * r + (
-            -1.0 / DISK_SCALE_HEIGHT
-        ) * z_smooth
-        log_vel_disk = (
+        r_beyond_sun = SUN_GC_DISTANCE - DISK_RDBREAK
+        log_dens_thin = (
+            np.log(DISK_LOCAL_NUMBER_DENSITY)
+            - (hinge(r - DISK_RDBREAK) - r_beyond_sun) / DISK_SCALE_LENGTH
+            - z_smooth / DISK_SCALE_HEIGHT
+        )
+        log_vel_thin = (
             (-0.5 / DISK_VELOCITY_SIGMA_U**2) * v_r**2
             + (-0.5 / DISK_VELOCITY_SIGMA_V**2)
             * (v_phi - DISK_ROTATION_VELOCITY) ** 2
             + (-0.5 / DISK_VELOCITY_SIGMA_W**2) * v_z**2
         )
-        # Each mixture branch must carry its own normalization: constants
-        # cancel within a single Potential but NOT across the logsumexp.
-        # Velocity Gaussians contribute -log(sigma1*sigma2*sigma3) (the
-        # shared (2*pi)^(3/2) is identical in both branches and dropped);
-        # without it the bulge's ~(120*100*80)/(30*30*30) wider ellipsoid
-        # was over-weighted by ~3.6 nats.  The density zero points
-        # log(rho0) set the physical disk:bulge count ratio (both in
-        # Msun/pc^3, see constants.py).
-        log_norm_disk = np.log(DISK_DENSITY_RHO0) - np.log(
-            DISK_VELOCITY_SIGMA_U
-            * DISK_VELOCITY_SIGMA_V
-            * DISK_VELOCITY_SIGMA_W
+        L_thin = (
+            log_dens_thin
+            + log_vel_thin
+            - np.log(
+                DISK_VELOCITY_SIGMA_U
+                * DISK_VELOCITY_SIGMA_V
+                * DISK_VELOCITY_SIGMA_W
+            )
         )
-        L_disk = log_dens_disk + log_vel_disk + log_norm_disk
 
-        # 2. Compute Bulge Likelihood (Spatial + Kinematic)
+        # 2. Thick disk (Spatial + Kinematic) -- same plateau, its own
+        # scale length/height; kinematics include the asymmetric drift
+        # (mean rotation 170 km/s) and hotter dispersions.
+        log_dens_thick = (
+            np.log(THICK_DISK_LOCAL_NUMBER_DENSITY)
+            - (hinge(r - DISK_RDBREAK) - r_beyond_sun)
+            / THICK_DISK_SCALE_LENGTH
+            - z_smooth / THICK_DISK_SCALE_HEIGHT
+        )
+        log_vel_thick = (
+            (-0.5 / THICK_DISK_VELOCITY_SIGMA_U**2) * v_r**2
+            + (-0.5 / THICK_DISK_VELOCITY_SIGMA_V**2)
+            * (v_phi - THICK_DISK_ROTATION_VELOCITY) ** 2
+            + (-0.5 / THICK_DISK_VELOCITY_SIGMA_W**2) * v_z**2
+        )
+        L_thick = (
+            log_dens_thick
+            + log_vel_thick
+            - np.log(
+                THICK_DISK_VELOCITY_SIGMA_U
+                * THICK_DISK_VELOCITY_SIGMA_V
+                * THICK_DISK_VELOCITY_SIGMA_W
+            )
+        )
+
+        # 3. Bulge/bar (Spatial + Kinematic), anchored at its center.
+        # The Gaussian cylindrical cutoff beyond BULGE_RC (genulens Rc/
+        # srob) is what confines the bar: without it the shallow
+        # exp(-r_s/2) profile is still 9% of central at a 4-kpc lens
+        # distance (vs ~4e-6 in genulens), flooding the disk range with
+        # spurious bulge stars.
         r_bulge_coord = pt.sqrt(
             (x_bar / BULGE_DENSITY_X_0) ** 2
             + (y_bar / BULGE_DENSITY_Y_0) ** 2
             + (z / BULGE_DENSITY_Z_0) ** 2
         )
-        log_dens_bulge = -0.5 * r_bulge_coord
+        log_dens_bulge = (
+            np.log(BULGE_CENTRAL_NUMBER_DENSITY)
+            - 0.5 * r_bulge_coord
+            - 0.5 * (hinge(r - BULGE_RC) / BULGE_RC_WIDTH) ** 2
+        )
         # Bulge cylindrical rotation is azimuthal too (same fix as above).
         bulge_rot = BULGE_ROTATION_ANGULAR_VELOCITY * r
         log_vel_bulge = (
@@ -261,12 +350,15 @@ class GalacticModel(Component):
             + (-0.5 / BULGE_VELOCITY_SIGMA_2**2) * (v_phi - bulge_rot) ** 2
             + (-0.5 / BULGE_VELOCITY_SIGMA_3**2) * v_z**2
         )
-        log_norm_bulge = np.log(BULGE_DENSITY_RHO0) - np.log(
-            BULGE_VELOCITY_SIGMA_1
-            * BULGE_VELOCITY_SIGMA_2
-            * BULGE_VELOCITY_SIGMA_3
+        L_bulge = (
+            log_dens_bulge
+            + log_vel_bulge
+            - np.log(
+                BULGE_VELOCITY_SIGMA_1
+                * BULGE_VELOCITY_SIGMA_2
+                * BULGE_VELOCITY_SIGMA_3
+            )
         )
-        L_bulge = log_dens_bulge + log_vel_bulge + log_norm_bulge
 
         volume_element = 2.0 * pt.log(distance * 1000.0)
 
@@ -280,10 +372,10 @@ class GalacticModel(Component):
         # under-weighting large distances by d^2.
         velocity_jacobian = 2.0 * pt.log(K_VEL_CONVERSION * distance)
 
-        # 3. Combine them using LogSumExp
-        # This effectively does: log(exp(L_disk) + exp(L_bulge))
+        # 4. Combine them using LogSumExp
+        # log(exp(L_thin) + exp(L_thick) + exp(L_bulge))
         kinematic_penalty = pt.sum(
-            pm.math.logsumexp(pt.stack([L_disk, L_bulge]), axis=0)
+            pm.math.logsumexp(pt.stack([L_thin, L_thick, L_bulge]), axis=0)
             + volume_element
             + velocity_jacobian
         )

--- a/src/exozippy/components/galacticmodel/galacticmodel.py
+++ b/src/exozippy/components/galacticmodel/galacticmodel.py
@@ -7,6 +7,7 @@ from astropy.coordinates import Galactocentric, SkyCoord
 from exozippy.components.component import Component
 from exozippy.constants import (
     BULGE_BAR_ANGLE,
+    BULGE_DENSITY_RHO0,
     BULGE_DENSITY_X_0,
     BULGE_DENSITY_Y_0,
     BULGE_DENSITY_Z_0,
@@ -15,6 +16,7 @@ from exozippy.constants import (
     BULGE_VELOCITY_SIGMA_1,
     BULGE_VELOCITY_SIGMA_2,
     BULGE_VELOCITY_SIGMA_3,
+    DISK_DENSITY_RHO0,
     DISK_ROTATION_VELOCITY,
     DISK_SCALE_HEIGHT,
     DISK_SCALE_LENGTH,
@@ -230,7 +232,20 @@ class GalacticModel(Component):
             * (v_phi - DISK_ROTATION_VELOCITY) ** 2
             + (-0.5 / DISK_VELOCITY_SIGMA_W**2) * v_z**2
         )
-        L_disk = log_dens_disk + log_vel_disk
+        # Each mixture branch must carry its own normalization: constants
+        # cancel within a single Potential but NOT across the logsumexp.
+        # Velocity Gaussians contribute -log(sigma1*sigma2*sigma3) (the
+        # shared (2*pi)^(3/2) is identical in both branches and dropped);
+        # without it the bulge's ~(120*100*80)/(30*30*30) wider ellipsoid
+        # was over-weighted by ~3.6 nats.  The density zero points
+        # log(rho0) set the physical disk:bulge count ratio (both in
+        # Msun/pc^3, see constants.py).
+        log_norm_disk = np.log(DISK_DENSITY_RHO0) - np.log(
+            DISK_VELOCITY_SIGMA_U
+            * DISK_VELOCITY_SIGMA_V
+            * DISK_VELOCITY_SIGMA_W
+        )
+        L_disk = log_dens_disk + log_vel_disk + log_norm_disk
 
         # 2. Compute Bulge Likelihood (Spatial + Kinematic)
         r_bulge_coord = pt.sqrt(
@@ -246,15 +261,31 @@ class GalacticModel(Component):
             + (-0.5 / BULGE_VELOCITY_SIGMA_2**2) * (v_phi - bulge_rot) ** 2
             + (-0.5 / BULGE_VELOCITY_SIGMA_3**2) * v_z**2
         )
-        L_bulge = log_dens_bulge + log_vel_bulge
+        log_norm_bulge = np.log(BULGE_DENSITY_RHO0) - np.log(
+            BULGE_VELOCITY_SIGMA_1
+            * BULGE_VELOCITY_SIGMA_2
+            * BULGE_VELOCITY_SIGMA_3
+        )
+        L_bulge = log_dens_bulge + log_vel_bulge + log_norm_bulge
 
         volume_element = 2.0 * pt.log(distance * 1000.0)
+
+        # The velocity Gaussians are evaluated in km/s while the sampled
+        # coordinates are (pm_ra, pm_dec, rv); the change of variables
+        # v = M_rot @ (K*pm_ra*d, K*pm_dec*d, rv/1e3) + v0 needs
+        # |det dv/d(pm_ra, pm_dec, rv)| = (K*d)^2 * 1e-3 (M_rot is a pure
+        # rotation, det = 1; the constant 1e-3 from m/s -> km/s is
+        # dropped).  Without the +2*log(d) the intended prior
+        # rho * d^2 * f(v) * (K*d)^2 was applied as rho * d^2 * f(v),
+        # under-weighting large distances by d^2.
+        velocity_jacobian = 2.0 * pt.log(K_VEL_CONVERSION * distance)
 
         # 3. Combine them using LogSumExp
         # This effectively does: log(exp(L_disk) + exp(L_bulge))
         kinematic_penalty = pt.sum(
             pm.math.logsumexp(pt.stack([L_disk, L_bulge]), axis=0)
             + volume_element
+            + velocity_jacobian
         )
         pm.Potential(f"{self.prefix}.kinematic_prior", kinematic_penalty)
 

--- a/src/exozippy/components/mulensing/defaults.yaml
+++ b/src/exozippy/components/mulensing/defaults.yaml
@@ -15,17 +15,20 @@ lens:
     internal_unit: ""
     latex: "u_0"
     description: "Impact parameter (Einstein radii)"
+  # t_E and the pi_E direction live in the light curve's GEOCENTRIC frame
+  # (Skowron+2011 t0_par anchor), so they derive from mu_rel_geo, not from
+  # the heliocentric pm difference.
   t_E:
     lower: 0.0
     unit: "d"
     internal_unit: "d"
     latex: "t_E"
-    description: "Einstein crossing time"
+    description: "Einstein crossing time (geocentric at t0_par)"
     debug_print: true
     expressions:
       default:
         func_name: "calc_t_E"
-        deps: [ "theta_E", "mu_rel_mag" ]
+        deps: [ "theta_E", "mu_rel_geo_mag" ]
   pi_E_N:
     initval: 0.0
     unit: ""
@@ -36,7 +39,7 @@ lens:
     expressions:
       default:
         func_name: "calc_pi_E_N"
-        deps: [ "pi_rel", "theta_E", "mu_dec_rel", "mu_rel_mag" ]
+        deps: [ "pi_rel", "theta_E", "mu_dec_rel_geo", "mu_rel_geo_mag" ]
   pi_E_E:
     initval: 0.0
     unit: ""
@@ -47,7 +50,7 @@ lens:
     expressions:
       default:
         func_name: "calc_pi_E_E"
-        deps: [ "pi_rel", "theta_E", "mu_ra_rel", "mu_rel_mag" ]
+        deps: [ "pi_rel", "theta_E", "mu_ra_rel_geo", "mu_rel_geo_mag" ]
   pi_rel:
     lower: 0.0
     upper: 10000
@@ -70,13 +73,17 @@ lens:
       default:
         func_name: "calc_theta_E"
         deps: [ "star.mass[lens_map]", "pi_rel" ]
+  # mu_ra_rel / mu_dec_rel / mu_rel_mag are HELIOCENTRIC: differences of the
+  # stars' barycentric proper motions (the frame the galactic kinematic
+  # prior and Gaia priors constrain).  The *_geo trio below converts to the
+  # geocentric frame at t0_par for the light-curve chain.
   mu_ra_rel:
     lower: -10000.0
     upper: 10000.0
     unit: "mas/yr"
     internal_unit: "mas/yr"
-    latex: "\\mu_{\\alpha,rel}"
-    description: "Relative lens-source proper motion (RA)"
+    latex: "\\mu_{\\alpha,rel,helio}"
+    description: "Relative lens-source proper motion (RA, heliocentric)"
     expressions:
       default:
         func_name: "calc_mu_ra_rel"
@@ -86,8 +93,8 @@ lens:
     upper: 10000.0
     unit: "mas/yr"
     internal_unit: "mas/yr"
-    latex: "\\mu_{\\delta,rel}"
-    description: "Relative lens-source proper motion (Dec)"
+    latex: "\\mu_{\\delta,rel,helio}"
+    description: "Relative lens-source proper motion (Dec, heliocentric)"
     expressions:
       default:
         func_name: "calc_mu_dec_rel"
@@ -97,12 +104,49 @@ lens:
     upper: 10000
     unit: "mas/yr"
     internal_unit: "mas/yr"
-    latex: "\\mu_{rel}"
-    description: "Relative lens-source proper motion"
+    latex: "\\mu_{rel,helio}"
+    description: "Relative lens-source proper motion (heliocentric)"
     expressions:
       default:
         func_name: "calc_mu_rel_mag"
         deps: ["mu_ra_rel", "mu_dec_rel"]
+  # Geocentric (t0_par frame, Gould 2004): mu_geo = mu_helio -
+  # pi_rel * v_earth_perp(t0_par)/AU.  earth_vperp_e/n are context
+  # constants injected by Lens.add_parameter (Earth's velocity at t0_par
+  # projected on East/North, AU/yr), declared in Lens.context_dep_names.
+  mu_ra_rel_geo:
+    lower: -10000.0
+    upper: 10000.0
+    unit: "mas/yr"
+    internal_unit: "mas/yr"
+    latex: "\\mu_{\\alpha,rel,geo}"
+    description: "Relative lens-source proper motion (RA, geocentric at t0_par)"
+    expressions:
+      default:
+        func_name: "calc_mu_ra_rel_geo"
+        deps: [ "mu_ra_rel", "pi_rel", "earth_vperp_e" ]
+  mu_dec_rel_geo:
+    lower: -10000.0
+    upper: 10000.0
+    unit: "mas/yr"
+    internal_unit: "mas/yr"
+    latex: "\\mu_{\\delta,rel,geo}"
+    description: "Relative lens-source proper motion (Dec, geocentric at t0_par)"
+    expressions:
+      default:
+        func_name: "calc_mu_dec_rel_geo"
+        deps: [ "mu_dec_rel", "pi_rel", "earth_vperp_n" ]
+  mu_rel_geo_mag:
+    lower: 0.0
+    upper: 10000
+    unit: "mas/yr"
+    internal_unit: "mas/yr"
+    latex: "\\mu_{rel,geo}"
+    description: "Relative lens-source proper motion (geocentric at t0_par)"
+    expressions:
+      default:
+        func_name: "calc_mu_rel_mag"
+        deps: ["mu_ra_rel_geo", "mu_dec_rel_geo"]
   rho:
     # Soft upper barrier only: real events have rho <~ 0.5, and rho >~ a few
     # both erases the microlensing signal (A -> 1) and drives VBM's

--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -49,6 +49,10 @@ class Lens(Component):
         source_ndx: 1
     """
 
+    # Deps satisfied by context-node injection in add_parameter (constants,
+    # not manifest parameters); graph.py skips them when ordering the build.
+    context_dep_names = frozenset({"earth_vperp_e", "earth_vperp_n"})
+
     def __init__(self, config, config_manager):
         super().__init__(config, config_manager)
         self.label = "Lens Parameters"
@@ -516,6 +520,9 @@ class Lens(Component):
             "mu_ra_rel": per_source("default"),
             "mu_dec_rel": per_source("default"),
             "mu_rel_mag": per_source("default"),
+            "mu_ra_rel_geo": per_source("default"),
+            "mu_dec_rel_geo": per_source("default"),
+            "mu_rel_geo_mag": per_source("default"),
             "t_E": per_source("default"),
             "pi_E_N": per_source("default"),
             "pi_E_E": per_source("default"),
@@ -712,14 +719,65 @@ class Lens(Component):
                         f"star.{l_idx}.logmass", scale
                     )
 
+    def add_parameter(self, model, param_name, system, context_nodes=None):
+        """Inject the Earth-velocity context constants for the mu_rel_geo
+        chain (see context_dep_names); everything else is generic."""
+        if param_name in ("mu_ra_rel_geo", "mu_dec_rel_geo"):
+            context_nodes = dict(context_nodes or {})
+            if "earth_vperp_e" not in context_nodes:
+                vperp_e, vperp_n = self._earth_vperp_en(system)
+                context_nodes["earth_vperp_e"] = pt.as_tensor_variable(vperp_e)
+                context_nodes["earth_vperp_n"] = pt.as_tensor_variable(vperp_n)
+        return super().add_parameter(model, param_name, system, context_nodes)
+
+    def _earth_vperp_en(self, system):
+        """Earth's velocity at t0_par projected on the sky, (East, North),
+        in AU/yr (numerically 1/yr once divided by the 1-AU baseline --
+        multiplying by pi_rel in mas gives mas/yr).
+
+        This is the Gould (2004) mu_helio -> mu_geo conversion constant:
+        mu_geo = mu_helio - pi_rel * v_perp / AU.  The velocity and the
+        (ra, dec) used for the projection come from MulensInstrument -- the
+        SAME anchor epoch and sky position its Skowron deltas use, so the
+        conversion and the trajectory share one frame by construction.
+        Without microlensing data there is no t0_par to anchor the frame;
+        the term is dropped (mu_geo == mu_helio) with a warning.
+        """
+        inst = getattr(system, "mulensinstrument", None)
+        vel = getattr(inst, "_earth_vel_ref", None)
+        radec = getattr(inst, "_source_radec_rad", None)
+        if vel is None or radec is None:
+            logger.warning(
+                f"[{self.prefix}] No microlensing data to anchor t0_par; "
+                "mu_rel_geo falls back to the heliocentric value (Earth-"
+                "velocity term dropped)."
+            )
+            return 0.0, 0.0
+        v = np.asarray(vel, dtype=float) * 365.25  # AU/day -> AU/yr
+        ra, dec = radec
+        e_hat = np.array([-np.sin(ra), np.cos(ra), 0.0])
+        n_hat = np.array(
+            [
+                -np.cos(ra) * np.sin(dec),
+                -np.sin(ra) * np.sin(dec),
+                np.cos(dec),
+            ]
+        )
+        return float(v @ e_hat), float(v @ n_hat)
+
     def build_likelihood(self, model, system):
         """Stage 6: Observational penalties on the lensing geometry."""
-        mu_rel = self.mu_rel_mag.value
+        # GEOCENTRIC mu_rel: the event-rate selection is the sky-sweep rate
+        # in the frame the event is observed in (rp.py used the geocentric
+        # value at t0_par; Batista+2011's rate is in the frame of the
+        # measured t_E), and it is also the divisor of t_E/pi_E, so the
+        # singularity guard belongs on it.
+        mu_rel_geo = self.mu_rel_geo_mag.value
         theta_E = self.theta_E.value
 
         pm.Potential(
             f"{self.prefix}.event_rate_prior",
-            pt.sum(pt.log(mu_rel) + pt.log(theta_E)),
+            pt.sum(pt.log(mu_rel_geo) + pt.log(theta_E)),
         )
 
         # Shared log-sigmoid barriers (see exozippy.potentials): smooth and
@@ -736,7 +794,7 @@ class Lens(Component):
 
         pm.Potential(
             f"{self.prefix}.mu_rel_singularity",
-            pt.sum(soft_lower_bound(mu_rel, 1e-6, scale=1e-5)),
+            pt.sum(soft_lower_bound(mu_rel_geo, 1e-6, scale=1e-5)),
         )
 
         pm.Potential(

--- a/src/exozippy/components/mulensing/mulensinstrument.py
+++ b/src/exozippy/components/mulensing/mulensinstrument.py
@@ -173,10 +173,14 @@ class MulensInstrument(Instrument):
         # run before the file loop so excluded points never enter the arrays.
         self._resolve_mmexofast(system)
 
-        # Source RA/Dec (degrees from resolve → radians for projection math)
+        # Source RA/Dec (degrees from resolve → radians for projection math).
+        # Stashed for Lens._earth_vperp_en: the mu_helio -> mu_geo conversion
+        # must project Earth's velocity with the same (ra, dec) the Skowron
+        # deltas are projected with.
         ra_deg, dec_deg = self._resolve_source_radec_deg(system)
         ra_rad = ra_deg * np.pi / 180.0
         dec_rad = dec_deg * np.pi / 180.0
+        self._source_radec_rad = (ra_rad, dec_rad)
 
         # Pass 1: read every file.  The raw times must exist before the
         # Skowron reference frame is anchored below (t0_par can fall back to

--- a/src/exozippy/components/mulensing/physics.py
+++ b/src/exozippy/components/mulensing/physics.py
@@ -48,6 +48,28 @@ def calc_mu_rel_mag(mu_ra_rel, mu_dec_rel):
     return pt.sqrt(pt.sqr(mu_ra_rel) + pt.sqr(mu_dec_rel))
 
 
+# Heliocentric -> geocentric frame conversion (Gould 2004):
+#   mu_geo = mu_helio - pi_rel * v_earth_perp(t0_par) / AU
+# The star pm_ra/pm_dec are barycentric observables (what the galactic
+# kinematic prior and any Gaia prior constrain), but the light-curve
+# trajectory is in the Skowron+2011 GEOCENTRIC convention (Earth's position
+# AND velocity at t0_par define the frame; see MulensInstrument), so t_E and
+# the pi_E direction must use the geocentric relative proper motion.
+# earth_vperp_* are Earth's velocity at t0_par projected on the sky
+# (East, North) in AU/yr -- context constants injected by Lens.add_parameter
+# (pi_rel in mas makes the product mas/yr).  The SIGN is pinned numerically
+# against the trajectory formula in tests/test_mu_rel_geo.py: the flipped
+# sign changes t_E by tens of percent at pi_rel ~ 0.35 mas.
+@register_physics
+def calc_mu_ra_rel_geo(mu_ra_rel, pi_rel, earth_vperp_e):
+    return mu_ra_rel - pi_rel * earth_vperp_e
+
+
+@register_physics
+def calc_mu_dec_rel_geo(mu_dec_rel, pi_rel, earth_vperp_n):
+    return mu_dec_rel - pi_rel * earth_vperp_n
+
+
 @register_physics
 def calc_t_E(theta_E, mu_rel_mag):
     # Convert mu_rel_mag from mas/yr to mas/day, then divide theta_E

--- a/src/exozippy/components/mulensing/symbolic_physics.py
+++ b/src/exozippy/components/mulensing/symbolic_physics.py
@@ -145,7 +145,14 @@ RELATIONS = [
     sp.Eq(theta_E**2, KAPPA * lens_mass_total * pi_rel),
     # Relative Parallax (dist in pc -> pi in mas)
     sp.Eq(pi_rel, (1000 / lens_distance) - (1000 / source_distance)),
-    # Einstein Time (mu in mas/yr -> t_E in days)
+    # Einstein Time (mu in mas/yr -> t_E in days).  SEEDING APPROXIMATION:
+    # the runtime graph derives t_E from mu_rel_GEO (= mu_rel_helio -
+    # pi_rel * v_earth_perp(t0_par)/AU, Gould 2004), but t0_par and Earth's
+    # velocity are resolved at stage 1a -- after these relations are
+    # constructed -- so the engine seeds through the heliocentric value.
+    # Starts land a few percent off for large-pi_rel events; the samplers
+    # absorb that.  (MMEXOFAST t_E seeds are geocentric, so the back-solved
+    # pms are helio-approximate too.)
     sp.Eq(t_E, theta_E / (mu_rel_mag / 365.25)),
     # Relative Motion Magnitude
     sp.Eq(mu_rel_mag**2, mu_ra_rel**2 + mu_dec_rel**2),

--- a/src/exozippy/constants.py
+++ b/src/exozippy/constants.py
@@ -89,6 +89,30 @@ SUN_VELOCITY_X = -12.7  # in km/s
 SUN_VELOCITY_Y = 24.0 + DISK_ROTATION_VELOCITY  # in km/s
 SUN_VELOCITY_Z = 7.25  # in km/s
 
+# --- 8. GALACTIC DENSITY ZERO POINTS (Msun/pc^3) ---
+# The disk/bulge mixture in components/galacticmodel needs each branch's
+# density on a COMMON absolute scale -- only the ratio matters for the
+# mixture weight, but a physical anchor keeps each rho0 auditable.  Both
+# are stellar MASS densities; using them as per-star (number) weights
+# assumes comparable mean stellar mass in the two populations, good to
+# ~10s of percent for two old populations with the same IMF.
+#
+# Disk: single exponential rho0 * exp(-r/L - |z|/H), anchored to the
+# local stellar mass density rho(R_sun, 0) ~ 0.04 Msun/pc^3 (Bovy 2017).
+DISK_DENSITY_RHO0 = 0.04 * np.exp(SUN_GC_DISTANCE / DISK_SCALE_LENGTH)
+# Bulge/bar: rho0 * exp(-r_s/2) with the Zhu+17 ellipsoid axes above,
+# anchored to a total bar stellar mass of 1.8e10 Msun (Portail+ 2015).
+# The profile integral is 64*pi*x0*y0*z0 (substitute u = r_s/2:
+# 4*pi*int s^2 exp(-s/2) ds = 64*pi); the 1e9 converts kpc^3 -> pc^3.
+BULGE_DENSITY_RHO0 = 1.8e10 / (
+    64.0
+    * np.pi
+    * BULGE_DENSITY_X_0
+    * BULGE_DENSITY_Y_0
+    * BULGE_DENSITY_Z_0
+    * 1e9
+)
+
 # IAU 2015, Resolution B2 zero point values
 LSUN = 1 * u.Lsun
 M_BOL_SUN = LSUN.to(u.M_bol).value

--- a/src/exozippy/constants.py
+++ b/src/exozippy/constants.py
@@ -56,6 +56,12 @@ BULGE_DENSITY_X_0 = 1.590  # in kpc, bulge density axis X in kpc from Zhu+17
 BULGE_DENSITY_Y_0 = 0.424  # in kpc, bulge density axis Y in kpc from Zhu+17
 BULGE_DENSITY_Z_0 = 0.424  # in kpc, bulge density axis Z in kpc from Zhu+17
 BULGE_GAMMA = -2.0  # see Koshimoto and Bennett 2020 Sec. 3.4
+# Outer cylindrical cutoff of the bar (genulens: Rc, srob).  Beyond
+# R = BULGE_RC the bar density is multiplied by a Gaussian of width
+# BULGE_RC_WIDTH in R -- without it the shallow exp(-r_s/2) profile
+# leaks bulge stars all the way to the Sun (0.9% of central at R0).
+BULGE_RC = 2.632  # in kpc, Koshimoto+ 2021 E-model Rc (genulens rc)
+BULGE_RC_WIDTH = 0.5  # in kpc (genulens srob)
 BULGE_VELOCITY_SIGMA_1 = (
     120.0  # in km/s, basedon on Koshimoto & Bennett 2020 tab. 1
 )
@@ -70,48 +76,62 @@ BULGE_ROTATION_ANGULAR_VELOCITY = (
 )
 
 # --- 6. DISK CONSTANTS ---
-DISK_SCALE_LENGTH = (
-    3.5  # disk density scale length from Koshimoto & Bennett 2020; in kpc
-)
-DISK_SCALE_HEIGHT = (
-    0.325  # disk density scale height from Koshimoto & Bennett 2020; in kpc
-)
-DISK_ROTATION_VELOCITY = 220.0  # in km/s
-DISK_VELOCITY_SIGMA_U = 30.0  # in km/s, rough guess
-DISK_VELOCITY_SIGMA_V = 30.0  # in km/s, rough guess
-DISK_VELOCITY_SIGMA_W = 30.0  # in km/s, rough guess
+# Thin disk structure from Koshimoto, Bennett & Suzuki 2021 (genulens):
+# Rd = 2.6 kpc with the density held CONSTANT inside R = 5.3 kpc (their
+# DISK=2 "hole"/plateau -- the inner disk does not keep rising toward
+# the GC), vertical exp with 325 pc (their age bins span 61-445 pc
+# sech^2; one exp layer is our simplification).
+DISK_SCALE_LENGTH = 2.6  # in kpc, thin disk Rd (genulens Rd[1])
+DISK_RDBREAK = 5.3  # in kpc, density flat inside this R (genulens Rdbreak)
+DISK_SCALE_HEIGHT = 0.325  # in kpc, thin disk vertical scale
+# Thick disk (genulens Rd[2], zd[7]): exp in both R (same plateau) and z.
+THICK_DISK_SCALE_LENGTH = 2.2  # in kpc
+THICK_DISK_SCALE_HEIGHT = 0.903  # in kpc
+# Disk kinematics: the analytic (non-Shu) branch genulens itself provides
+# (its B14disk mode, Bennett et al. 2014): mean rotation and fixed
+# dispersions per component.  These replace the old "rough guess"
+# (220; 30,30,30).
+DISK_ROTATION_VELOCITY = 218.0  # in km/s, thin disk mean v_phi
+DISK_VELOCITY_SIGMA_U = 39.9  # in km/s, thin disk radial
+DISK_VELOCITY_SIGMA_V = 27.9  # in km/s, thin disk azimuthal
+DISK_VELOCITY_SIGMA_W = 19.1  # in km/s, thin disk vertical
+THICK_DISK_ROTATION_VELOCITY = 170.0  # in km/s (asymmetric drift included)
+THICK_DISK_VELOCITY_SIGMA_U = 67.0  # in km/s
+THICK_DISK_VELOCITY_SIGMA_V = 51.0  # in km/s
+THICK_DISK_VELOCITY_SIGMA_W = 42.0  # in km/s
 KROUPA_IMF_SLOPE = -1.3  # Kroupa IMF (mass range typical for lenses)
 SALPETER_IMF_SLOPE = -2.35  # Salpeter IMF
 
 # --- 7. SUN CONSTANTS ---
-SUN_GC_DISTANCE = 8.3
-SUN_VELOCITY_X = -12.7  # in km/s
-SUN_VELOCITY_Y = 24.0 + DISK_ROTATION_VELOCITY  # in km/s
-SUN_VELOCITY_Z = 7.25  # in km/s
+SUN_GC_DISTANCE = 8.16  # in kpc (genulens/Koshimoto+21 R0 = 8160 pc)
+SUN_Z_OFFSET = 0.025  # in kpc, Sun's height above the plane (genulens zsun)
+# Solar velocity in the galactocentric frame, genulens convention
+# (vxsun toward the GC, vysun in the rotation direction, vzsun up):
+SUN_GALCEN_V = (10.0, 243.0, 7.0)  # in km/s
+SUN_VELOCITY_X = -12.7  # in km/s (legacy, rp.py convention)
+SUN_VELOCITY_Y = 24.0 + DISK_ROTATION_VELOCITY  # in km/s (legacy)
+SUN_VELOCITY_Z = 7.25  # in km/s (legacy)
 
-# --- 8. GALACTIC DENSITY ZERO POINTS (Msun/pc^3) ---
-# The disk/bulge mixture in components/galacticmodel needs each branch's
-# density on a COMMON absolute scale -- only the ratio matters for the
-# mixture weight, but a physical anchor keeps each rho0 auditable.  Both
-# are stellar MASS densities; using them as per-star (number) weights
-# assumes comparable mean stellar mass in the two populations, good to
-# ~10s of percent for two old populations with the same IMF.
+# --- 8. GALACTIC POPULATION NUMBER DENSITIES (stars/pc^3, MS+BD) ---
+# Branch weights for the disk/thick/bulge mixture in
+# components/galacticmodel.  These are genulens's own NUMBER-density
+# channel (n0MS* in its run_context.hpp) -- the channel it uses to decide
+# which population a star belongs to -- so no mean-stellar-mass caveat
+# applies.  Only ratios matter for the mixture; the absolute scale is
+# arbitrary but kept physical for auditability.
 #
-# Disk: single exponential rho0 * exp(-r/L - |z|/H), anchored to the
-# local stellar mass density rho(R_sun, 0) ~ 0.04 Msun/pc^3 (Bovy 2017).
-DISK_DENSITY_RHO0 = 0.04 * np.exp(SUN_GC_DISTANCE / DISK_SCALE_LENGTH)
-# Bulge/bar: rho0 * exp(-r_s/2) with the Zhu+17 ellipsoid axes above,
-# anchored to a total bar stellar mass of 1.8e10 Msun (Portail+ 2015).
-# The profile integral is 64*pi*x0*y0*z0 (substitute u = r_s/2:
-# 4*pi*int s^2 exp(-s/2) ds = 64*pi); the 1e9 converts kpc^3 -> pc^3.
-BULGE_DENSITY_RHO0 = 1.8e10 / (
-    64.0
-    * np.pi
-    * BULGE_DENSITY_X_0
-    * BULGE_DENSITY_Y_0
-    * BULGE_DENSITY_Z_0
-    * 1e9
-)
+# Thin disk local (R0, midplane): sum of the 7 thin-disk age bins' n0MSd.
+DISK_LOCAL_NUMBER_DENSITY = 0.1633
+# Thick disk local: n0MSd[7].
+THICK_DISK_LOCAL_NUMBER_DENSITY = 7.91e-3
+# Bar central: derived with genulens's VVV-box budget applied to OUR bar
+# profile (exp(-r_s/2), Zhu+17 axes, BULGE_RC cutoff):
+#   rho0b = (frho0b * M_VVV(P17) - M_disk_in_box) / int_box(profile)
+#         = (0.839015 * 1.32e10 - 1.312e9) / 9.307e9 pc^3
+#         = 1.049 Msun/pc^3   (Portail+ 2017 box |xb|<2.2,|yb|<1.4,|z|<1.2)
+#   n0   = rho0b * fb_MS * m2nb_MS = rho0b * (1.62/2.07) / 0.227943
+# Pinned by tests/test_galactic_model.py, which recomputes the integral.
+BULGE_CENTRAL_NUMBER_DENSITY = 3.60
 
 # IAU 2015, Resolution B2 zero point values
 LSUN = 1 * u.Lsun

--- a/src/exozippy/graph.py
+++ b/src/exozippy/graph.py
@@ -49,7 +49,14 @@ def determine_pymc_build_order(active_components, config_manager):
                     if manifest_deps is not None
                     else expressions_dict[expr_key].get("deps", [])
                 )
+                # Deps a component declares in context_dep_names are
+                # satisfied by context-node injection in its add_parameter
+                # override (constants, not manifest parameters) -- they are
+                # excluded from the build-order graph.
+                context_deps = getattr(comp, "context_dep_names", frozenset())
                 for d in dep_names:
+                    if d in context_deps:
+                        continue
                     if "." in d:
                         # Strip off any bracket indicators to get the raw structural key (e.g., "star.mass")
                         clean_dep = d.split("[")[0] if "[" in d else d

--- a/tests/test_galactic_model.py
+++ b/tests/test_galactic_model.py
@@ -215,8 +215,10 @@ def test_kinematic_prior_prefers_corotation_over_radial_plunge():
 
     # ASSERT: margins allow for the logsumexp bulge branch, whose ~110 km/s
     # dispersions partially absorb any velocity direction and floor the
-    # disk-term penalty (measured: corot beats radial by 7.9 nats and
-    # counter-rotation by 14.3; before the fix corot LOST to radial by 43).
+    # disk-term penalty (measured: corot beats radial by 11.6 nats and
+    # counter-rotation by 18.0; before the fix corot LOST to radial by 43.
+    # The 2026-08 mixture normalization down-weighted the bulge branch by
+    # ~3.9 nats, which widened these margins from 7.9/14.3).
     assert lps["corot"] > lps["radial"] + 5.0
     assert lps["corot"] > lps["counter"] + 10.0
 
@@ -249,7 +251,152 @@ def test_kinematic_prior_corotating_star_pays_no_velocity_penalty():
     lp_fast = lp_at(DISK_ROTATION_VELOCITY + 3.0 * DISK_VELOCITY_SIGMA_V)
     lp_slow = lp_at(DISK_ROTATION_VELOCITY - 3.0 * DISK_VELOCITY_SIGMA_V)
 
-    # Margins again reflect bulge-branch flooring (measured: +1.4 and +2.5
-    # nats for +/-3 sigma; the disk term alone would give 4.5).
+    # Margins again reflect bulge-branch flooring (measured: +4.1 and +4.3
+    # nats for +/-3 sigma after the 2026-08 mixture normalization weakened
+    # the floor, up from +1.4/+2.5; the disk term alone would give 4.5).
     assert lp_circ > lp_fast + 1.0
     assert lp_circ > lp_slow + 1.0
+
+
+# ---------------------------------------------------------------------------
+# Normalization: velocity Jacobian + mixture branch normalization
+# ---------------------------------------------------------------------------
+
+
+def _reference_kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms):
+    """Independent numpy reference of the kinematic prior for one star at
+    the mock RA/Dec, with astropy doing the full (nonlinearized) velocity
+    transform.  Pins the 2026-08 normalization fixes:
+      - the pm -> velocity change-of-variables Jacobian +2*log(K*d)
+        (velocity Gaussians in km/s, sampled coordinates in mas/yr),
+      - per-branch velocity normalization -log(sigma1*sigma2*sigma3),
+      - per-branch density zero points log(rho0_disk) / log(rho0_bulge).
+    """
+    import astropy.units as u
+    from astropy.coordinates import Galactocentric, SkyCoord
+
+    from exozippy.constants import (
+        BULGE_BAR_ANGLE,
+        BULGE_DENSITY_RHO0,
+        BULGE_DENSITY_X_0,
+        BULGE_DENSITY_Y_0,
+        BULGE_DENSITY_Z_0,
+        BULGE_ROTATION_ANGULAR_VELOCITY,
+        BULGE_VELOCITY_SIGMA_1,
+        BULGE_VELOCITY_SIGMA_2,
+        BULGE_VELOCITY_SIGMA_3,
+        DISK_DENSITY_RHO0,
+        DISK_ROTATION_VELOCITY,
+        DISK_SCALE_HEIGHT,
+        DISK_SCALE_LENGTH,
+        DISK_VELOCITY_SIGMA_U,
+        DISK_VELOCITY_SIGMA_V,
+        DISK_VELOCITY_SIGMA_W,
+        K_VEL_CONVERSION,
+        SUN_GC_DISTANCE,
+    )
+
+    sc = SkyCoord(ra=_RA_RAD * u.rad, dec=_DEC_RAD * u.rad)
+    l_rad, b_rad = sc.galactic.l.rad, sc.galactic.b.rad
+    d = max(d_pc, 1e-3) / 1e3  # kpc, same floor as the model
+
+    # Position in the model's own convention (Sun at x = +SUN_GC_DISTANCE)
+    x = SUN_GC_DISTANCE - d * np.cos(l_rad) * np.cos(b_rad)
+    y = d * np.sin(l_rad) * np.cos(b_rad)
+    z = d * np.sin(b_rad)
+    z_smooth = np.sqrt(z**2 + 1e-6)
+    r = np.sqrt(x**2 + y**2 + 1e-6)
+
+    # Velocity via astropy's exact transform.  The model linearizes at
+    # d = 1 kpc, but the map is exactly linear in (K*pm*d, rv), so the
+    # two agree to float precision.
+    gal = SkyCoord(
+        ra=_RA_RAD * u.rad,
+        dec=_DEC_RAD * u.rad,
+        distance=d * u.kpc,
+        pm_ra_cosdec=pm_ra * u.mas / u.yr,
+        pm_dec=pm_dec * u.mas / u.yr,
+        radial_velocity=(rv_ms / 1e3) * u.km / u.s,
+    ).transform_to(Galactocentric())
+    v_x = gal.v_x.to_value(u.km / u.s)
+    v_y = gal.v_y.to_value(u.km / u.s)
+    v_z = gal.v_z.to_value(u.km / u.s)
+    v_r = v_y * (y / r) + v_x * (x / r)
+    v_phi = v_y * (x / r) - v_x * (y / r)
+
+    cos_bar, sin_bar = np.cos(BULGE_BAR_ANGLE), np.sin(BULGE_BAR_ANGLE)
+    x_bar = x * cos_bar + y * sin_bar
+    y_bar = -x * sin_bar + y * cos_bar
+
+    L_disk = (
+        -r / DISK_SCALE_LENGTH
+        - z_smooth / DISK_SCALE_HEIGHT
+        - 0.5 * (v_r / DISK_VELOCITY_SIGMA_U) ** 2
+        - 0.5 * ((v_phi - DISK_ROTATION_VELOCITY) / DISK_VELOCITY_SIGMA_V) ** 2
+        - 0.5 * (v_z / DISK_VELOCITY_SIGMA_W) ** 2
+        + np.log(DISK_DENSITY_RHO0)
+        - np.log(
+            DISK_VELOCITY_SIGMA_U
+            * DISK_VELOCITY_SIGMA_V
+            * DISK_VELOCITY_SIGMA_W
+        )
+    )
+    r_s = np.sqrt(
+        (x_bar / BULGE_DENSITY_X_0) ** 2
+        + (y_bar / BULGE_DENSITY_Y_0) ** 2
+        + (z / BULGE_DENSITY_Z_0) ** 2
+    )
+    L_bulge = (
+        -0.5 * r_s
+        - 0.5 * (v_r / BULGE_VELOCITY_SIGMA_1) ** 2
+        - 0.5
+        * (
+            (v_phi - BULGE_ROTATION_ANGULAR_VELOCITY * r)
+            / BULGE_VELOCITY_SIGMA_2
+        )
+        ** 2
+        - 0.5 * (v_z / BULGE_VELOCITY_SIGMA_3) ** 2
+        + np.log(BULGE_DENSITY_RHO0)
+        - np.log(
+            BULGE_VELOCITY_SIGMA_1
+            * BULGE_VELOCITY_SIGMA_2
+            * BULGE_VELOCITY_SIGMA_3
+        )
+    )
+    return (
+        np.logaddexp(L_disk, L_bulge)
+        + 2.0 * np.log(d * 1e3)
+        + 2.0 * np.log(K_VEL_CONVERSION * d)
+    )
+
+
+@pytest.mark.parametrize(
+    "d_pc, pm_ra, pm_dec, rv_ms",
+    [
+        (8000.0, 0.0, 0.0, 0.0),  # bulge-like, at rest on the sky
+        (2500.0, -2.0, -4.0, 1.5e4),  # disk-lens-like, moving
+        (1000.0, 5.0, 3.0, -2.0e4),  # nearby, fast
+        (5000.0, -1.0, -6.0, 8.0e4),  # intermediate
+    ],
+)
+def test_kinematic_prior_matches_independent_reference(
+    d_pc, pm_ra, pm_dec, rv_ms
+):
+    """
+    Given a star with the given distance, proper motion, and RV,
+    When the kinematic_prior Potential is evaluated,
+    Then it matches an independent numpy/astropy implementation of the
+      normalized mixture prior -- including the +2*log(K*d) velocity
+      Jacobian and the per-branch -log(sigma^3) + log(rho0) terms, whose
+      omission previously tilted distances low by d^2 and over-weighted
+      the bulge branch by ~3.9 nats.
+
+    Spanning 1-8 kpc makes the test sensitive to any wrong power of
+    distance, and the disk/bulge mix shifts across the points so a
+    missing branch normalization cannot cancel.
+    """
+    lp_model = _kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms)
+    lp_ref = _reference_kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms)
+    assert np.isclose(lp_model, lp_ref, rtol=0.0, atol=1e-6), (
+        f"model {lp_model} != reference {lp_ref}"
+    )

--- a/tests/test_galactic_model.py
+++ b/tests/test_galactic_model.py
@@ -138,14 +138,19 @@ def test_imf_salpeter_branch_does_not_crash():
 
 def _pm_rv_for_velocity(ra_deg, dec_deg, d_kpc, v_gal):
     """ICRS (pm_ra_cosdec [mas/yr], pm_dec [mas/yr], rv [m/s]) of a star at
-    the given position with the given astropy-Galactocentric velocity."""
+    the given position with the given galactocentric velocity, in the
+    component's own frame (R0/z_sun/vsun-consistent with the densities)."""
     import astropy.units as u
-    from astropy.coordinates import ICRS, Galactocentric, SkyCoord
+    from astropy.coordinates import ICRS, SkyCoord
+
+    from exozippy.components.galacticmodel.galacticmodel import (
+        GALACTOCENTRIC_FRAME,
+    )
 
     sc = SkyCoord(
         ra=ra_deg * u.deg, dec=dec_deg * u.deg, distance=d_kpc * u.kpc
     )
-    gc = sc.transform_to(Galactocentric())
+    gc = sc.transform_to(GALACTOCENTRIC_FRAME)
     star = SkyCoord(
         x=gc.x,
         y=gc.y,
@@ -153,7 +158,7 @@ def _pm_rv_for_velocity(ra_deg, dec_deg, d_kpc, v_gal):
         v_x=v_gal[0] * u.km / u.s,
         v_y=v_gal[1] * u.km / u.s,
         v_z=v_gal[2] * u.km / u.s,
-        frame=Galactocentric(),
+        frame=GALACTOCENTRIC_FRAME,
     ).transform_to(ICRS())
     return (
         float(star.pm_ra_cosdec.to_value(u.mas / u.yr)),
@@ -213,12 +218,12 @@ def test_kinematic_prior_prefers_corotation_over_radial_plunge():
         # ACT
         lps[tag] = _kinematic_lp(d_kpc * 1e3, pm_ra, pm_dec, rv)
 
-    # ASSERT: margins allow for the logsumexp bulge branch, whose ~110 km/s
-    # dispersions partially absorb any velocity direction and floor the
-    # disk-term penalty (measured: corot beats radial by 11.6 nats and
-    # counter-rotation by 18.0; before the fix corot LOST to radial by 43.
-    # The 2026-08 mixture normalization down-weighted the bulge branch by
-    # ~3.9 nats, which widened these margins from 7.9/14.3).
+    # ASSERT: margins allow for the logsumexp bulge/thick branches, whose
+    # hotter dispersions partially absorb any velocity direction and floor
+    # the thin-disk penalty (measured: corot beats radial by 16.5 nats and
+    # counter-rotation by 33.1; before the fix corot LOST to radial by 43.
+    # The 2026-08 mixture normalization + bar cutoff + genulens kinematics
+    # widened these margins from 7.9/14.3).
     assert lps["corot"] > lps["radial"] + 5.0
     assert lps["corot"] > lps["counter"] + 10.0
 
@@ -251,9 +256,10 @@ def test_kinematic_prior_corotating_star_pays_no_velocity_penalty():
     lp_fast = lp_at(DISK_ROTATION_VELOCITY + 3.0 * DISK_VELOCITY_SIGMA_V)
     lp_slow = lp_at(DISK_ROTATION_VELOCITY - 3.0 * DISK_VELOCITY_SIGMA_V)
 
-    # Margins again reflect bulge-branch flooring (measured: +4.1 and +4.3
-    # nats for +/-3 sigma after the 2026-08 mixture normalization weakened
-    # the floor, up from +1.4/+2.5; the disk term alone would give 4.5).
+    # Margins again reflect mixture flooring by the hotter branches
+    # (measured: +4.4 and +3.9 nats for +/-3 sigma after the 2026-08
+    # normalization + fidelity upgrade, up from +1.4/+2.5; the thin-disk
+    # term alone would give 4.5).
     assert lp_circ > lp_fast + 1.0
     assert lp_circ > lp_slow + 1.0
 
@@ -266,26 +272,36 @@ def test_kinematic_prior_corotating_star_pays_no_velocity_penalty():
 def _reference_kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms):
     """Independent numpy reference of the kinematic prior for one star at
     the mock RA/Dec, with astropy doing the full (nonlinearized) velocity
-    transform.  Pins the 2026-08 normalization fixes:
+    transform.  Pins the 2026-08 normalization fixes and the genulens-
+    fidelity upgrade:
       - the pm -> velocity change-of-variables Jacobian +2*log(K*d)
         (velocity Gaussians in km/s, sampled coordinates in mas/yr),
       - per-branch velocity normalization -log(sigma1*sigma2*sigma3),
-      - per-branch density zero points log(rho0_disk) / log(rho0_bulge).
+      - per-branch number-density anchors (thin/thick local, bulge central),
+      - the inner-disk plateau (R < DISK_RDBREAK) and the bar's outer
+        cylindrical cutoff (beyond BULGE_RC),
+      - the thick-disk branch and the R0/z_sun-consistent frame.
     """
     import astropy.units as u
-    from astropy.coordinates import Galactocentric, SkyCoord
+    from astropy.coordinates import SkyCoord
 
+    from exozippy.components.galacticmodel.galacticmodel import (
+        GALACTOCENTRIC_FRAME,
+    )
     from exozippy.constants import (
         BULGE_BAR_ANGLE,
-        BULGE_DENSITY_RHO0,
+        BULGE_CENTRAL_NUMBER_DENSITY,
         BULGE_DENSITY_X_0,
         BULGE_DENSITY_Y_0,
         BULGE_DENSITY_Z_0,
+        BULGE_RC,
+        BULGE_RC_WIDTH,
         BULGE_ROTATION_ANGULAR_VELOCITY,
         BULGE_VELOCITY_SIGMA_1,
         BULGE_VELOCITY_SIGMA_2,
         BULGE_VELOCITY_SIGMA_3,
-        DISK_DENSITY_RHO0,
+        DISK_LOCAL_NUMBER_DENSITY,
+        DISK_RDBREAK,
         DISK_ROTATION_VELOCITY,
         DISK_SCALE_HEIGHT,
         DISK_SCALE_LENGTH,
@@ -294,22 +310,35 @@ def _reference_kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms):
         DISK_VELOCITY_SIGMA_W,
         K_VEL_CONVERSION,
         SUN_GC_DISTANCE,
+        SUN_Z_OFFSET,
+        THICK_DISK_LOCAL_NUMBER_DENSITY,
+        THICK_DISK_ROTATION_VELOCITY,
+        THICK_DISK_SCALE_HEIGHT,
+        THICK_DISK_SCALE_LENGTH,
+        THICK_DISK_VELOCITY_SIGMA_U,
+        THICK_DISK_VELOCITY_SIGMA_V,
+        THICK_DISK_VELOCITY_SIGMA_W,
     )
+
+    def hinge(t):  # same smooth max(t, 0) as the model
+        return 0.5 * (t + np.sqrt(t * t + 0.0025))
 
     sc = SkyCoord(ra=_RA_RAD * u.rad, dec=_DEC_RAD * u.rad)
     l_rad, b_rad = sc.galactic.l.rad, sc.galactic.b.rad
     d = max(d_pc, 1e-3) / 1e3  # kpc, same floor as the model
 
-    # Position in the model's own convention (Sun at x = +SUN_GC_DISTANCE)
+    # Position in the model's own convention (Sun at x = +SUN_GC_DISTANCE,
+    # z tilted by bsun = z_sun/R0 so d=0 lands at z = +z_sun)
     x = SUN_GC_DISTANCE - d * np.cos(l_rad) * np.cos(b_rad)
     y = d * np.sin(l_rad) * np.cos(b_rad)
-    z = d * np.sin(b_rad)
+    bsun = SUN_Z_OFFSET / SUN_GC_DISTANCE
+    z = d * np.sin(b_rad) * np.cos(bsun) + x * np.sin(bsun)
     z_smooth = np.sqrt(z**2 + 1e-6)
     r = np.sqrt(x**2 + y**2 + 1e-6)
 
-    # Velocity via astropy's exact transform.  The model linearizes at
-    # d = 1 kpc, but the map is exactly linear in (K*pm*d, rv), so the
-    # two agree to float precision.
+    # Velocity via astropy's exact transform in the component's frame.
+    # The model linearizes at d = 1 kpc, but the map is exactly linear in
+    # (K*pm*d, rv), so the two agree to float precision.
     gal = SkyCoord(
         ra=_RA_RAD * u.rad,
         dec=_DEC_RAD * u.rad,
@@ -317,7 +346,7 @@ def _reference_kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms):
         pm_ra_cosdec=pm_ra * u.mas / u.yr,
         pm_dec=pm_dec * u.mas / u.yr,
         radial_velocity=(rv_ms / 1e3) * u.km / u.s,
-    ).transform_to(Galactocentric())
+    ).transform_to(GALACTOCENTRIC_FRAME)
     v_x = gal.v_x.to_value(u.km / u.s)
     v_y = gal.v_y.to_value(u.km / u.s)
     v_z = gal.v_z.to_value(u.km / u.s)
@@ -328,17 +357,36 @@ def _reference_kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms):
     x_bar = x * cos_bar + y * sin_bar
     y_bar = -x * sin_bar + y * cos_bar
 
-    L_disk = (
-        -r / DISK_SCALE_LENGTH
+    r_plateau = hinge(r - DISK_RDBREAK) - (SUN_GC_DISTANCE - DISK_RDBREAK)
+    L_thin = (
+        np.log(DISK_LOCAL_NUMBER_DENSITY)
+        - r_plateau / DISK_SCALE_LENGTH
         - z_smooth / DISK_SCALE_HEIGHT
         - 0.5 * (v_r / DISK_VELOCITY_SIGMA_U) ** 2
         - 0.5 * ((v_phi - DISK_ROTATION_VELOCITY) / DISK_VELOCITY_SIGMA_V) ** 2
         - 0.5 * (v_z / DISK_VELOCITY_SIGMA_W) ** 2
-        + np.log(DISK_DENSITY_RHO0)
         - np.log(
             DISK_VELOCITY_SIGMA_U
             * DISK_VELOCITY_SIGMA_V
             * DISK_VELOCITY_SIGMA_W
+        )
+    )
+    L_thick = (
+        np.log(THICK_DISK_LOCAL_NUMBER_DENSITY)
+        - r_plateau / THICK_DISK_SCALE_LENGTH
+        - z_smooth / THICK_DISK_SCALE_HEIGHT
+        - 0.5 * (v_r / THICK_DISK_VELOCITY_SIGMA_U) ** 2
+        - 0.5
+        * (
+            (v_phi - THICK_DISK_ROTATION_VELOCITY)
+            / THICK_DISK_VELOCITY_SIGMA_V
+        )
+        ** 2
+        - 0.5 * (v_z / THICK_DISK_VELOCITY_SIGMA_W) ** 2
+        - np.log(
+            THICK_DISK_VELOCITY_SIGMA_U
+            * THICK_DISK_VELOCITY_SIGMA_V
+            * THICK_DISK_VELOCITY_SIGMA_W
         )
     )
     r_s = np.sqrt(
@@ -347,7 +395,9 @@ def _reference_kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms):
         + (z / BULGE_DENSITY_Z_0) ** 2
     )
     L_bulge = (
-        -0.5 * r_s
+        np.log(BULGE_CENTRAL_NUMBER_DENSITY)
+        - 0.5 * r_s
+        - 0.5 * (hinge(r - BULGE_RC) / BULGE_RC_WIDTH) ** 2
         - 0.5 * (v_r / BULGE_VELOCITY_SIGMA_1) ** 2
         - 0.5
         * (
@@ -356,15 +406,17 @@ def _reference_kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms):
         )
         ** 2
         - 0.5 * (v_z / BULGE_VELOCITY_SIGMA_3) ** 2
-        + np.log(BULGE_DENSITY_RHO0)
         - np.log(
             BULGE_VELOCITY_SIGMA_1
             * BULGE_VELOCITY_SIGMA_2
             * BULGE_VELOCITY_SIGMA_3
         )
     )
+    branches = np.array([L_thin, L_thick, L_bulge])
+    m = branches.max()
     return (
-        np.logaddexp(L_disk, L_bulge)
+        m
+        + np.log(np.exp(branches - m).sum())
         + 2.0 * np.log(d * 1e3)
         + 2.0 * np.log(K_VEL_CONVERSION * d)
     )
@@ -399,4 +451,76 @@ def test_kinematic_prior_matches_independent_reference(
     lp_ref = _reference_kinematic_lp(d_pc, pm_ra, pm_dec, rv_ms)
     assert np.isclose(lp_model, lp_ref, rtol=0.0, atol=1e-6), (
         f"model {lp_model} != reference {lp_ref}"
+    )
+
+
+def test_bulge_number_density_matches_vvv_box_budget():
+    """
+    Given the bar profile the component actually uses (exp(-r_s/2), Zhu+17
+      axes, BULGE_RC cutoff),
+    When its central density is derived with genulens's VVV-box budget
+      (rho0b = (frho0b * M_VVV(Portail+17) - M_disk_in_box)/box integral,
+      then mass -> MS+BD number via fb_MS/mean-MS-mass),
+    Then it reproduces the hard-coded BULGE_CENTRAL_NUMBER_DENSITY --
+      guarding the constant's derivation against silent drift in either
+      the profile or the disk constants it subtracts.
+    """
+    from exozippy.constants import (
+        BULGE_CENTRAL_NUMBER_DENSITY,
+        BULGE_DENSITY_X_0,
+        BULGE_DENSITY_Y_0,
+        BULGE_DENSITY_Z_0,
+        BULGE_RC,
+        BULGE_RC_WIDTH,
+        DISK_RDBREAK,
+        DISK_SCALE_HEIGHT,
+        DISK_SCALE_LENGTH,
+        SUN_GC_DISTANCE,
+        THICK_DISK_SCALE_HEIGHT,
+        THICK_DISK_SCALE_LENGTH,
+    )
+
+    # ARRANGE: Portail+17 VVV box, bar frame, in kpc
+    xmax, ymax, zmax = 2.2, 1.4, 1.2
+    n = 200
+    xg = np.linspace(0.0, xmax, n)
+    yg = np.linspace(0.0, ymax, n)
+    zg = np.linspace(0.0, zmax, n)
+    X, Y = np.meshgrid(xg, yg, indexing="ij")
+    R = np.hypot(X, Y)
+    cut = np.exp(-0.5 * (np.maximum(R - BULGE_RC, 0.0) / BULGE_RC_WIDTH) ** 2)
+    box_integral = 0.0  # kpc^3
+    for zz in zg:
+        r_s = np.sqrt(
+            (X / BULGE_DENSITY_X_0) ** 2
+            + (Y / BULGE_DENSITY_Y_0) ** 2
+            + (zz / BULGE_DENSITY_Z_0) ** 2
+        )
+        box_integral += (np.exp(-0.5 * r_s) * cut).sum()
+    box_integral *= 8 * (xg[1] - xg[0]) * (yg[1] - yg[0]) * (zg[1] - zg[0])
+
+    # Disk mass in the box (all R < BULGE_RC < DISK_RDBREAK -> plateau).
+    # Local MASS densities incl. WDs (genulens rho0d): thin 0.0501,
+    # thick 0.00228 Msun/pc^3 -- the box subtraction is a mass budget,
+    # unlike the number-density branch weights.
+    area_pc2 = (2 * xmax * 1e3) * (2 * ymax * 1e3)
+
+    def vertical(h_kpc):
+        h = h_kpc * 1e3
+        return 2 * h * (1 - np.exp(-zmax * 1e3 / h))
+
+    plateau = SUN_GC_DISTANCE - DISK_RDBREAK
+    m_disk_box = 0.050095 * np.exp(plateau / DISK_SCALE_LENGTH) * area_pc2 * (
+        vertical(DISK_SCALE_HEIGHT)
+    ) + 0.002282 * np.exp(plateau / THICK_DISK_SCALE_LENGTH) * area_pc2 * (
+        vertical(THICK_DISK_SCALE_HEIGHT)
+    )
+
+    # ACT: genulens normalization (frho0b, M_VVV, fb_MS, mean MS mass)
+    rho0b = (0.839014514507754 * 1.32e10 - m_disk_box) / (box_integral * 1e9)
+    n0_msb = rho0b * (1.62 / 2.07) / 0.227943
+
+    # ASSERT: 1% covers the box-integral grid resolution
+    assert np.isclose(n0_msb, BULGE_CENTRAL_NUMBER_DENSITY, rtol=0.01), (
+        f"recomputed {n0_msb:.4f} vs constant {BULGE_CENTRAL_NUMBER_DENSITY}"
     )

--- a/tests/test_mu_rel_geo.py
+++ b/tests/test_mu_rel_geo.py
@@ -1,0 +1,187 @@
+"""Tests for the heliocentric -> geocentric mu_rel frame conversion.
+
+The star pm_ra/pm_dec are barycentric observables (constrained by the
+galactic kinematic prior), but the light-curve trajectory is in the
+Skowron+2011 GEOCENTRIC convention (Earth's position and velocity at t0_par
+define the frame), so t_E and the pi_E direction must derive from
+mu_rel_geo = mu_rel_helio - pi_rel * v_earth_perp(t0_par)/AU (Gould 2004).
+The SIGN of that conversion is what these tests pin -- the flipped sign
+changes t_E by tens of percent at pi_rel ~ 0.35 mas.
+"""
+
+import numpy as np
+import pytensor.tensor as pt
+
+from exozippy.components.mulensing.physics import (
+    calc_mu_dec_rel_geo,
+    calc_mu_ra_rel_geo,
+)
+
+
+def test_calc_mu_rel_geo_values():
+    """
+    Given a heliocentric relative proper motion, pi_rel, and an Earth
+      velocity projection,
+    When the geo conversion physics functions are evaluated,
+    Then mu_geo = mu_helio - pi_rel * vperp, component by component.
+    """
+    mu_ra = pt.dscalar("mu_ra")
+    mu_dec = pt.dscalar("mu_dec")
+    pi_rel = pt.dscalar("pi_rel")
+    v_e = pt.dscalar("v_e")
+    v_n = pt.dscalar("v_n")
+
+    ra_geo = calc_mu_ra_rel_geo(mu_ra, pi_rel, v_e).eval(
+        {mu_ra: 3.1, pi_rel: 0.35, v_e: 4.2}
+    )
+    dec_geo = calc_mu_dec_rel_geo(mu_dec, pi_rel, v_n).eval(
+        {mu_dec: -2.4, pi_rel: 0.35, v_n: -1.7}
+    )
+    assert np.isclose(float(ra_geo), 3.1 - 0.35 * 4.2, rtol=0, atol=1e-14)
+    assert np.isclose(float(dec_geo), -2.4 + 0.35 * 1.7, rtol=0, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# First-principles sign pin
+# ---------------------------------------------------------------------------
+
+_EPS_ECL = np.radians(23.44)
+
+
+def _s_of_t(t):
+    """Synthetic circular 'Earth' orbit in the equatorial frame (AU)."""
+    th = 2 * np.pi * np.asarray(t) / 365.25
+    return np.stack(
+        [
+            np.cos(th),
+            np.sin(th) * np.cos(_EPS_ECL),
+            np.sin(th) * np.sin(_EPS_ECL),
+        ],
+        axis=-1,
+    )
+
+
+def _v_of_t(t, dt=0.5):
+    """AU/day, same finite difference as MulensInstrument."""
+    return (_s_of_t(np.asarray(t) + dt) - _s_of_t(np.asarray(t) - dt)) / (
+        2 * dt
+    )
+
+
+def test_mu_geo_sign_matches_first_principles_trajectory():
+    """
+    Given a lens-source pair defined HELIOCENTRICALLY (mu_helio, pi_rel,
+      theta_E) observed from a moving platform with full parallax,
+    When the light-curve trajectory is computed the model's way -- Skowron
+      deltas at t0_par, tau_p/u_p with t_E and pi_E derived from mu_rel_geo
+      via the actual physics functions,
+    Then the model magnification-trajectory u(t) reproduces the
+      first-principles heliocentric u(t) to float precision -- and the
+      OPPOSITE conversion sign (mu_helio + pi_rel*vperp) matches for no
+      orientation convention at all.
+
+    The trajectory formula (tau_p/u_p) is copied from Lens.get_magnification
+    and is separately pinned against MulensModel; what this test adds is the
+    frame-conversion sign feeding it.
+    """
+    # ARRANGE: sky position, anchor epoch, and the code's projections
+    ra, dec = np.radians(268.0), np.radians(-28.5)
+    e_hat = np.array([-np.sin(ra), np.cos(ra), 0.0])
+    n_hat = np.array(
+        [-np.cos(ra) * np.sin(dec), -np.sin(ra) * np.sin(dec), np.cos(dec)]
+    )
+
+    def proj_en(xyz):
+        return xyz @ e_hat, xyz @ n_hat
+
+    t0p = 137.0
+    t = np.linspace(t0p - 120, t0p + 120, 2001)
+
+    # Skowron deltas exactly as MulensInstrument._abs_to_delta builds them
+    dev = _s_of_t(t) - _s_of_t([t0p])[0] - np.outer(t - t0p, _v_of_t([t0p])[0])
+    delta_e, delta_n = proj_en(dev)
+
+    # Physical (heliocentric) parameters
+    pi_rel = 0.35  # mas
+    theta_E = 0.55  # mas
+    mu_helio = np.array([3.1, -2.4])  # (E, N), mas/yr
+    u0, t0 = 0.31, t0p
+
+    vperp_en = np.array(proj_en(_v_of_t([t0p])[0] * 365.25))  # AU/yr
+    s_full_e, s_full_n = proj_en(_s_of_t(t))
+    s0_e, s0_n = proj_en(_s_of_t([t0p])[0])
+
+    def best_match(mu_geo):
+        """Min over orientation conventions of max|u_model - u_truth|."""
+        mu_mag = float(np.hypot(*mu_geo))
+        m_hat = mu_geo / mu_mag
+        tE = theta_E / (mu_mag / 365.25)  # days, calc_t_E convention
+        piE_E = pi_rel / theta_E * m_hat[0]
+        piE_N = pi_rel / theta_E * m_hat[1]
+        best = np.inf
+        for p_sign in (+1, -1):
+            # Truth: heliocentric linear motion + FULL parallax shift
+            # (apparent relative position -= pi_rel * s_perp / AU), with
+            # the constant offset chosen so the geocentric-linear part has
+            # impact u0 at t0.
+            p_hat = p_sign * np.array([-m_hat[1], m_hat[0]])
+            th0 = theta_E * u0 * p_hat + pi_rel * np.array([s0_e, s0_n])
+            dt_yr = (t - t0) / 365.25
+            th_e = th0[0] + mu_helio[0] * dt_yr - pi_rel * s_full_e
+            th_n = th0[1] + mu_helio[1] * dt_yr - pi_rel * s_full_n
+            u_truth = np.hypot(th_e, th_n) / theta_E
+            for u0_sign in (+1, -1):
+                # Model: Lens.get_magnification's trajectory formula
+                tau = (t - t0) / tE
+                tau_p = tau - delta_n * piE_N - delta_e * piE_E
+                u_p = u0_sign * u0 + delta_n * piE_E - delta_e * piE_N
+                u_model = np.hypot(tau_p, u_p)
+                best = min(best, float(np.max(np.abs(u_model - u_truth))))
+        return best
+
+    # ACT: convert through the ACTUAL physics functions
+    mu_ra_s = pt.dscalar("mu_ra")
+    mu_dec_s = pt.dscalar("mu_dec")
+    pi_s = pt.dscalar("pi")
+    ve_s = pt.dscalar("ve")
+    vn_s = pt.dscalar("vn")
+    mu_geo_code = np.array(
+        [
+            float(
+                calc_mu_ra_rel_geo(mu_ra_s, pi_s, ve_s).eval(
+                    {mu_ra_s: mu_helio[0], pi_s: pi_rel, ve_s: vperp_en[0]}
+                )
+            ),
+            float(
+                calc_mu_dec_rel_geo(mu_dec_s, pi_s, vn_s).eval(
+                    {mu_dec_s: mu_helio[1], pi_s: pi_rel, vn_s: vperp_en[1]}
+                )
+            ),
+        ]
+    )
+    mu_geo_flipped = mu_helio + pi_rel * vperp_en
+
+    # ASSERT
+    assert best_match(mu_geo_code) < 1e-9, (
+        "physics-function mu_geo does not reproduce the heliocentric truth"
+    )
+    assert best_match(mu_geo_flipped) > 0.1, (
+        "flipped conversion sign should NOT match -- the pin is meaningless"
+    )
+
+
+def test_earth_vperp_fallback_without_mulens_data():
+    """
+    Given a Lens in a system with no mulensinstrument (no t0_par anchor),
+    When _earth_vperp_en is called,
+    Then it returns (0, 0) -- mu_rel_geo degrades to the heliocentric value
+      instead of crashing.
+    """
+    from types import SimpleNamespace
+
+    from exozippy.components.mulensing.lens import Lens
+
+    mock_self = SimpleNamespace(prefix="lens")
+    mock_system = SimpleNamespace()  # no mulensinstrument attribute
+    v_e, v_n = Lens._earth_vperp_en(mock_self, mock_system)
+    assert v_e == 0.0 and v_n == 0.0

--- a/tests/test_runaway_logp_regression.py
+++ b/tests/test_runaway_logp_regression.py
@@ -160,13 +160,15 @@ def _point(raw_dict):
 # post free_symbols-sort hardening).  Differs from the historical stored lp
 # (~2982.18) because the model itself has changed since that trace; see the
 # module docstring.
-# Re-measured 2026-08-08 three times: the Op-path annual parallax fix
+# Re-measured 2026-08-08 four times: the Op-path annual parallax fix
 # (review 1.1) moved the mulens likelihood (-934.604); the galacticmodel
 # prior normalization (reviews 1.3/1.4: pm->velocity Jacobian + mixture
 # branch normalization) shifted it to -952.076; the genulens-fidelity
 # upgrade (thick disk branch, bar cutoff, disk plateau, number-density
-# anchors, R0 = 8.16 frame) nudged it to -953.817.
-GOOD_EXPECTED_LP = -953.817
+# anchors, R0 = 8.16 frame) nudged it to -953.817; the mu_rel helio->geo
+# frame fix (t_E/pi_E now derive from mu_rel_geo at t0_par) moved the
+# mulens likelihood at this raw point to -944.858.
+GOOD_EXPECTED_LP = -944.858
 
 
 def test_good_draw_logp_matches_deterministic_build(dc2018_128_logp):

--- a/tests/test_runaway_logp_regression.py
+++ b/tests/test_runaway_logp_regression.py
@@ -160,7 +160,12 @@ def _point(raw_dict):
 # post free_symbols-sort hardening).  Differs from the historical stored lp
 # (~2982.18) because the model itself has changed since that trace; see the
 # module docstring.
-GOOD_EXPECTED_LP = -934.604  # re-measured 2026-08-08: Op-path annual parallax fix (review 1.1) moved the mulens likelihood
+# Re-measured 2026-08-08 twice: the Op-path annual parallax fix (review 1.1)
+# moved the mulens likelihood (-934.604), then the galacticmodel prior
+# normalization (reviews 1.3/1.4: pm->velocity Jacobian + mixture branch
+# normalization) shifted it by -17.47 (two stars x [-log(sigma^3 rho0
+# branch norm) + 2*log(K*d)]).
+GOOD_EXPECTED_LP = -952.076
 
 
 def test_good_draw_logp_matches_deterministic_build(dc2018_128_logp):

--- a/tests/test_runaway_logp_regression.py
+++ b/tests/test_runaway_logp_regression.py
@@ -160,12 +160,13 @@ def _point(raw_dict):
 # post free_symbols-sort hardening).  Differs from the historical stored lp
 # (~2982.18) because the model itself has changed since that trace; see the
 # module docstring.
-# Re-measured 2026-08-08 twice: the Op-path annual parallax fix (review 1.1)
-# moved the mulens likelihood (-934.604), then the galacticmodel prior
-# normalization (reviews 1.3/1.4: pm->velocity Jacobian + mixture branch
-# normalization) shifted it by -17.47 (two stars x [-log(sigma^3 rho0
-# branch norm) + 2*log(K*d)]).
-GOOD_EXPECTED_LP = -952.076
+# Re-measured 2026-08-08 three times: the Op-path annual parallax fix
+# (review 1.1) moved the mulens likelihood (-934.604); the galacticmodel
+# prior normalization (reviews 1.3/1.4: pm->velocity Jacobian + mixture
+# branch normalization) shifted it to -952.076; the genulens-fidelity
+# upgrade (thick disk branch, bar cutoff, disk plateau, number-density
+# anchors, R0 = 8.16 frame) nudged it to -953.817.
+GOOD_EXPECTED_LP = -953.817
 
 
 def test_good_draw_logp_matches_deterministic_build(dc2018_128_logp):


### PR DESCRIPTION
Three commits, each independently tested; full suite green (1009 passed).

## 1. Review items 1.3 + 1.4 (galacticmodel normalization biases)

- **1.3**: the kinematic prior evaluated velocity Gaussians in km/s while sampling (pm_ra, pm_dec, rv) without the change-of-variables Jacobian `|det dv/d(pm,rv)| = (K*d)^2` -- a d^-2 tilt pulling every star's distance posterior low. Fixed with a `+2*log(K*d)` term per star.
- **1.4**: the disk/bulge logsumexp branches dropped `-log(sigma1*sigma2*sigma3)` (bulge over-weighted ~3.6 nats) and their density zero points. Each branch now carries its own normalization on one absolute scale.

## 2. genulens fidelity upgrade (a-e)

Reviewed our refactor against the actual genulens source (Koshimoto+21):

- **(a)** Bar outer cutoff (Gaussian beyond R = 2.632 kpc, width 500 pc): without it the shallow `exp(-r_s/2)` profile put the bulge branch at 9% of central at a 4-kpc lens distance (genulens: 4e-6).
- **(b)** Thin disk Rd = 2.6 kpc with the genulens inner plateau (flat inside R = 5.3 kpc), replacing the 3.5-kpc plain exponential (~3x over-weight at R = 1 kpc).
- **(c)** Branch weights re-anchored to genulens's number-density channel (thin 0.1633/pc^3 local, thick 7.91e-3, bulge central 3.60 via the Portail+17 VVV-box budget applied to our profile; a test re-derives the constant).
- **(d)** One consistent galactocentric frame (R0 = 8.16 kpc, z_sun = 25 pc, vsun = (10, 243, 7)) for both the density grid and the velocity transform.
- **(e)** Thick disk as a third mixture branch; thin/thick kinematics from genulens's analytic B14disk table (Bennett+14).

All transitions use a C-infinity sqrt hinge so NUTS gradients stay smooth. The kinematic prior is pinned against an independent numpy/astropy reference at 1-8 kpc.

## 3. Geocentric mu_rel frame fix (found while tracing the event-rate prior)

Star pms are barycentric, but the light-curve trajectory is in the Skowron+2011 geocentric convention -- and t_E, the pi_E direction, and the event-rate prior were derived from the heliocentric pm difference. The mismatch is `(v_earth_perp(t0_par)/AU) * pi_rel`: tens of percent of t_E for nearby-lens (large pi_rel) events. New derived `mu_*_rel_geo` parameters apply the Gould 2004 conversion and feed the light-curve chain; the heliocentric trio remains reported. The conversion sign is pinned by a first-principles test (flipped sign = t_E 38 vs 73 days at pi_rel = 0.35 mas).

`GOOD_EXPECTED_LP` re-measured at each step (provenance chain in the comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)