### PR TITLE
mulensmodel: fix point-source binary lens (review 1.19) + A/B comparison vs vbm_direct

### DIFF
--- a/src/exozippy/components/mulensing/op.py
+++ b/src/exozippy/components/mulensing/op.py
@@ -1,3 +1,5 @@
+import warnings
+
 import astropy.units as u
 import MulensModel as mm
 import numpy as np
@@ -123,7 +125,14 @@ def _build_binary_model(p, coords, mag_method, use_rho=False):
         model.set_magnification_methods(mag_method)
     elif mag_method == "auto_vbbl":
         # Keyed on the finite_source config flag, not the runtime rho value.
-        method = "VBM" if use_rho else "VBBL"
+        # Point source must NOT ask for VBBL/VBM: MulensModel's _check_methods
+        # only allows "point_source"/"point_source_point_lens" when the
+        # parameters carry no rho, and otherwise raises ValueError -- which
+        # perform() would swallow into an all-NaN (i.e. -inf logp) curve for
+        # every proposal.  "point_source" selects
+        # BinaryLensPointSourceMagnification, the exact binary point-source
+        # solver (it reproduces VBBL at rho -> 0 to machine precision).
+        method = "VBM" if use_rho else "point_source"
         model.set_magnification_methods([0.0, method])
     else:
         model.set_magnification_methods([0.0, mag_method])
@@ -157,6 +166,7 @@ class _MagOpBase(Op):
             bandpass  # None = no LD; str = apply u1 LD for this bandpass
         )
         self._coord_cache = {}
+        self._warned = False
 
     def infer_shape(self, node, input_shapes):
         return [input_shapes[1]]
@@ -181,10 +191,26 @@ class _MagOpBase(Op):
                     A = model.get_magnification(
                         times_np, satellite_skycoord=sat_coord
                     )
-        except (ValueError, RuntimeError):
+        except (ValueError, RuntimeError) as exc:
             # Invalid parameter combination (e.g. NaN source position from extreme
             # parallax values during sampler exploration). Return NaN so the
             # likelihood evaluates to -inf and the sampler rejects the proposal.
