### PR TITLE
run: make inspect_start read-only and canonicalize its user_params lookup (review 1.18)

### DIFF
--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -212,6 +212,35 @@ def validate_sigma_has_center(user_params, links=None, source=None):
         )
 
 
+def canonical_param_key(key, system_config):
+    """Canonical (index-form) spelling of a user-facing parameter key.
+
+    ``star.A.mass`` -> ``star.0.mass`` when the config's ``star`` list has an
+    entry named ``A``.  This is the ONE place the name -> index translation
+    lives: ``standardize_param_names`` uses it to store ``user_params``, and
+    anything looking a key up in ``user_params`` must go through it too --
+    otherwise the lookup silently depends on whether the user named their
+    instances.
+
+    Keys that are not 3-part, that name a flat-dict (non-list) component, or
+    that name an instance the config does not define are returned unchanged,
+    which is exactly how ``standardize_param_names`` stores them.
+    """
+    parts = key.split(".", 2)
+    if len(parts) != 3:
+        return key
+
+    comp_type, comp_name, param_name = parts
+    comp_list = (system_config or {}).get(comp_type)
+    if not isinstance(comp_list, list):
+        return key
+
+    for idx, entry in enumerate(comp_list):
+        if isinstance(entry, dict) and entry.get("name") == comp_name:
+            return f"{comp_type}.{idx}.{param_name}"
+    return key
+
+
 # Provenance Ranks
 RANK_USER = 100  # Explicitly in params.yaml
 RANK_DERIVED_USER = 80  # Solved using ONLY Rank 100s
@@ -953,6 +982,16 @@ class ConfigManager:
         except Exception:
             return 1.0
 
