### PR TITLE
config: honor a user unit: override in both start-value conversions

### DIFF
--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -1089,8 +1089,12 @@ class ConfigManager:
                     if c_type == comp_type and str(i) == str(idx):
                         final_path = f"{comp_type}.{c_name}.{param}"
                         break
+                # `path` (index form), not `final_path` (name form): a user
+                # `unit:` override lives under the standardized index key, so
+                # looking it up by name silently falls back to the default
+                # unit and the injected start is off by that factor.
                 factor = self.get_conversion_factor(
-                    comp_type, param, full_path=final_path
+                    comp_type, param, full_path=path
                 )
                 user_val = val / factor
             else:
@@ -1584,7 +1588,12 @@ class ConfigManager:
             )
 
             if path_str not in resolved and cfg.get("initval") is not None:
-                factor = self.get_conversion_factor(c_type, p_name)
+                # resolve() returns the initval in USER units, so the factor
+                # must honor a user `unit:` override -- pass full_path, the
+                # same way the init_scale conversion below does.
+                factor = self.get_conversion_factor(
+                    c_type, p_name, full_path=path_str
+                )
                 resolved[path_str] = to_scalar(cfg["initval"]) * factor
                 provenance[path_str] = param_rank
 

--- a/tests/test_config_units.py
+++ b/tests/test_config_units.py
@@ -1,0 +1,137 @@
+"""Unit-conversion regressions in ConfigManager.finalize_user_params.
+
+Both bugs here only bite when a user sets a non-default `unit:` on a
+parameter, and both silently corrupt the starting point rather than raising:
+
+(a) the inject-back loop looked up the user's `unit:` override by the NAME
+    form of the path (planet.b.mass) while standardize_param_names stores
+    every entry under the INDEX form (planet.0.mass), so the override was
+    never found and the default unit's factor was used;
+
+(b) the relaxation engine's default-armor step converted resolve()'s initval
+    -- which is already in USER units -- with no full_path at all, so it too
+    always used the default unit's factor.
+"""
+
+import astropy.units as u
+import numpy as np
+
+from exozippy.config import ConfigManager
+
+PLANET_SYSTEM = {
+    "star": [{"name": "A"}],
+    "planet": [{"name": "b", "star_ndx": 0, "orbit_ndx": 0}],
+    "orbit": [{"name": "b"}],
+}
+
+
+def test_inject_back_honors_user_unit_on_a_named_instance():
+    """
+    Given a user initval given in a non-default unit on a NAMED instance
+    (planet.b.mass = 1.0 earthMass, defaults.yaml unit jupiterMass),
+    When finalize_user_params injects the solved values back into user_params,
+    Then the stored initval is still 1.0 in the user's own unit.
+
+    Regression: the inject-back divided the internal (solMass) value by the
+    jupiterMass factor because get_conversion_factor was handed the name-form
+    path, which is absent from the standardized user_params.  The user's
+    explicit 1.0 earthMass came back as 0.00315 earthMass -- a 318x error in
+    the start that then cascades into every derived start (q, log_q, K).
+    """
+    # ARRANGE
+    user_params = {
+        "planet.b.mass": {"initval": 1.0, "unit": "earthMass"},
+        "star.A.mass": {"initval": 1.0},
+    }
+
+    # ACT
+    cm = ConfigManager(user_params, system_config=PLANET_SYSTEM)
+    cm.finalize_user_params()
+
+    # ASSERT -- the entry lives under the index form; unit and value must agree
+    entry = cm.user_params["planet.0.mass"]
+    assert entry["unit"] == "earthMass"
+    assert np.isclose(entry["initval"], 1.0, rtol=1e-6), (
+        f"expected 1.0 earthMass, got {entry['initval']:.6g}; "
+        f"{1.0 / float(u.jupiterMass.to(u.earthMass)):.6g} means the "
+        f"jupiterMass factor was used for an earthMass parameter."
+    )
+    # ... and the internal value the model will see is the earthMass one.
+    assert np.isclose(
+        cm._last_resolved["planet.0.mass"],
+        float(u.earthMass.to(u.solMass)),
+        rtol=1e-6,
+    )
+
+
+def test_inject_back_unchanged_without_a_unit_override():
+    """
+    Given the same setup but no `unit:` key (so the default applies),
+    When finalize_user_params runs,
+    Then the injected initval is the user's value in the default unit.
+    """
+    # ARRANGE / ACT
+    cm = ConfigManager(
+        {
+            "planet.b.mass": {"initval": 1.0},
+            "star.A.mass": {"initval": 1.0},
+        },
+        system_config=PLANET_SYSTEM,
+    )
+    cm.finalize_user_params()
+
+    # ASSERT
+    assert np.isclose(cm.user_params["planet.0.mass"]["initval"], 1.0)
+    assert np.isclose(
+        cm._last_resolved["planet.0.mass"],
+        float(u.jupiterMass.to(u.solMass)),
+        rtol=1e-6,
+    )
+
+
+def test_default_armor_honors_user_unit():
+    """
+    Given a parameter with a `unit:` override and a Gaussian prior but no
+    explicit initval (star.A.ra: mu 4.73 rad; defaults.yaml unit is deg),
+    When the relaxation engine seeds it in its default-armor step,
+    Then the internal (radian) value is 4.73, not 4.73 deg-converted.
+
+    Regression: the armor step called get_conversion_factor with no
+    full_path, so resolve()'s user-unit initval was multiplied by the
+    default deg->rad factor and the start landed at 0.0826 rad.  star.ra is
+    used because no physics relation rewrites it, so the armor value is
+    observable in isolation.
+    """
+    # ARRANGE / ACT
+    cm = ConfigManager(
+        {"star.A.ra": {"mu": 4.73, "sigma": 1e-5, "unit": "rad"}},
+        system_config={"star": [{"name": "A"}]},
+    )
+    cm.finalize_user_params()
+
+    # ASSERT
+    internal = cm._last_resolved["star.0.ra"]
+    assert np.isclose(internal, 4.73, rtol=1e-9), (
+        f"expected 4.73 rad, got {internal:.6g}; "
+        f"{4.73 * float(u.deg.to(u.rad)):.6g} means the deg factor was "
+        f"applied to a parameter the user declared in rad."
+    )
+
+
+def test_default_armor_unchanged_without_a_unit_override():
+    """
+    Given the same prior expressed in the default unit (deg),
+    When the engine seeds it,
+    Then the internal value is the radian conversion of 271.0 deg.
+    """
+    # ARRANGE / ACT
+    cm = ConfigManager(
+        {"star.A.ra": {"mu": 271.0, "sigma": 1e-3}},
+        system_config={"star": [{"name": "A"}]},
+    )
+    cm.finalize_user_params()
+
+    # ASSERT
+    assert np.isclose(
+        cm._last_resolved["star.0.ra"], np.radians(271.0), rtol=1e-9
+    )