+            #
+            # Warn once per Op instance: a *misconfigured* backend raises here
+            # on every single proposal, which is indistinguishable from a
+            # rejected proposal unless the first one is reported (this is
+            # exactly how the point-source-binary "VBBL" bug stayed hidden).
+            if not self._warned:
+                self._warned = True
+                warnings.warn(
+                    f"{type(self).__name__}: MulensModel raised "
+                    f"{type(exc).__name__}: {exc} -- returning NaN "
+                    "magnifications (logp = -inf) for this proposal. "
+                    "If this repeats for every proposal the backend is "
+                    "misconfigured, not merely exploring bad parameters.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
             A = np.full(len(times_np), np.nan)
         outputs[0][0] = np.asarray(A)
 

--- a/tests/test_mulens_review_fixes.py
+++ b/tests/test_mulens_review_fixes.py
@@ -2,9 +2,8 @@
 config validation."""
 
 import logging
-from unittest.mock import patch
+import warnings
 
-import MulensModel as mm
 import numpy as np
 import pytest
 
@@ -12,6 +11,7 @@ from conftest import _DummyComponent, _DummyConfigManager, _DummySystem
 from exozippy.components.mulensing.lens import Lens
 from exozippy.components.mulensing.mulensinstrument import MulensInstrument
 from exozippy.components.mulensing.op import (
+    BinaryLensMagOp,
     _build_binary_model,
     _build_pspl_model,
     _dev_skycoord,
@@ -64,25 +64,113 @@ def test_pspl_model_floors_nonpositive_rho():
     assert float(model.parameters.rho) > 0
 
 
+# Binary-lens parameter vectors: [t_0, u_0, t_E, pi_E_N, pi_E_E, (rho), s, q, alpha]
+_P_BINARY_FS = np.array(
+    [2450000.0, 0.1, 20.0, 0.0, 0.0, 1e-3, 1.2, 0.01, 30.0]
+)
+_P_BINARY_PS = np.array([2450000.0, 0.1, 20.0, 0.0, 0.0, 1.2, 0.01, 30.0])
+
+
 def test_binary_method_selection_follows_finite_source_flag():
     """
     Given a binary-lens parameter vector,
     When the model is built with and without finite_source (use_rho),
     Then the finite-source method (VBM) is selected iff use_rho is True,
-      independent of the runtime rho value.
+      independent of the runtime rho value, and the point-source case gets
+      MulensModel's point-source method (asking VBBL for a rho-less model
+      raises inside MulensModel).
+
+    Note this asserts against the REAL model object, not a mocked
+    set_magnification_methods -- the mock is what let the point-source
+    "VBBL" selection ship broken.
     """
-    # Arrange: [t_0, u_0, t_E, pi_E_N, pi_E_E, (rho), s, q, alpha]
-    p_fs = np.array([2450000.0, 0.1, 20.0, 0.0, 0.0, 1e-3, 1.2, 0.01, 30.0])
-    p_ps = np.array([2450000.0, 0.1, 20.0, 0.0, 0.0, 1.2, 0.01, 30.0])
+    # Act
+    model_fs = _build_binary_model(
+        _P_BINARY_FS, COORDS, "auto_vbbl", use_rho=True
+    )
+    model_ps = _build_binary_model(
+        _P_BINARY_PS, COORDS, "auto_vbbl", use_rho=False
+    )
 
-    # Act / Assert
-    with patch.object(mm.Model, "set_magnification_methods") as set_methods:
-        _build_binary_model(p_fs, COORDS, "auto_vbbl", use_rho=True)
-        assert set_methods.call_args[0][0][1] == "VBM"
+    # Assert
+    assert model_fs.methods[1] == "VBM"
+    assert model_ps.methods[1] == "point_source"
 
-    with patch.object(mm.Model, "set_magnification_methods") as set_methods:
-        _build_binary_model(p_ps, COORDS, "auto_vbbl", use_rho=False)
-        assert set_methods.call_args[0][0][1] == "VBBL"
+
+def test_point_source_binary_model_yields_finite_magnifications():
+    """
+    Given a point-source binary lens (backend: mulensmodel, finite_source
+      false),
+    When magnifications are computed through the real MulensModel call path,
+    Then they are finite and above 1 -- the old "VBBL" selection made
+      MulensModel raise, which perform() turned into an all-NaN curve and
+      hence -inf logp for every proposal.
+    """
+    # Arrange
+    op = BinaryLensMagOp(COORDS, mag_method="auto_vbbl", use_rho=False)
+    times = np.linspace(2449980.0, 2450020.0, 41)
+    obs_pos = np.zeros((times.size, 3))
+    outputs = [[None]]
+
+    # Act
+    op.perform(None, [_P_BINARY_PS, times, obs_pos], outputs)
+    magnification = outputs[0][0]
+
+    # Assert
+    assert np.all(np.isfinite(magnification))
+    assert np.all(magnification > 1.0)
+
+
+def test_finite_source_binary_model_yields_finite_magnifications():
+    """
+    Given a finite-source binary lens (finite_source true, so VBM),
+    When magnifications are computed through the real MulensModel call path,
+    Then they are finite and above 1, and agree with the point-source result
+      because rho is small enough to be indistinguishable.
+    """
+    # Arrange
+    times = np.linspace(2449980.0, 2450020.0, 41)
+    obs_pos = np.zeros((times.size, 3))
+    op_fs = BinaryLensMagOp(COORDS, mag_method="auto_vbbl", use_rho=True)
+    op_ps = BinaryLensMagOp(COORDS, mag_method="auto_vbbl", use_rho=False)
+    out_fs, out_ps = [[None]], [[None]]
+
+    # Act
+    op_fs.perform(None, [_P_BINARY_FS, times, obs_pos], out_fs)
+    op_ps.perform(None, [_P_BINARY_PS, times, obs_pos], out_ps)
+
+    # Assert
+    assert np.all(np.isfinite(out_fs[0][0]))
+    assert np.all(out_fs[0][0] > 1.0)
+    np.testing.assert_allclose(out_fs[0][0], out_ps[0][0], rtol=1e-4)
+
+
+def test_mag_op_warns_once_when_falling_back_to_nan():
+    """
+    Given an Op configured with a magnification method MulensModel rejects,
+    When perform() is called twice,
+    Then both calls return NaN (so the sampler rejects the proposal) but a
+      single RuntimeWarning naming the underlying error is emitted -- the
+      silent all-NaN fallback is what hid the point-source binary bug.
+    """
+    # Arrange
+    op = BinaryLensMagOp(COORDS, mag_method="VBBL", use_rho=False)
+    times = np.linspace(2449980.0, 2450020.0, 11)
+    obs_pos = np.zeros((times.size, 3))
+    first, second = [[None]], [[None]]
+
+    # Act
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        op.perform(None, [_P_BINARY_PS, times, obs_pos], first)
+        op.perform(None, [_P_BINARY_PS, times, obs_pos], second)
+
+    # Assert
+    assert np.all(np.isnan(first[0][0]))
+    assert np.all(np.isnan(second[0][0]))
+    runtime = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert len(runtime) == 1
+    assert "VBBL" in str(runtime[0].message)
 
 
 def test_lens_rejects_missing_body_component():

--- a/tests/test_vbm_direct_vs_mulensmodel.py
+++ b/tests/test_vbm_direct_vs_mulensmodel.py
@@ -47,6 +47,12 @@ _ORDER = [
     "alpha",
     "u1",
 ]
+# Slice of a full _draw() vector for the point-source, no-LD param layout
+# ([t_0, u_0, t_E, pi_E_N, pi_E_E, s, q, alpha]): drop rho and u1, keep the
+# draw scatter conventions identical to the finite-source comparison.
+_POINT_SOURCE_INDEX = [
+    _ORDER.index(k) for k in _ORDER if k not in ("rho", "u1")
+]
 
 
 def _times_and_obs(n=400, span=150.0):
@@ -129,6 +135,79 @@ def test_vbm_direct_matches_mulensmodel_binary_with_parallax_and_ld():
         A_dir = f_dir(p, times, obs)
         worst = max(worst, np.max(np.abs(A_mm - A_dir) / np.abs(A_mm)))
     assert worst < 1e-8, f"direct path deviates from MulensModel: {worst:.2e}"
+
+
+@pytest.mark.parametrize(
+    "grid_name, n, span, min_peak",
+    [
+        ("wide", 400, 150.0, 5.0),
+        ("caustic", 600, 2.0, 50.0),
+    ],
+)
+def test_vbm_direct_matches_mulensmodel_binary_point_source(
+    grid_name, n, span, min_peak
+):
+    """
+    Given a POINT-source binary lens with satellite parallax and random
+      parameter draws around the DC128 MAP,
+    When both the MulensModel Op (auto_vbbl -> "point_source") and the
+      direct-VBM Op (BinaryMag0) are evaluated,
+    Then magnifications are finite and agree per-point to rtol 1e-9.
+
+    This is the first independent check of vbm_direct's point-source binary
+    magnification. It could not exist before: the MulensModel Op selected
+    "VBBL" for a rho-less model, MulensModel refused, and perform() returned
+    all-NaN -- so every A/B test in this file used use_rho=True.
+
+    Two grids, because the wide one alone would prove nothing here: at 0.75 d
+    sampling the narrow central caustic falls between epochs and the peak only
+    reaches A ~ 11.  The "caustic" grid resolves it (A ~ 60-600 depending on
+    the draw, up to ~63x the equivalent single-lens magnification), which is
+    where two independent root solvers are most likely to part ways.
+    min_peak asserts the grid really does sample that structure, so the test
+    cannot silently decay into a flat-wings comparison.
+
+    Both engines are exact analytic point-source solvers (MulensModel's
+    BinaryLensPointSourceMagnification vs VBM's BinaryMag0), not the shared
+    VBM kernel the finite-source test compares, so agreement is a genuine
+    cross-implementation result rather than a tautology.
+    """
+    # Arrange
+    times, obs = _times_and_obs(n=n, span=span)
+    f_mm = _compile(
+        BinaryLensMagOp(coords=_COORDS, mag_method="auto_vbbl", use_rho=False)
+    )
+    f_dir = _compile(
+        VBMDirectMagOp(coords=_COORDS, n_companions=1, use_rho=False)
+    )
+
+    # Act
+    rng = np.random.default_rng(42)
+    worst = 0.0
+    peak = 0.0
+    for _ in range(25):
+        p = _draw(rng)[_POINT_SOURCE_INDEX]
+        A_mm = f_mm(p, times, obs)
+        A_dir = f_dir(p, times, obs)
+        assert np.all(np.isfinite(A_mm)), f"{grid_name}: MulensModel gave NaN"
+        assert np.all(np.isfinite(A_dir)), f"{grid_name}: direct path gave NaN"
+        worst = max(worst, np.max(np.abs(A_mm - A_dir) / np.abs(A_mm)))
+        peak = max(peak, A_mm.max())
+
+    # Assert
+    assert peak > min_peak, (
+        f"{grid_name} grid never reached the caustic (peak A={peak:.2f}); "
+        "the comparison would be vacuous"
+    )
+    # Observed worst: 7.7e-15 (wide), 1.7e-12 (caustic); the caustic grid is
+    # worse because point-source magnification diverges at a fold and the
+    # 5th-order complex root solve is ill-conditioned there.  1e-9 keeps ~500x
+    # headroom over that while staying far below any convention error (an
+    # alpha or pi_E sign flip moves these by O(0.1-100), not O(1e-9)).
+    assert worst < 1e-9, (
+        f"{grid_name}: direct point-source path deviates from "
+        f"MulensModel: {worst:.2e}"
+    )
 
 
 def test_multi_lens_frame_reduces_to_binary():


### PR DESCRIPTION
Fixes item **1.19** from `notes/code_review_20260808.txt`, and adds the A/B
comparison the bug had been silently preventing.

## The bug

`_build_binary_model` with `auto_vbbl` and `use_rho=False` selected method
`"VBBL"`, and MulensModel 3.11.0 raises
`ValueError: It is impossible to use finite source method for a point source : {'VBBL'}`
(`model.py:868`, where `allowed = {'point_source', 'point_source_point_lens'}`).
`_MagOpBase.perform` caught it and returned an all-NaN curve, so
`backend: mulensmodel` + `finite_source: false` gave `-inf` logp for **every**
proposal.

Reproduced before fixing:

```
RAISED ValueError It is impossible to use finite source method for a point source : {'VBBL'}
A = [nan nan nan nan nan nan nan nan nan nan nan]
```

It stayed hidden because `vbm_direct` is the default binary backend, and because
`test_binary_method_selection_follows_finite_source_flag` mocked
`set_magnification_methods` -- so nothing ever exercised the real call.

## The fix

1. `_build_binary_model`: `method = "VBM" if use_rho else "point_source"`. For a
   binary lens MulensModel maps `point_source` to
   `BinaryLensPointSourceMagnification` -- the exact binary point-source solver
   (`magnificationcurve.py:399-401`), not an approximation. Verified it reproduces
   the VBBL curve at `rho = 1e-6` with max relative difference **0.0**. This also
   mirrors what `_build_pspl_model` already did on its point-source branch.
   (`point_source_point_lens` was rejected: it is a point-*lens* approximation,
   wrong for a resolved binary.)
2. `_MagOpBase.perform` now warns **once per Op instance** (`RuntimeWarning`
   carrying the exception type and message) when it falls back to NaN. Behavior is
   otherwise unchanged. A misconfigured backend that raises on every proposal was
   previously indistinguishable from a sampler exploring bad parameters -- which is
   precisely what made this silent for so long.

## Scope note

`mulensmodel` is **not** the production path: `lens.py` defaults `backend` to
`vbm_direct`, and this code is reached only via the `elif n_lenses == 2` branch
under an explicit `backend: mulensmodel`, documented there as
"rebuild an mm.Model per call (A/B reference; binary only)". The value of the fix
is that the A/B reference itself was unusable for point-source binaries.

## The comparison it unlocks

`tests/test_vbm_direct_vs_mulensmodel.py` only ever passed `use_rho=True`, so
**vbm_direct's point-source binary magnification had never been checked against an
independent implementation** -- the only tool for that check returned all-NaN.

New `test_vbm_direct_matches_mulensmodel_binary_point_source` compares
`VBMDirectMagOp(use_rho=False)` (VBM `BinaryMag0`) against
`BinaryLensMagOp(mag_method="auto_vbbl", use_rho=False)` (MulensModel's
independent 5th-order complex root solve), reusing the file's existing
`_times_and_obs` / `_draw` / `_compile` harness.

Parametrized over two grids, because the file's default grid alone would have been
vacuous: at its 0.75 d sampling the narrow central caustic of the DC128 MAP
(`q=0.0011, s=0.98`) falls *between* epochs and the peak reaches only A ~ 11. The
`caustic` grid (`span=2.0`) resolves it to A ~ 60-610, up to 63x the equivalent
single-lens magnification (checked against `MulensMagOp` to confirm it is genuine
caustic structure). A `min_peak` assertion on each grid keeps the comparison from
silently decaying into flat wings later.

| Grid | Peak A | Max relative deviation |
|---|---|---|
| wide (span 150 d) | ~11 | 7.7e-15 |
| caustic (span 2 d) | ~610 | 1.7e-12 |

Stable across five seeds (2.6e-13 to 2.1e-12). **Tolerance 1e-9** -- ~500x headroom,
and tighter than the existing finite-source test's 1e-8, so nothing was loosened.

Negative controls (measured, not committed) flipping the sign of `alpha`, `pi_E_N`
and `u_0` give deviations of 0.046 to 86 -- ten to thirteen orders of magnitude
above threshold, so the test has real teeth. The caustic grid is 30-120x more
sensitive to a convention error than the wide one.

The existing mocked test is de-mocked and now asserts `model.methods[1]` on a real
`mm.Model`; two more tests cover finite magnifications on both source paths and the
warn-once fallback. The point-source test fails on pre-fix code (all NaN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
