### PR TITLE
test: use the signal timeout method so xdist timeouts name the test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,4 +304,19 @@ markers = [
     "slow: tests that build a full System + compile PyTensor graphs (~30s+ each); skip with -m 'not slow'",
 ]
 timeout = 300
-timeout_method = "thread"
+# "signal" (SIGALRM), NOT "thread".  pytest-timeout's thread method ends in
+# os._exit(1): the xdist worker vanishes without sending workerfinished, so the
+# controller reports only "[gwN] node down: Not properly terminated".  Worse,
+# execnet dup2's /dev/null onto the worker's fd 1, so the "+++ Timeout +++"
+# banner and stack dump -- written to stdout -- are DISCARDED.  A timeout under
+# -n therefore produced no test name, no traceback, and (via a downstream
+# xdist loadscope KeyError on worker replacement) no summary line at all.
+# Reproduce the old behavior in 11 s with three files of time.sleep(20):
+#   pytest -q -n6 --dist loadfile --timeout=6 --timeout-method=thread .
+# The signal method raises inside the test instead, so the run reports
+#   FAILED tests/test_x.py::test_y - Failed: Timeout (>300.0s) ...
+# and the session survives.  Tradeoff: SIGALRM cannot interrupt code blocked in
+# a C extension that never returns to the interpreter; such a hang now stalls
+# rather than being killed.  That is the better failure -- a stalled run can be
+# diagnosed, a silently truncated one cannot.
+timeout_method = "signal"


### PR DESCRIPTION
Applies fix 1 from today's investigation into the intermittent `-n6` suite collapse.

## The bug this makes visible

`timeout_method = "thread"` ends in pytest-timeout's `os._exit(1)`. A worker that vanishes that way never sends `workerfinished`, so xdist reports exactly:

```
[gw0] node down: Not properly terminated
```

and **execnet `dup2`s `/dev/null` onto the worker's fd 1**, so pytest-timeout's `+++ Timeout +++` banner and full stack dump -- written to stdout -- are discarded. Worker replacement then hits a downstream xdist `loadscope` `KeyError` that kills the summary line as well.

Net effect: a timeout under `-n` produced **no test name, no traceback, and no summary**. Four collapsed runs across two sessions today were all this, and the missing banner actively misled diagnosis -- it looked like evidence *against* a timeout.

## Reproduction

11 seconds, no project code -- three files each containing `time.sleep(20)`:

```
pytest -q -p no:cacheprovider -n 6 --dist loadfile --timeout=6 --timeout-method=thread .
```

Signature-identical to the observed failures, including the doubled `bringing up nodes...` and the absent "replacing crashed worker" lines (those are gated on `verbose >= 0`, suppressed by `-q`).

## After this change

The same scenario reports:

```
FAILED tests/test_x.py::test_y - Failed: Timeout (>300.0s) from pytest-timeout
```

and the session survives to print a summary.

## Tradeoff

SIGALRM cannot interrupt code blocked in a C extension that never returns to the interpreter; such a hang now stalls rather than being killed. That is the better failure mode -- a stalled run can be diagnosed, a silently truncated one cannot.

## Not included

Two follow-ups from the same investigation, deliberately left for separate PRs:

1. **Two tests have internal poll budgets exceeding their own timeout marks** and so cannot fail cleanly on a slow box: `test_runner_lifecycle.py::test_run_lifecycle_status_snapshot_and_graceful_stop` (~1140 s vs a 900 s mark) and `test_run_endpoints.py::test_endpoint_run_lifecycle_start_sampling_stop` (~1130 s vs 900 s). The fix is to cut the 360/600 s polls, not to raise the marks.
2. **Per-worktree `base_compiledir`.** `ModuleCache.refresh()` holds the global cross-process lock for ~5.9 s against a shared 1.3 G compiledir, so concurrent pytensor processes serialize at N x 5.9 s; `compile__timeout = 120` makes that a plausible source of the failures preceding each collapse.

Note CI sets `-n 2` (see `.github/workflows/tests.yml`), which is why this never reproduced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)