### PR TITLE
config: deepcopy user-param entries in every standardize pass (review 1.10)

### DIFF
--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -879,6 +879,17 @@ class ConfigManager:
 
         After this function, self.user_params contains only indexed or flat-dict
         keys internally.  The 2-part form is purely a user convenience.
+
+        EVERY pass deepcopies the entry.  The returned dict must share no object
+        with the caller's, because downstream code writes through these entries
+        in place: extract_links deletes the link-expression fields, and
+        finalize_user_params' inject-back sets initval/derived.  Aliasing them
+        would (a) strip a caller's link strings out of their own dict, so a
+        second ConfigManager built from it sees no links and a hard link
+        silently degrades to a fixed parameter, and (b) feed the previous
+        solve's answer back in as RANK_USER input.  Pass 2 additionally needs
+        the copy per broadcast instance, so the last instance's write does not
+        clobber all the others (e.g. per-source radii solved from rho).
         """
         if not user_params:
             return {}
@@ -903,9 +914,8 @@ class ConfigManager:
 
             comp_list = config[comp_type]
             if not isinstance(comp_list, list):
-                standardized[key] = (
-                    val  # flat-dict component 3-part key: keep as-is
-                )
+                # flat-dict component 3-part key: keep the key as-is
+                standardized[key] = copy.deepcopy(val)
                 continue
 
             try:
@@ -914,11 +924,12 @@ class ConfigManager:
                     for i, c in enumerate(comp_list)
                     if isinstance(c, dict) and c.get("name") == comp_name
                 )
-                standardized[f"{comp_type}.{idx}.{param_name}"] = val
-            except StopIteration:
-                standardized[key] = (
-                    val  # numeric index or unknown name: keep as-is
+                standardized[f"{comp_type}.{idx}.{param_name}"] = (
+                    copy.deepcopy(val)
                 )
+            except StopIteration:
+                # numeric index or unknown name: keep the key as-is
+                standardized[key] = copy.deepcopy(val)
 
         # Pass 2: expand 2-part keys for list components.
         # Indexed entries written by Pass 1 are never overwritten (explicit beats broadcast).
@@ -931,25 +942,19 @@ class ConfigManager:
             comp_list = config.get(comp_type)
 
             if not isinstance(comp_list, list):
-                standardized[key] = (
-                    val  # flat-dict or unknown component: keep as-is
-                )
+                # flat-dict or unknown component: keep the key as-is
+                standardized[key] = copy.deepcopy(val)
                 continue
 
             for i in range(len(comp_list)):
                 indexed_key = f"{comp_type}.{i}.{param_name}"
                 if indexed_key not in standardized:
-                    # Each instance must get its OWN dict: downstream code
-                    # (finalize_user_params inject-back, init_scale sync)
-                    # mutates these entries per-instance, and a shared object
-                    # would let the last instance's write clobber all others
-                    # (e.g. per-source radii solved from rho).
                     standardized[indexed_key] = copy.deepcopy(val)
 
         # Pass 3: 1-part and other unhandled keys (e.g. 'run').
         for key, val in user_params.items():
             if "." not in key and key not in standardized:
-                standardized[key] = val
+                standardized[key] = copy.deepcopy(val)
 
         return standardized
 
@@ -1267,8 +1272,10 @@ class ConfigManager:
         measured directly from the data at startup (see exozippy/whitening.py)
         and any user value would be overwritten anyway.  Old params files keep
         working -- the key is simply ignored with a warning.  Entries are
-        removed via a rebuilt per-parameter dict so a caller's original dict
-        (raw_user_params) is never mutated.
+        removed via a rebuilt per-parameter dict; the caller's original dict
+        (raw_user_params) is already insulated by standardize_param_names,
+        which deepcopies every entry, so this is belt and braces for the
+        no-config path that skips standardization.
         """
         stripped = []
         for k, v in list(self.user_params.items()):