+    def canonical_key(self, key):
+        """Index-form spelling of ``key`` under THIS manager's system config.
+
+        Thin instance wrapper around :func:`canonical_param_key`, for callers
+        that hold a ConfigManager and need to look a user-facing (possibly
+        name-form) path up in ``self.user_params``, which is stored in index
+        form.
+        """
+        return canonical_param_key(key, self.system_config)
+
     @staticmethod
     def standardize_param_names(user_params, config):
         """
@@ -1010,18 +1049,10 @@ class ConfigManager:
                 standardized[key] = copy.deepcopy(val)
                 continue
 
-            try:
-                idx = next(
-                    i
-                    for i, c in enumerate(comp_list)
-                    if isinstance(c, dict) and c.get("name") == comp_name
-                )
-                standardized[f"{comp_type}.{idx}.{param_name}"] = (
-                    copy.deepcopy(val)
-                )
-            except StopIteration:
-                # numeric index or unknown name: keep the key as-is
-                standardized[key] = copy.deepcopy(val)
+            # Numeric index or unknown name: canonical_param_key returns the
+            # key unchanged and it is stored as-is.  deepcopy so broadcast
+            # instances never share one dict (see the aliasing fix in #76).
+            standardized[canonical_param_key(key, config)] = copy.deepcopy(val)
 
         # Pass 2: expand 2-part keys for list components.
         # Indexed entries written by Pass 1 are never overwritten (explicit beats broadcast).

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -717,6 +717,72 @@ def _run_fit(config, gui, user_params=None):
         logger.exception("mkprior failed (non-fatal)")
 
 
+def _element_conversion_factor(par, index):
+    """Internal -> user conversion factor for element ``index`` of ``par``."""
+    f = par._get_conversion_factors()
+    if np.size(f) > 1:
+        return float(np.ravel(f)[index])
+    if np.size(f) == 1:
+        return float(np.ravel(f)[0])
+    return float(f)
+
+
+def _user_initval(config_manager, par, index):
+    """Start value (INTERNAL units) for element ``index`` of ``par`` as spelled
+    in the user/solved parameter table, or None if the table does not set one.
+
+    The key lookup mirrors ``ConfigManager.resolve``: the same three forms
+    (``comp.param``, ``comp.<index>.param``, ``comp.<name>.param``) in the same
+    precedence (later wins), each canonicalized through
+    ``ConfigManager.canonical_key``.  Without that canonicalization a NAMED
+    instance never matches, because ``standardize_param_names`` stores every
+    entry in index form -- so the lookup used to succeed or fail depending on
+    whether the user had named their components.
+    """
+    prefix = par.label.split(".")[0]
+    attr = par.label.split(".")[-1]
+    candidates = [
+        f"{prefix}.{attr}",
+        f"{prefix}.{index}.{attr}",
+        par.get_display_label(index),
+    ]
+
+    val = None
+    for key in candidates:
+        entry = config_manager.user_params.get(
+            config_manager.canonical_key(key)
+        )
+        if entry is None:
+            continue
+        if not isinstance(entry, dict):
+            entry = {"initval": entry}  # bare scalar, as resolve() treats it
+        if "initval" not in entry:
+            continue
+        v = entry["initval"]
+        # List-valued initvals are per-seed starts (P4); seed 0 is canonical.
+        if isinstance(v, (list, tuple)):
+            v = v[0] if len(v) else None
+        if v is not None:
+            val = v
+
+    if val is None:
+        return None
+    try:
+        return float(val) / _element_conversion_factor(par, index)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+
+
+def _is_unset(x):
+    """True when a start-value element carries no usable number."""
+    if x is None:
+        return True
+    try:
+        return bool(np.isnan(float(x)))
+    except (TypeError, ValueError):
+        return False
+
+
 def inspect_start(
     model,
     system,
@@ -813,17 +879,21 @@ def inspect_start(
         raw_v = p.initval
         raw_s = p.init_scale
 
+        n_elements = int(np.prod(p.shape)) if p.shape not in ((), None) else 1
+        cfg_mgr = auditor.system.config_manager
+
         if raw_v is None:
-            # 1. Try to get it from the expression's dependency-solved graph
+            # 1. Try the user/solved parameter table, one element at a time so
+            #    a vector parameter still reports every element.
             try:
-                if p.label in auditor.system.config_manager.user_params:
-                    user_val = auditor.system.config_manager.user_params[
-                        p.label
-                    ].get("initval")
-                    if user_val is not None:
-                        # Convert to internal units so it matches expectations
-                        raw_v = p.to_internal(user_val)
-            except:
+                vals = np.full(n_elements, np.nan)
+                for i in range(n_elements):
+                    uv = _user_initval(cfg_mgr, p, i)
+                    if uv is not None:
+                        vals[i] = uv
+                if np.any(np.isfinite(vals)):
+                    raw_v = vals if n_elements > 1 else float(vals[0])
+            except Exception:
                 pass
 
             # 2. Last resort: Eval the expression if it exists
@@ -842,7 +912,13 @@ def inspect_start(
         if raw_v is None:
             continue
 
-        v_phys = np.atleast_1d(raw_v)
+        # inspect_start is a READ-ONLY diagnostic.  np.atleast_1d returns the
+        # SAME object for a 1-D array, so without the copy every write below
+        # lands in Parameter.initval itself -- which used to revert the
+        # polished starts apply_polished_starts had just stored there, so the
+        # table lied AND get_raw_starts/_seed_initvals_for rebuilt the later
+        # seeds from the reverted values.
+        v_phys = np.atleast_1d(raw_v).copy()
         s_phys = np.atleast_1d(raw_s if raw_s is not None else np.nan)
         m_phys = np.atleast_1d(mult_map.get(p.label, [np.nan] * len(v_phys)))
 
@@ -851,20 +927,19 @@ def inspect_start(
         for i in range(len(v_phys)):
             row_label = p.get_display_label(i)
 
-            # Grab the solver's reconciled value if it exists ---
-            if row_label in auditor.system.config_manager.user_params:
-                resolved_data = auditor.system.config_manager.user_params[
-                    row_label
-                ]
-                if "initval" in resolved_data:
-                    # Fetch the conversion factor and apply it backwards
-                    f = p._get_conversion_factors()
-                    f_val = (
-                        f[i]
-                        if np.size(f) > 1
-                        else (f[0] if np.size(f) == 1 else f)
-                    )
-                    v_phys[i] = float(resolved_data["initval"]) / float(f_val)
+            # Parameter.initval is the AUTHORITATIVE start: it is what
+            # get_raw_start encodes and what the sampler actually begins from.
+            # ConfigManager.resolve already layered the solver-reconciled
+            # user_params value into it at construction, and a pre-whitening
+            # seed polish (apply_polished_starts) may legitimately have moved
+            # it since.  So the user_params entry is only a FALLBACK, for an
+            # element the Parameter never got a number for -- re-asserting it
+            # over a live initval would make this table report a start the
+            # sampler is not going to use.
+            if _is_unset(v_phys[i]):
+                uv = _user_initval(cfg_mgr, p, i)
+                if uv is not None:
+                    v_phys[i] = uv
 
             def safe_float(x):
                 if x is None or (hasattr(x, "size") and x.size == 0):

--- a/tests/test_inspect_start.py
+++ b/tests/test_inspect_start.py
@@ -1,0 +1,233 @@
+"""inspect_start's read-only contract and its user_params key lookup.
+
+inspect_start renders the startup table.  It is a diagnostic: it must report
+the start the sampler is actually going to use, and it must not change it.
+Two defects used to break both halves of that:
+
+  * ``np.atleast_1d(p.initval)`` ALIASES a 1-D initval array, so writing the
+    solver-reconciled value into it mutated ``Parameter.initval`` in place --
+    reverting the polished starts ``System.apply_polished_starts`` had just
+    stored there.  ``get_raw_starts``/``_seed_initvals_for`` then rebuilt the
+    later seeds from the reverted values.
+  * the lookup keys were built from name-form display labels
+    (``star.B.mass``) while ``ConfigManager.user_params`` is stored in index
+    form (``star.1.mass``), so the lookup succeeded or failed depending on
+    whether the user had named their components.
+"""
+
+import logging
+from unittest.mock import patch
+
+import numpy as np
+import pymc as pm
+import pytest
+
+from exozippy.components.parameter import Parameter
+from exozippy.components.star.star import Star
+from exozippy.config import ConfigManager, canonical_param_key
+from exozippy.run import _user_initval, inspect_start
+
+CONFIG = {"star": [{"name": "A"}, {"name": "B"}]}
+
+
+class _Sys:
+    """Duck-typed System: only what ModelAuditor/inspect_start touch."""
+
+    def __init__(self, config_manager, params):
+        self.config_manager = config_manager
+        self.user_params = config_manager.user_params
+        self._params = params
+
+    def get_all_parameters(self):
+        return self._params
+
+    def get_parameter_lookup(self):
+        return {p.label: p for p in self._params}
+
+
+def _build_star_mass(user_params, model_name, system_config=CONFIG):
+    """Build the two-element star.mass Parameter for CONFIG's named stars.
+
+    ``system_config=None`` keeps ConfigManager from standardizing the user
+    keys, so they stay in whatever form the caller wrote them -- the two
+    spellings the read-only contract has to hold for.
+    """
+    cm = ConfigManager(user_params, system_config=system_config)
+    star = Star(CONFIG["star"], cm)
+    with pm.Model(name=model_name) as model:
+        star.manifest = {"mass": {}}
+        star.add_parameter(model=model, param_name="mass", system=None)
+    p = star.mass
+    return model, _Sys(cm, [p]), p
+
+
+def _table_row(caplog, label):
+    """The startup-table line for one element, or None."""
+    for rec in caplog.records:
+        if rec.getMessage().strip().startswith(label + " "):
+            return rec.getMessage()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# (a) read-only with respect to Parameter.initval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("system_config", [CONFIG, None])
+@patch("exozippy.diagnostics.ModelAuditor.get_aggregated_logps")
+def test_inspect_start_never_mutates_initval(mock_logp, system_config):
+    """
+    Given a vector Parameter whose initval was moved after construction
+      (exactly what the pre-whitening seed polish does),
+    When inspect_start renders the startup table,
+    Then Parameter.initval is byte-identical afterwards -- the table is a
+      diagnostic and the start it reports on belongs to the sampler.
+    """
+    # ARRANGE
+    mock_logp.return_value = ({}, {})
+    model, system, p = _build_star_mass(
+        {"star.A.mass": {"initval": 1.0}, "star.B.mass": {"initval": 0.85}},
+        f"model_readonly_{system_config is not None}",
+        system_config=system_config,
+    )
+    polished = np.array([1.4, 0.5])
+    p.initval = polished.copy()
+    before = p.initval.copy()
+
+    # ACT
+    inspect_start(model, system, {}, {}, {})
+
+    # ASSERT
+    assert p.initval.tobytes() == before.tobytes()
+    np.testing.assert_array_equal(p.initval, polished)
+
+
+@pytest.mark.parametrize("system_config", [CONFIG, None])
+@patch("exozippy.diagnostics.ModelAuditor.get_aggregated_logps")
+def test_inspect_start_reports_the_start_the_sampler_will_use(
+    mock_logp, caplog, system_config
+):
+    """
+    Given a polished initval that differs from the user_params entry it was
+      originally resolved from,
+    When inspect_start renders the startup table,
+    Then the table shows the LIVE initval (what get_raw_start encodes and the
+      sampler begins from), not the stale user_params value.
+    """
+    # ARRANGE
+    mock_logp.return_value = ({}, {})
+    model, system, p = _build_star_mass(
+        {"star.A.mass": {"initval": 1.0}, "star.B.mass": {"initval": 0.85}},
+        f"model_reports_live_{system_config is not None}",
+        system_config=system_config,
+    )
+    p.initval = np.array([1.4, 0.5])
+
+    # ACT
+    with caplog.at_level(logging.INFO, logger="exozippy.run"):
+        inspect_start(model, system, {}, {}, {})
+
+    # ASSERT
+    row_a = _table_row(caplog, "star.A.mass")
+    row_b = _table_row(caplog, "star.B.mass")
+    assert row_a is not None and row_b is not None
+    assert "1.40000000" in row_a and "1.00000000" not in row_a
+    assert "0.50000000" in row_b and "0.85000000" not in row_b
+
+
+# ---------------------------------------------------------------------------
+# (b) the lookup no longer depends on how the user spelled the instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", ["star.B.mass", "star.1.mass"])
+def test_user_initval_found_by_name_or_index(key):
+    """
+    Given a user entry written EITHER by instance name or by index,
+    When _user_initval looks the element's start value up,
+    Then it finds the same value both ways -- user_params is stored in index
+      form, so a name-form key only matches after canonicalization.
+    """
+    # ARRANGE
+    model, system, p = _build_star_mass(
+        {key: {"initval": 0.85}}, f"model_lookup_{key.replace('.', '_')}"
+    )
+    assert "star.1.mass" in system.config_manager.user_params  # index form
+
+    # ACT
+    found = _user_initval(system.config_manager, p, 1)
+
+    # ASSERT
+    assert found == pytest.approx(0.85)
+    assert _user_initval(system.config_manager, p, 0) is None
+
+
+@pytest.mark.parametrize("key", ["star.B.mass", "star.1.mass"])
+@patch("exozippy.diagnostics.ModelAuditor.get_aggregated_logps")
+def test_unset_element_falls_back_to_user_params_either_spelling(
+    mock_logp, caplog, key
+):
+    """
+    Given an element the Parameter carries no number for,
+    When inspect_start renders the startup table,
+    Then it falls back to the user/solved parameter table, identically
+      whether the user named the instance or indexed it.
+    """
+    # ARRANGE
+    mock_logp.return_value = ({}, {})
+    model, system, p = _build_star_mass(
+        {key: {"initval": 0.85}},
+        f"model_fallback_{key.replace('.', '_')}",
+    )
+    p.initval = np.array([np.nan, np.nan])
+
+    # ACT
+    with caplog.at_level(logging.INFO, logger="exozippy.run"):
+        inspect_start(model, system, {}, {}, {})
+
+    # ASSERT
+    row_b = _table_row(caplog, "star.B.mass")
+    assert row_b is not None
+    assert "0.85000000" in row_b
+
+
+def test_canonical_param_key_leaves_unknown_and_short_keys_alone():
+    """
+    Given keys the config cannot resolve to an instance index,
+    When canonical_param_key canonicalizes them,
+    Then they come back unchanged -- which is how standardize_param_names
+      stores them, so the two stay in agreement.
+    """
+    assert canonical_param_key("star.B.mass", CONFIG) == "star.1.mass"
+    assert canonical_param_key("star.1.mass", CONFIG) == "star.1.mass"
+    assert canonical_param_key("star.mass", CONFIG) == "star.mass"
+    assert canonical_param_key("star.Z.mass", CONFIG) == "star.Z.mass"
+    assert canonical_param_key("sed.errscale", CONFIG) == "sed.errscale"
+    assert canonical_param_key("run", CONFIG) == "run"
+
+
+def test_scalar_initval_is_also_left_alone():
+    """
+    Given a scalar-shaped Parameter (np.atleast_1d copies there, so it was
+      never corrupted),
+    When inspect_start runs,
+    Then its initval is unchanged too -- pinning that the fix did not make
+      the scalar path worse.
+    """
+    # ARRANGE
+    cm = ConfigManager({}, system_config={})
+    p = Parameter(label="toy.x", initval=2.0, lower=0.0, upper=10.0)
+    with pm.Model(name="model_scalar_initval") as model:
+        p.build_pymc()
+    system = _Sys(cm, [p])
+
+    # ACT
+    with patch(
+        "exozippy.diagnostics.ModelAuditor.get_aggregated_logps",
+        return_value=({}, {}),
+    ):
+        inspect_start(model, system, {}, {}, {})
+
+    # ASSERT
+    assert np.asarray(p.initval).tolist() == [2.0]


### PR DESCRIPTION
Fixes item **1.18** from `notes/code_review_20260808.txt`. Two defects that were
masking each other, so they had to be fixed together.

## (a) `inspect_start` silently mutated `Parameter.initval`

`run.py` did `v_phys = np.atleast_1d(raw_v)` where `raw_v = p.initval`.
`np.atleast_1d` returns the *same object* for a 1-D array, so the subsequent
`v_phys[i] = ...` wrote straight into `Parameter.initval`.

`System.apply_polished_starts` deliberately stores the pre-whitening polished
start in `par.initval`, and `inspect_start` runs immediately after it. Every
element the loop touched was therefore reverted to its pre-polish `user_params`
value. `get_raw_starts` -> `_seed_initvals_for` runs *after* `inspect_start`, so
seeds k>0 were rebuilt from the reverted numbers and the startup table reported a
start the sampler would not use. (Scalar-shaped parameters were safe --
`atleast_1d` of a float allocates.)

## (b) The override key never matched for named instances

The lookup key came from `p.get_display_label(i)`, which is name-form
(`star.B.mass`), while `ConfigManager.user_params` is stored index-form
(`star.0.mass`) by `standardize_param_names`. The override only fired when
instances were *unnamed*.

**The two masked each other:** fixing (b) alone would have made the mutation in (a)
fire on every named-instance config. That is why the review says to fix both
together.

## The fix

- **Which value wins:** `Parameter.initval` is authoritative -- it is what
  `get_raw_start` encodes and what the sampler begins from. The table now reports
  it, and the `user_params` entry is demoted to a *fallback* used only for an
  element carrying no number (NaN/None), which is the case the block was
  originally written for. Table and sampler now agree by construction.
  Worth noting: `ConfigManager.resolve` already layers the user `initval` into
  `Parameter.initval` at construction, so the override was redundant in the normal
  case and wrong in the only case where it differed.
- `v_phys = np.atleast_1d(raw_v).copy()` -- `inspect_start` is read-only with
  respect to `Parameter.initval`.
- **Canonicalization:** new `config.canonical_param_key(key, system_config)` is the
  single home of the name -> index translation. `standardize_param_names` now calls
  it (its inline `next(...)`/`StopIteration` copy is deleted) and
  `ConfigManager.canonical_key()` exposes it to lookup callers. New
  `run._user_initval(cm, par, index)` mirrors `resolve()`'s three key forms and
  precedence, so behavior no longer depends on whether instances are named.
- The `raw_v is None` path had the same disease (it used the 2-part `p.label`) and
  now also builds a full-length vector, so a vector parameter reports every element
  instead of only one row.

## Tests

`tests/test_inspect_start.py` (new, 10 tests):

1. `test_inspect_start_never_mutates_initval[CONFIG|None]` -- the core contract,
   asserted on `p.initval.tobytes()` across the call, for both user-key spellings.
2. `test_inspect_start_reports_the_start_the_sampler_will_use[CONFIG|None]` -- the
   table row shows the polished value, not the stale `user_params` one.
3. `test_user_initval_found_by_name_or_index[star.B.mass|star.1.mass]`
4. `test_unset_element_falls_back_to_user_params_either_spelling[...]`
5. `test_canonical_param_key_leaves_unknown_and_short_keys_alone`,
   `test_scalar_initval_is_also_left_alone`

Four of them fail on pre-fix code (verified by stashing the `src/` changes).

## Validation

Full suite green on this branch: **1037 passed, 6 skipped** (serial run, 14:50).

Rebase onto master needed one real conflict resolution in
`standardize_param_names`: master's #76 added `copy.deepcopy(val)` there (the
broadcast shared-dict aliasing fix) while this branch replaced the same block with
`canonical_param_key`. Resolved by keeping **both** -- taking either side alone
would have silently reintroduced #76's aliasing bug. Re-verified after the rebase
with `test_inspect_start`, `test_multiseed_config`, `test_linked_params`,
`test_mmexofast_support`, `test_config_healing`, `test_config_units`: 60 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