### PR DESCRIPTION
Fixes review note **1.9** in `notes/code_review_20260808.txt`.

Two independent sites in `src/exozippy/config.py` converted a start value with the **default** unit's factor even when the user had declared a different `unit:`. Both bite only when a non-default unit is set, and both corrupt the starting point silently rather than raising.

### (a) `finalize_user_params`' inject-back (`config.py:1092`)

`get_conversion_factor` was handed `final_path`, the **name** form of the path (`planet.b.mass`), while `standardize_param_names` stores every entry under the **index** form (`planet.0.mass`). The lookup therefore always missed the user's `unit:` and fell back to the default. Now passes `path`.

The user's own explicit initval is what gets clobbered, and it cascades into every derived start (`q`, `log_q`, `K`).

### (b) The relaxation engine's default-armor step (`config.py:1587`)

Passed no `full_path` at all, so `resolve()`'s initval -- which is already in **user** units -- was scaled by the default unit's factor. The `init_scale` conversion four lines below already passed `full_path`; only the initval line was asymmetric. Now passes `full_path=path_str`.

## Reproduced before, verified after

| case | before | after |
|---|---|---|
| (a) `planet.b.mass {initval: 1.0, unit: earthMass}` | injected `0.0031463` earthMass (318x off) | `1.0` earthMass |
| (b) `star.A.ra {mu: 4.73, sigma: 1e-5, unit: rad}` | internal `0.08255` rad (57.3x off) | `4.73` rad |

## Tests

New `tests/test_config_units.py`: one regression per bug plus a default-unit control for each. Both regressions fail on the pre-fix tree (verified by stashing the `config.py` change) and pass after.

Full suite on this branch: **1014 passed, 6 skipped**.

## Noted, not addressed here

The inject-back *creates* new entries under the **name** form (`self.user_params[final_path] = ...`), so `user_params` ends up mixing index-form and name-form keys (e.g. `star.A.logmass` alongside `star.0.mass`). `resolve()` checks all three forms so nothing breaks today, but it is the same name/index asymmetry that caused (a).

`star.ra` is used for the (b) test because no physics relation rewrites it, so the armor value is observable in isolation; in the note's own `planet.mass` repro the `K` relation overwrites it afterwards, which is the engine working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)