--- a/tests/test_linked_params.py
+++ b/tests/test_linked_params.py
@@ -13,6 +13,8 @@ Unit convention: referenced parameters contribute their values in their own
 user units; the expression result is interpreted in the target's user unit.
 """
 
+import copy
+
 import numpy as np
 import pymc as pm
 import pytest
@@ -370,3 +372,90 @@ def test_circular_hard_links_raise():
     }
     with pytest.raises(ValueError, match="[Cc]ircular"):
         _build_star_param(user_params, ["age"])
+
+
+# ----------------------------------------------------------------------
+# The caller's params dict is never mutated (review item 1.10)
+# ----------------------------------------------------------------------
+
+
+def test_construction_does_not_mutate_callers_params_dict():
+    """
+    Given a params dict holding a hard link,
+    When a ConfigManager is constructed from it,
+    Then the caller's dict still holds the link expression.
+
+    extract_links strips the link strings out of the entries it scans.  Those
+    entries must be copies: standardize_param_names deepcopies every one, so
+    the strip lands on ConfigManager's own dict, not the caller's.
+    """
+    # ARRANGE
+    config = {"star": [{"name": "A"}, {"name": "B"}]}
+    user_params = {
+        "star.B.age": {"initval": 4.0},
+        "star.A.age": {"initval": "star.B.age", "sigma": 0},
+    }
+    before = copy.deepcopy(user_params)
+
+    # ACT
+    ConfigManager(user_params, system_config=config)
+
+    # ASSERT
+    assert user_params == before
+
+
+def test_links_survive_a_second_configmanager_from_the_same_dict():
+    """
+    Given a params dict already used to build one ConfigManager,
+    When a second ConfigManager is built from the same dict,
+    Then it finds the same links.
+
+    A lost link is silent and changes the posterior: the target stops tracking
+    its expression and is fixed at its default/solved value instead.  Bites any
+    in-process reuse -- run_fit twice, solve_api.solve() twice (documented as
+    safe to repeat), a shared test fixture.
+    """
+    # ARRANGE
+    config = {"star": [{"name": "A"}, {"name": "B"}]}
+    user_params = {
+        "star.B.age": {"initval": 4.0},
+        "star.A.age": {"initval": "star.B.age", "sigma": 0},
+    }
+    first = ConfigManager(user_params, system_config=config)
+
+    # ACT
+    second = ConfigManager(user_params, system_config=config)
+
+    # ASSERT
+    assert set(second.links) == set(first.links) == {"star.0.age"}
+    assert set(second.links["star.0.age"]) == {"initval"}
+    assert (
+        second.links["star.0.age"]["initval"].expr_str
+        == first.links["star.0.age"]["initval"].expr_str
+    )
+
+
+def test_solve_does_not_inject_results_into_callers_params_dict():
+    """
+    Given a params dict driving a full finalize_user_params solve,
+    When the relaxation engine injects its solution back,
+    Then the caller's dict is unchanged.
+
+    finalize_user_params writes initval/derived into the entries it resolved.
+    Were those shared, a reused dict would come back carrying the previous
+    solve's answer at RANK_USER.
+    """
+    # ARRANGE
+    config = {"star": [{"name": "A"}, {"name": "B"}]}
+    user_params = {
+        "star.A.teff": {"initval": 5800.0},
+        "star.A.radius": {"initval": 1.0},
+    }
+    before = copy.deepcopy(user_params)
+    cm = ConfigManager(user_params, system_config=config)
+
+    # ACT
+    cm.finalize_user_params()
+
+    # ASSERT
+    assert user_params == before

--- a/tests/test_solve_api.py
+++ b/tests/test_solve_api.py
@@ -166,10 +166,23 @@ def test_solve_is_repeatable_in_one_process(kelt4_inputs):
     """
     Given solve() must not leak module-level state,
     When it is called twice consecutively in one process,
-    Then both calls succeed and report the same parameter set.
+    Then both calls succeed, report the same parameter set, and leave the
+    caller's config and params dicts untouched.
+
+    The immutability half is load-bearing for the repeatability claim in
+    solve()'s docstring: ConfigManager writes through its parameter entries
+    (extract_links strips link expressions, finalize_user_params injects the
+    solved initval back), so any entry shared with the caller would make the
+    second call see different inputs from the first.
     """
-    # Arrange
+    # Arrange -- private copies: the module fixture is shared, so an earlier
+    # test's solve would otherwise have pre-mutated it and the assertions
+    # below would compare contaminated inputs against themselves.
     config, user_params, workdir = kelt4_inputs
+    config = copy.deepcopy(config)
+    user_params = copy.deepcopy(user_params)
+    config_before = copy.deepcopy(config)
+    params_before = copy.deepcopy(user_params)
 
     # Act
     first = solve(config, user_params, workdir)
@@ -179,6 +192,8 @@ def test_solve_is_repeatable_in_one_process(kelt4_inputs):
     assert set(first.parameters) == set(second.parameters)
     assert first.parameters["star.A.radius"]["provenance"]["label"] == "user"
     assert second.parameters["star.A.radius"]["provenance"]["label"] == "user"
+    assert user_params == params_before
+    assert config == config_before
 
 
 def test_solve_accepts_user_params_from_file(kelt4_inputs):


### PR DESCRIPTION
Fixes review item 1.10 in `notes/code_review_20260808.txt`.

`ConfigManager.standardize_param_names` deepcopied only Pass 2 (2-part
broadcast keys). Pass 1 (3-part keys -- the form parameter links are written
in), Pass 2's flat-dict branch, and Pass 3 stored the caller's entry dicts by
reference, so `ConfigManager.user_params` aliased the caller's params dict.

Two pieces of downstream code write through those entries in place:

* `extract_links` deletes the link-expression fields it consumes
  (`linking.py:272`), which stripped the link strings out of the caller's own
  dict. A second `ConfigManager` built from that dict found `links == {}`, and
  a hard link silently degraded into a parameter fixed at its default/solved
  value.
* `finalize_user_params`' inject-back sets `initval`/`derived`, so a reused
  dict came back carrying the previous solve's answer at `RANK_USER`. The
  original review note did not cover this half.

### When this actually fired

Narrower than it looks, which is worth recording:

* **CLI -- unaffected.** `System` `yaml.safe_load`s a fresh dict and builds
  exactly one `ConfigManager`.
* **GUI -- unaffected, but only by luck.** Both `/api/doc/validate` and
  `/api/tune/solve` pass `_jsonable(doc.params)`, which rebuilds plain dicts
  per request; the tune worker gets its params re-pickled over a queue.
* **Exposed:** in-process reuse of one dict -- `run_fit(config, user_params=d)`
  twice, `solve_api.solve()`/`validate()` twice (whose docstring promises
  "Safe to call repeatedly in one process"), and shared test fixtures.
  `ConfigManager.attach_config` would hit it within a single run but has no
  caller anywhere.

The inject-back half was live in the suite: `test_solve_api`'s module-scoped
`kelt4_inputs` fixture picks up `derived: True` on every entry from the first
`solve()` and hands the mutated dict to every later test in the file.

### Fix

`copy.deepcopy(val)` in every pass, restoring the invariant the code already
claimed at `_strip_user_init_scales`.

### Tests

Three new tests in `test_linked_params.py` (caller dict unmutated, links
survive a second `ConfigManager`, solve does not inject back into the caller's
dict) plus a strengthened `test_solve_is_repeatable_in_one_process`. All four
verified to fail without the fix. Full suite: 1019 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)