### PR TITLE
mkprior: merge existing alpha/bigomega entries instead of clobbering the MAP (review 1.17)

### DIFF
--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -126,6 +126,92 @@ def validate_instance_names(system_config):
                 )
 
 
+def _sigma_is_zero(value):
+    """True only if ``value`` is definitively zero (scalar or all-zero list).
+
+    Anything unparseable -- a link expression string, None-free junk -- returns
+    False, i.e. "treat as a real prior width", which is the conservative answer
+    for validate_sigma_has_center.
+    """
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return False
+        try:
+            return all(float(v) == 0.0 for v in value)
+        except (TypeError, ValueError):
+            return False
+    try:
+        return float(value) == 0.0
+    except (TypeError, ValueError):
+        return False
+
+
+def validate_sigma_has_center(user_params, links=None, source=None):
+    """Fatal-error check: a Gaussian prior must have an explicit center.
+
+    ``sigma > 0`` on a user parameter asks for a Gaussian prior.  When neither
+    ``mu`` nor ``initval`` is given, Parameter.build_pymc centers that prior on
+    whatever start value the system resolved (``prior_mus = np.where(~isnan(mus),
+    mus, inits)``) -- and that start is frequently DERIVED FROM THE DATA: a
+    component's RANK_DERIVED_DATA hint, a relaxation-engine solution, or an
+    mkprior MAP.  A prior centered on the data's own best fit double-counts the
+    data, so there is no configuration in which it is what the user meant.  We
+    refuse to run rather than silently produce it.
+
+    Legitimate, and NOT flagged:
+      - ``sigma: 0`` (any all-zero form) -- a fixed pin, not a prior.  It means
+        "hold this at whatever it resolves to", which double-counts nothing.
+      - a LINK expression in ``mu`` or ``initval`` -- a center is specified, it
+        is just computed from another parameter.
+
+    A ``sigma`` that is itself a link expression still requires a center: its
+    width is dynamic but its center is no less obliged to be independent.
+
+    Parameters
+    ----------
+    user_params : dict
+        Standardized user params.  Entries that are not dicts are skipped.
+    links : dict, optional
+        ``{target_path: {field: ParamLink}}`` from ``extract_links``, which
+        DELETES the link string from the entry -- so a linked mu/sigma is
+        invisible in ``user_params`` and must be read from here instead.
+    source : str, optional
+        File the params came from, quoted in the error message.
+    """
+    links = links or {}
+    offenders = []
+    for key, entry in (user_params or {}).items():
+        if not isinstance(entry, dict):
+            continue
+        entry_links = links.get(key, {})
+        sigma_linked = "sigma" in entry_links
+        sigma_val = entry.get("sigma")
+        if not sigma_linked and ("sigma" not in entry or sigma_val is None):
+            continue  # no sigma at all (an absent or null sigma is not a prior)
+        if not sigma_linked and _sigma_is_zero(sigma_val):
+            continue  # fixed pin, not a Gaussian prior
+        if {"mu", "initval"} & (set(entry) | set(entry_links)):
+            continue  # a center is specified (numerically or via a link)
+        offenders.append(key)
+
+    if offenders:
+        where = f" in {source}" if source else ""
+        raise ValueError(
+            f"Gaussian prior with no center{where}: "
+            f"{', '.join(sorted(offenders))}. "
+            f"A 'sigma' greater than 0 asks for a Gaussian prior, but with "
+            f"neither 'mu' nor 'initval' given the prior is centered on "
+            f"whatever start value the system resolves -- and that start is "
+            f"frequently derived FROM THE DATA (a component's data hint, a "
+            f"relaxation-engine solution, or an mkprior MAP). A prior "
+            f"centered on the data's own best fit double-counts that data, "
+            f"so it can never be justified. "
+            f"Fix: give an explicit 'mu' (the independent prior center you "
+            f"actually mean), or use 'sigma: 0' to hold the parameter fixed "
+            f"at its resolved value (a pin, which applies no prior)."
+        )
+
+
 # Provenance Ranks
 RANK_USER = 100  # Explicitly in params.yaml
 RANK_DERIVED_USER = 80  # Solved using ONLY Rank 100s
@@ -227,6 +313,12 @@ class ConfigManager:
         else:
             self.user_params = user_params
             self._strip_user_init_scales()
+
+        # Must run AFTER extract_links: that call deletes the link string from
+        # the entry, so a linked mu/initval is only visible in self.links.  In
+        # the no-system_config branch extract_links never ran and the link
+        # strings are still in the entries, which the same check accepts.
+        validate_sigma_has_center(self.user_params, self.links)
 
         self.system_config = system_config or {}
         self.base_defaults = {}

--- a/src/exozippy/mkparam.py
+++ b/src/exozippy/mkparam.py
@@ -36,6 +36,38 @@ def _find_existing(existing_params, comp_key, idx, name, param):
     return None, None
 
 
+def _apply_existing_constraints(entry, existing_entry):
+    """Layer an existing params entry's constraint fields onto a fresh entry.
+
+    ``entry`` already carries the new ``initval`` (the trace MAP, or the
+    length-K seed list). The existing entry's mu/sigma/bounds are copied over
+    unchanged -- mu is the prior center, not the starting point, so it must
+    never drift toward the MAP.
+
+    If the original carried a Gaussian prior (sigma > 0) but no explicit mu,
+    its initval WAS the prior center (``Parameter.build_pymc`` centers the
+    potential on initval whenever mu is absent, for sampled and derived
+    parameters alike), so promote it to mu. Without the promotion the prior
+    would silently follow the MAP on every successive mkprior run.
+
+    Returns ``entry`` (mutated in place) for convenience.
+    """
+    if not isinstance(existing_entry, dict):
+        return entry
+    for prior_key in ("mu", "sigma", "lower", "upper"):
+        if prior_key in existing_entry:
+            entry[prior_key] = existing_entry[prior_key]
+    existing_sigma = existing_entry.get("sigma")
+    if (
+        existing_sigma is not None
+        and float(existing_sigma) != 0
+        and "mu" not in existing_entry
+        and "initval" in existing_entry
+    ):
+        entry["mu"] = existing_entry["initval"]
+    return entry
+
+
 def _normalize_key(key, config):
     """Rewrite comp.0.param index notation to comp.Name.param for readability."""
     parts = key.split(".", 2)
@@ -315,6 +347,9 @@ def mkprior(
 
     output = {}
     consumed_existing = set()
+    # out_key -> (comp_key, element index, instance name), so the direction-pair
+    # -> angle pass below can look the angle's existing entry up the same way.
+    key_context = {}
 
     for var_name in sampled_vars:
         comp_key, param = var_name.rsplit(".", 1)
@@ -352,31 +387,15 @@ def mkprior(
 
             # Set initval to the seed value(s) so the next run starts there: a
             # scalar for single-seed, a length-K list for multi-seed (P4).
-            # Preserve mu/sigma/bounds from the existing entry unchanged — mu is
-            # the prior center, not the starting point, so it must not move.
+            # mu/sigma/bounds carry over from the existing entry unchanged.
             # No init_scale: whitening scales are measured from the data at
             # startup, and the key would be warn-ignored anyway.
-            entry = {
-                "initval": mv if K == 1 else mv_list,
-            }
-            if isinstance(existing_entry, dict):
-                for prior_key in ("mu", "sigma", "lower", "upper"):
-                    if prior_key in existing_entry:
-                        entry[prior_key] = existing_entry[prior_key]
-                # If the original had a Gaussian prior (sigma > 0) but no
-                # explicit mu, the original initval was the prior center.
-                # Promote it to mu so the prior doesn't shift as initval
-                # moves to the MAP on successive mkparam runs.
-                existing_sigma = existing_entry.get("sigma")
-                if (
-                    existing_sigma is not None
-                    and float(existing_sigma) != 0
-                    and "mu" not in existing_entry
-                    and "initval" in existing_entry
-                ):
-                    entry["mu"] = existing_entry["initval"]
+            entry = _apply_existing_constraints(
+                {"initval": mv if K == 1 else mv_list}, existing_entry
+            )
 
             output[out_key] = entry
+            key_context[out_key] = (comp_key, i, name)
 
     # Convert direction-vector pairs (x, y) → their angle (degrees).
     # These pairs (lens xalpha/yalpha, orbit xbigomega/ybigomega) are sampled
@@ -411,9 +430,26 @@ def mkprior(
             ]
             del output[x_key]
             del output[y_key]
-            output[f"{prefix}.{angle_name}"] = {
+            angle_entry = {
                 "initval": angles[0] if len(angles) == 1 else angles,
             }
+            # The angle itself is never in ``sampled_vars`` (only the x/y pair
+            # is), so its existing entry has NOT been consumed above.  Consume
+            # it here and merge it: a user prior/bound on alpha (or bigomega)
+            # survives, while the initval comes from the trace MAP.  Without
+            # this the pass-through loop below would overwrite the fresh MAP
+            # angle with the stale entry, breaking the restart contract.
+            comp_key, idx, name = key_context.get(
+                x_key, (prefix.split(".", 1)[0], 0, None)
+            )
+            existing_key, existing_entry = _find_existing(
+                existing_params, comp_key, idx, name, angle_name
+            )
+            if existing_key:
+                consumed_existing.add(existing_key)
+            output[f"{prefix}.{angle_name}"] = _apply_existing_constraints(
+                angle_entry, existing_entry
+            )
 
     _CONSTRAINT_FIELDS = {"sigma", "upper", "lower"}
 

--- a/src/exozippy/mkparam.py
+++ b/src/exozippy/mkparam.py
@@ -8,6 +8,7 @@ import arviz as az
 import numpy as np
 import yaml
 
+from exozippy.config import validate_sigma_has_center
 from exozippy.samplers import convergence
 
 logger = logging.getLogger(__name__)
@@ -284,6 +285,13 @@ def mkprior(
         param_path = base_dir / param_file
         if param_path.exists():
             existing_params = _load_yaml(str(param_path))
+            # mkprior reads the params file directly, bypassing ConfigManager,
+            # so the same check has to run here.  Every entry mkprior
+            # synthesizes carries an initval, but the pass-through loop below
+            # copies constraint-bearing entries verbatim -- a legacy
+            # '{sigma: 0.5}' would be re-emitted into the restart file.  Fail
+            # on the input: it is the actual source and the file to edit.
+            validate_sigma_has_center(existing_params, source=str(param_path))
 
     idata = az.from_netcdf(str(trace_path))
 

--- a/tests/test_linked_params.py
+++ b/tests/test_linked_params.py
@@ -363,12 +363,16 @@ def test_sigma_link_snapshots_numerically():
     Given star.A.age with sigma = "0.5 * star.B.age" and star.B.age = 4.0,
     When finalize_user_params runs,
     Then sigma resolves to the static numeric snapshot 2.0.
+
+    The explicit mu is required: a linked sigma is still a Gaussian prior, and
+    validate_sigma_has_center refuses a prior with no stated center (it would
+    otherwise be centered on a possibly data-derived start value).
     """
     # ARRANGE
     config = {"star": [{"name": "A"}, {"name": "B"}]}
     user_params = {
         "star.B.age": {"initval": 4.0},
-        "star.A.age": {"sigma": "0.5 * star.B.age"},
+        "star.A.age": {"mu": 3.0, "sigma": "0.5 * star.B.age"},
     }
     cm = ConfigManager(user_params, system_config=config)
 

--- a/tests/test_mkparam.py
+++ b/tests/test_mkparam.py
@@ -608,6 +608,44 @@ def test_angle_entry_keeps_bounds_and_adds_no_mu(tmp_path):
     assert "mu" not in entry, "bounds are not a prior center"
 
 
+def test_uncentered_sigma_in_params_file_is_fatal(tmp_path):
+    """
+    Given an existing params file with sigma > 0 and no mu/initval,
+    When mkprior runs,
+    Then it raises and names the offending file.
+
+    mkprior reads the params file directly (bypassing ConfigManager), and its
+    pass-through loop copies constraint-bearing entries verbatim -- so without
+    this check it would launder an uncentered Gaussian prior into the restart
+    file, where the prior ends up centered on a data-derived start value.
+    """
+    import yaml
+
+    existing_params = {"star.Host.teff": {"sigma": 100.0}}
+    param_file = tmp_path / "star.params.yaml"
+    with open(param_file, "w") as f:
+        yaml.dump(existing_params, f)
+
+    trace = _make_idata({"star.mass": 1.0}, tmpdir=tmp_path)
+    config = {
+        "prefix": "fitresults/model",
+        "parameter_file": "star.params.yaml",
+        "star": [{"name": "Host"}],
+    }
+
+    with pytest.raises(ValueError) as exc:
+        mkprior(
+            config,
+            base_dir=tmp_path,
+            trace_path=trace,
+            output_path=tmp_path / "out.yaml",
+        )
+
+    msg = str(exc.value)
+    assert "star.Host.teff" in msg
+    assert "star.params.yaml" in msg, "the input file must be named"
+
+
 def test_standardize_param_names_flat_dict_component_no_crash(tmp_path):
     """
     Regression: standardize_param_names crashed with AttributeError when a

--- a/tests/test_mkparam.py
+++ b/tests/test_mkparam.py
@@ -469,6 +469,145 @@ def test_non_sampled_constraint_gets_mu_promotion(tmp_path):
     assert np.isclose(parallax_entry["sigma"], 0.01745, rtol=1e-6)
 
 
+def test_angle_entry_takes_map_initval_and_keeps_prior(tmp_path):
+    """
+    Given an existing lens.L.alpha entry carrying a Gaussian prior
+      (initval + sigma, no explicit mu) and a trace whose xalpha/yalpha MAP
+      direction is a different angle,
+    When mkprior runs,
+    Then the written alpha entry has the NEW MAP angle as initval, keeps
+      sigma, and promotes the stale initval to mu (the prior center must not
+      follow the MAP).
+
+    Regression (review 1.17): alpha/bigomega are synthesized from the sampled
+    x/y pair AFTER the main loop, so they were never in consumed_existing.
+    The pass-through loop then overwrote the fresh MAP angle with the stale
+    entry, so restart files violated the "initval at the trace MAP" contract.
+    """
+    import yaml
+
+    existing_params = {"lens.L.alpha": {"initval": 12.0, "sigma": 5.0}}
+    param_file = tmp_path / "ob.params.yaml"
+    with open(param_file, "w") as f:
+        yaml.dump(existing_params, f)
+
+    # arctan2(1, 0) = +90 deg
+    trace = _make_idata(
+        {"lens.xalpha": 0.0, "lens.yalpha": 1.0}, tmpdir=tmp_path
+    )
+    config = {
+        "prefix": "fitresults/ob",
+        "parameter_file": "ob.params.yaml",
+        "lens": [{"name": "L"}],
+    }
+
+    out = mkprior(
+        config,
+        base_dir=tmp_path,
+        trace_path=trace,
+        output_path=tmp_path / "out.yaml",
+    )
+
+    result = yaml.safe_load(open(out))
+    entry = result["lens.L.alpha"]
+
+    assert entry["initval"] == pytest.approx(90.0, abs=1e-6), (
+        "alpha initval must be the trace MAP angle, not the stale entry"
+    )
+    assert entry["sigma"] == pytest.approx(5.0), "user prior must survive"
+    assert entry["mu"] == pytest.approx(12.0, abs=1e-6), (
+        "stale initval promoted to mu -- the prior center must not move"
+    )
+    assert not any(k.endswith(("xalpha", "yalpha")) for k in result)
+
+
+def test_angle_entry_index_notation_merges_without_duplicate(tmp_path):
+    """
+    Given an existing orbit.0.bigomega entry written in index notation with an
+      explicit mu + sigma, and a trace whose xbigomega/ybigomega MAP is a
+      different angle,
+    When mkprior runs,
+    Then exactly one bigomega entry is written, under the name notation, with
+      the MAP initval and the explicit mu/sigma untouched.
+    """
+    import yaml
+
+    existing_params = {"orbit.0.bigomega": {"mu": 30.0, "sigma": 10.0}}
+    param_file = tmp_path / "kelt4.params.yaml"
+    with open(param_file, "w") as f:
+        yaml.dump(existing_params, f)
+
+    # arctan2(0, -1) = 180 deg
+    trace = _make_idata(
+        {"orbit.xbigomega": -1.0, "orbit.ybigomega": 0.0}, tmpdir=tmp_path
+    )
+    config = {
+        "prefix": "fitresults/kelt4",
+        "parameter_file": "kelt4.params.yaml",
+        "orbit": [{"name": "b"}],
+    }
+
+    out = mkprior(
+        config,
+        base_dir=tmp_path,
+        trace_path=trace,
+        output_path=tmp_path / "out.yaml",
+    )
+
+    result = yaml.safe_load(open(out))
+
+    assert "orbit.0.bigomega" not in result, (
+        "stale index-notation entry must be consumed, not passed through"
+    )
+    entry = result["orbit.b.bigomega"]
+    assert entry["initval"] == pytest.approx(180.0, abs=1e-6)
+    assert entry["mu"] == pytest.approx(30.0, abs=1e-6), (
+        "explicit mu must be preserved exactly"
+    )
+    assert entry["sigma"] == pytest.approx(10.0)
+
+
+def test_angle_entry_keeps_bounds_and_adds_no_mu(tmp_path):
+    """
+    Given an existing lens.L.alpha entry carrying only bounds (a constraint,
+      so the pass-through loop used to keep it and clobber the angle),
+    When mkprior runs,
+    Then the bounds survive, initval is the MAP angle, and no mu is invented
+      (bounds are not a Gaussian prior center).
+    """
+    import yaml
+
+    existing_params = {"lens.L.alpha": {"lower": -180.0, "upper": 180.0}}
+    param_file = tmp_path / "ob.params.yaml"
+    with open(param_file, "w") as f:
+        yaml.dump(existing_params, f)
+
+    # arctan2(-1, 0) = -90 deg
+    trace = _make_idata(
+        {"lens.xalpha": 0.0, "lens.yalpha": -1.0}, tmpdir=tmp_path
+    )
+    config = {
+        "prefix": "fitresults/ob",
+        "parameter_file": "ob.params.yaml",
+        "lens": [{"name": "L"}],
+    }
+
+    out = mkprior(
+        config,
+        base_dir=tmp_path,
+        trace_path=trace,
+        output_path=tmp_path / "out.yaml",
+    )
+
+    result = yaml.safe_load(open(out))
+    entry = result["lens.L.alpha"]
+
+    assert entry["initval"] == pytest.approx(-90.0, abs=1e-6)
+    assert entry["lower"] == pytest.approx(-180.0)
+    assert entry["upper"] == pytest.approx(180.0)
+    assert "mu" not in entry, "bounds are not a prior center"
+
+
 def test_standardize_param_names_flat_dict_component_no_crash(tmp_path):
     """
     Regression: standardize_param_names crashed with AttributeError when a

--- a/tests/test_sigma_center.py
+++ b/tests/test_sigma_center.py
@@ -1,0 +1,222 @@
+"""Tests for validate_sigma_has_center (config.py).
+
+A user 'sigma' > 0 asks for a Gaussian prior.  With neither 'mu' nor 'initval'
+given, Parameter.build_pymc centers that prior on whatever start value the
+system resolved -- frequently one derived FROM THE DATA (a component data hint,
+a relaxation-engine solution, an mkprior MAP).  Centering a prior on the data's
+own best fit double-counts the data, so the config is rejected outright rather
+than silently sampled.
+"""
+
+import pytest
+
+from exozippy.config import ConfigManager, validate_sigma_has_center
+
+CONFIG = {"star": [{"name": "A"}, {"name": "B"}]}
+
+
+def test_sigma_without_center_is_fatal():
+    """
+    Given a params entry with sigma > 0 and neither mu nor initval,
+    When the ConfigManager is constructed,
+    Then a ValueError names the parameter and explains both fixes.
+    """
+    # ARRANGE
+    user_params = {"star.A.teff": {"sigma": 100.0}}
+
+    # ACT / ASSERT
+    with pytest.raises(ValueError) as exc:
+        ConfigManager(user_params, system_config=CONFIG)
+
+    msg = str(exc.value)
+    assert "star.0.teff" in msg, "the offending parameter must be named"
+    assert "double-count" in msg, "the reason must be stated"
+    assert "'mu'" in msg and "sigma: 0" in msg, "both fixes must be offered"
+
+
+def test_sigma_zero_alone_is_legal():
+    """
+    Given a params entry with sigma == 0 and no mu/initval,
+    When the ConfigManager is constructed,
+    Then it succeeds -- sigma 0 is a fixed pin ("hold this at whatever it
+      resolves to"), not a Gaussian prior, so nothing is double-counted.
+    """
+    # ARRANGE / ACT
+    cm = ConfigManager(
+        {"star.A.teff": {"sigma": 0}, "star.B.teff": {"sigma": 0.0}},
+        system_config=CONFIG,
+    )
+
+    # ASSERT
+    assert cm.user_params["star.0.teff"]["sigma"] == 0
+
+
+def test_explicit_mu_plus_sigma_is_legal():
+    """
+    Given a params entry with an explicit mu and sigma > 0,
+    When the ConfigManager is constructed,
+    Then it succeeds -- the prior center is stated independently.
+    """
+    # ARRANGE / ACT
+    cm = ConfigManager(
+        {"star.A.teff": {"mu": 5800.0, "sigma": 100.0}}, system_config=CONFIG
+    )
+
+    # ASSERT
+    assert cm.user_params["star.0.teff"]["mu"] == 5800.0
+
+
+def test_initval_plus_sigma_is_legal():
+    """
+    Given a params entry with initval and sigma > 0 (the common shorthand for
+      "prior centered here"),
+    When the ConfigManager is constructed,
+    Then it succeeds.
+    """
+    # ARRANGE / ACT
+    cm = ConfigManager(
+        {"star.A.teff": {"initval": 5800.0, "sigma": 100.0}},
+        system_config=CONFIG,
+    )
+
+    # ASSERT
+    assert cm.user_params["star.0.teff"]["initval"] == 5800.0
+
+
+def test_linked_mu_plus_sigma_is_legal():
+    """
+    Given a params entry whose mu is a LINK expression plus sigma > 0,
+    When the ConfigManager is constructed,
+    Then it succeeds.
+
+    Regression guard: extract_links deletes the link string from the entry, so
+    a check reading only user_params would see no mu and hard-error on a legal
+    file.  The validator must consult ConfigManager.links.
+    """
+    # ARRANGE / ACT
+    cm = ConfigManager(
+        {
+            "star.B.teff": {"initval": 5000.0},
+            "star.A.teff": {"mu": "star.B.teff", "sigma": 100.0},
+        },
+        system_config=CONFIG,
+    )
+
+    # ASSERT -- the link really was extracted (so the entry no longer has mu)
+    assert "mu" in cm.links["star.0.teff"]
+    assert "mu" not in cm.user_params["star.0.teff"]
+
+
+def test_linked_initval_plus_sigma_is_legal():
+    """
+    Given a params entry whose initval is a link expression plus sigma > 0,
+    When the ConfigManager is constructed,
+    Then it succeeds (a linked initval states a center just as mu does).
+    """
+    # ARRANGE / ACT
+    cm = ConfigManager(
+        {
+            "star.B.teff": {"initval": 5000.0},
+            "star.A.teff": {"initval": "star.B.teff + 100", "sigma": 50.0},
+        },
+        system_config=CONFIG,
+    )
+
+    # ASSERT
+    assert "initval" in cm.links["star.0.teff"]
+
+
+def test_linked_sigma_without_center_is_fatal():
+    """
+    Given a params entry whose sigma is a link expression and which has no
+      mu or initval,
+    When the ConfigManager is constructed,
+    Then it still raises -- a dynamic width does not excuse an unstated center.
+    """
+    # ARRANGE
+    user_params = {
+        "star.B.age": {"initval": 4.0},
+        "star.A.age": {"sigma": "0.5 * star.B.age"},
+    }
+
+    # ACT / ASSERT
+    with pytest.raises(ValueError, match="star.0.age"):
+        ConfigManager(user_params, system_config=CONFIG)
+
+
+def test_all_zero_sigma_list_is_legal():
+    """
+    Given a per-element sigma list that is all zeros,
+    When validated,
+    Then it passes (every element is a pin), while a list containing a
+      non-zero width with no center is rejected.
+    """
+    # ARRANGE / ACT / ASSERT
+    validate_sigma_has_center({"star.0.teff": {"sigma": [0.0, 0]}})
+
+    with pytest.raises(ValueError, match="star.0.teff"):
+        validate_sigma_has_center({"star.0.teff": {"sigma": [0.0, 0.5]}})
+
+
+def test_absent_and_null_sigma_and_non_dict_entries_are_skipped():
+    """
+    Given entries with no sigma, an explicit null sigma, and a bare scalar,
+    When validated,
+    Then none of them is flagged (no sigma means no prior to center).
+    """
+    # ARRANGE / ACT / ASSERT -- must not raise
+    validate_sigma_has_center(
+        {
+            "star.0.teff": {"lower": 3000.0, "upper": 9000.0},
+            "star.0.mass": {"sigma": None},
+            "star.0.radius": 1.0,
+        }
+    )
+
+
+def test_bounds_alone_do_not_count_as_a_center():
+    """
+    Given a params entry with sigma > 0 and only lower/upper bounds,
+    When validated,
+    Then it is still rejected -- a bound is not a prior center.
+    """
+    # ARRANGE / ACT / ASSERT
+    with pytest.raises(ValueError, match="star.0.teff"):
+        validate_sigma_has_center(
+            {"star.0.teff": {"sigma": 100.0, "lower": 3000.0, "upper": 9000.0}}
+        )
+
+
+def test_error_names_every_offender():
+    """
+    Given several offending entries,
+    When validated,
+    Then the single error names all of them, so the user fixes the file once.
+    """
+    # ARRANGE / ACT
+    with pytest.raises(ValueError) as exc:
+        validate_sigma_has_center(
+            {
+                "star.0.teff": {"sigma": 100.0},
+                "star.1.feh": {"sigma": 0.08},
+                "star.0.mass": {"initval": 1.0, "sigma": 0.05},
+            }
+        )
+
+    # ASSERT
+    msg = str(exc.value)
+    assert "star.0.teff" in msg and "star.1.feh" in msg
+    assert "star.0.mass" not in msg, "a centered entry must not be flagged"
+
+
+def test_source_file_is_named_when_given():
+    """
+    Given a source label,
+    When validation fails,
+    Then the message quotes the file so the user knows what to edit.
+    """
+    # ARRANGE / ACT / ASSERT
+    with pytest.raises(ValueError, match="my.params.yaml"):
+        validate_sigma_has_center(
+            {"star.0.teff": {"sigma": 100.0}}, source="my.params.yaml"
+        )


### PR DESCRIPTION
Fixes item **1.17** from `notes/code_review_20260808.txt`, plus a related statistical-safety check the fix exposed.

## 1. mkprior clobbered the MAP angle (review 1.17)

`mkprior()` synthesizes `lens.<X>.alpha` / `orbit.<X>.bigomega` from the sampled
`xalpha`/`yalpha` pair *after* the main sampled-variable loop. Only the sampled
x/y names ever went through `_find_existing`, so the angle key was never added to
`consumed_existing`. The pass-through loop then found the user's existing `alpha`
entry, saw a constraint field, and wrote it over the freshly computed MAP angle.

Reproduced before fixing: existing `lens.L.alpha: {initval: 12.0, sigma: 5.0}`
plus a trace whose MAP direction is 90 deg produced
`{initval: 12.0, mu: 12.0, sigma: 5.0}` -- the MAP angle was gone, so restart
files violated the "initval at the trace MAP" contract.

**Fix (merge, not replace):** the sampled path's existing-entry merge is factored
into `_apply_existing_constraints()` and reused for the angle entries, which now
resolve through `_find_existing` (matching all three key spellings) and are added
to `consumed_existing`. Post-fix the same input yields
`{initval: 90.0, mu: 12.0, sigma: 5.0}`.

`initval` + `sigma` is promoted to `mu` + `sigma`, identical to the sampled path's
existing rule. This matters most here: `alpha`/`bigomega` are *derived*, and
`parameter.py` centers their potential on `prior_mus = where(~isnan(mus), mus, inits)`
-- i.e. on `initval` when `mu` is absent. Without the promotion, overwriting
`initval` with the MAP would drag the user's prior center onto the MAP on every
successive mkprior run.

## 2. A `sigma` with no center is now a fatal error

The promotion above is safe only because the user stated a center. If they did
not, a `sigma > 0` silently centers the Gaussian on whatever `initval` the system
resolved -- frequently data-derived (a component data hint, a relaxation-engine
solution, or an mkprior MAP). A prior centered on the data's own best fit
double-counts that data and cannot be justified.

`validate_sigma_has_center()` (module-level in `config.py`, called from
`ConfigManager.__init__` beside `_strip_user_init_scales()`) raises naming every
offending path at once. `system.py` is the only `ConfigManager` construction site
in `src/`, so hand-written and generated params files are checked alike.
`mkprior` additionally validates its input, which it reads via `_load_yaml`,
bypassing `ConfigManager` entirely.

Semantics:
- only `sigma > 0` triggers; `sigma: 0` is a legitimate pin and applies no prior
- a **link expression** in `mu` or `initval` satisfies the requirement
- a linked `sigma` still demands a center

The link case needed care: `extract_links` does `del entry[fld]`, so a linked `mu`
is gone from `user_params` afterwards, and it only runs when `system_config is not
None`. The check therefore runs after the whole if/else and consults both
`user_params` and `self.links`; a test asserts the link really was extracted so
that cannot silently regress.

## Blast radius

- **`examples/`: zero offenders.** All 41 YAMLs scanned (18 params-like), 120
  `sigma`-bearing entries inspected; every entry lacking `mu`/`initval` is
  `sigma: 0`. Verified after the fact that all 18 example params files pass the
  new validator. No science config changed.
- **`tests/`: one offender**, `test_linked_params.py` `test_sigma_link_snapshots_numerically`
  (`star.A.age: {sigma: "0.5 * star.B.age"}` -- a linked sigma with no center).
  Given an explicit `mu`; its assertion is unchanged and still passes.

## Tests

`tests/test_sigma_center.py` (new, 12 cases) covers fatal-vs-legal across
`sigma: 0`, `mu`+`sigma`, `initval`+`sigma`, linked `mu`, linked `initval`, linked
`sigma` alone, all-zero vs mixed sigma lists, absent/null sigma, non-dict entries,
bounds-are-not-a-center, the multi-offender message and the named source file.
Three new cases in `tests/test_mkparam.py` cover the angle merge (MAP initval
taken, constraint kept, index-notation, bounds-only-adds-no-mu); all three fail on
the pre-fix code. Plus one for the mkprior input path.

Full suite green (1049 passed) before the rebase onto master; rebased cleanly onto
894a232 and re-validated by CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
