### PR TITLE
test: right-size the runner poll budgets so they fit inside their timeout marks

### DIFF
--- a/tests/test_run_endpoints.py
+++ b/tests/test_run_endpoints.py
@@ -24,7 +24,29 @@ from exozippy.gui import TERMINAL_PHASES
 
 EXAMPLE_DIR = Path(__file__).parent.parent / "examples" / "kelt4"
 
+# Poll budgets for the slow end-to-end test at the bottom. Their sum must sit
+# comfortably UNDER that test's @pytest.mark.timeout(900): if the guard fires
+# first, pytest-timeout kills the test instead of letting the poll report what
+# it was waiting for (and under xdist that used to surface as a nameless dead
+# worker). Warm, that test measures 52-84 s end to end; a cold pytensor compile
+# cache alone has been seen to multiply it ~6x, so the one budget that spans a
+# compile stays large and the post-stop ones -- which only cover wrap-up and
+# process reaping -- are sized to that work, not to the compile.
+#
+#   REACH_SAMPLING_TIMEOUT 360 s  subprocess + imports + model build + a COLD
+#                                 pytensor compile + tune + 100 draws
+#   GRACEFUL_EXIT_TIMEOUT  240 s  wrap-up: save partial trace + reports/plots
+#                                 (~20-30 s warm, so ~8x headroom)
+#   FORCE_EXIT_TIMEOUT      45 s  only reached after stop(force=True), which
+#                                 itself blocks ~50 s through second-SIGINT and
+#                                 SIGKILL; the terminal phase is then written
+#                                 (or synthesized by RunHandle.status) at once
+#
+# Worst case, counting the ~50 s each force stop blocks internally:
+# 360 + 240 + 50 + 45 + 50 = 745 s < 900 s.
 REACH_SAMPLING_TIMEOUT = 360.0
+GRACEFUL_EXIT_TIMEOUT = 240.0
+FORCE_EXIT_TIMEOUT = 45.0
 POLL_INTERVAL = 0.5
 
 
@@ -341,7 +363,8 @@ def test_endpoint_run_lifecycle_start_sampling_stop(kelt4_workdir, tmp_path):
             )
 
         assert _poll_until(_sampling_with_progress, REACH_SAMPLING_TIMEOUT), (
-            "run never reported n_draws>=100 during sampling; last status: "
+            "run never reported n_draws>=100 during sampling within "
+            f"{REACH_SAMPLING_TIMEOUT}s; last status: "
             f"{client.get('/api/run/status').json()}"
         )
 
@@ -366,14 +389,20 @@ def test_endpoint_run_lifecycle_start_sampling_stop(kelt4_workdir, tmp_path):
             final_status.update(st)
             return st["phase"] if st.get("phase") in TERMINAL_PHASES else None
 
-        final_phase = _poll_until(_terminal, timeout=600.0)
-        if final_phase is None:
+        final_phase = _poll_until(_terminal, timeout=GRACEFUL_EXIT_TIMEOUT)
+        escalated = final_phase is None
+        if escalated:
             client.post("/api/run/stop", json={"force": True})
-            final_phase = _poll_until(_terminal, timeout=120.0)
+            final_phase = _poll_until(_terminal, timeout=FORCE_EXIT_TIMEOUT)
     finally:
         client.post("/api/run/stop", json={"force": True})
 
-    assert final_phase in {
-        "stopped",
-        "done",
-    }, f"non-terminal end: {final_phase}; status: {final_status}"
+    how = (
+        f"graceful stop timed out after {GRACEFUL_EXIT_TIMEOUT}s and was "
+        "force-escalated"
+        if escalated
+        else "graceful stop was honored"
+    )
+    assert final_phase in {"stopped", "done"}, (
+        f"non-terminal end: {final_phase}; {how}; last status: {final_status}"
+    )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -23,8 +23,16 @@ from exozippy.gui.status import GuiReporter, gui_enabled
 EXAMPLE_DIR = Path(__file__).parent.parent / "examples" / "kelt4"
 
 # Generous ceilings: subprocess start + import + graph compile + reaching the
-# first convergence check (100 stored draws) all happen inside these.
+# first convergence check (100 stored draws) all happen inside this one. It is
+# the only budget in these tests that spans a pytensor compile, so it stays big
+# enough for a COLD compile cache (~6x the warm cost has been measured).
 REACH_SAMPLING_TIMEOUT = 360.0
+# Waiting only for the child to write its FIRST status doc: interpreter start +
+# `import exozippy` + config load, i.e. everything before build_model. That is
+# ~15-30 s and involves no model compile, so it needs a fraction of the budget
+# above. Callers must keep their total under their own timeout mark -- a poll
+# that outlives its mark is killed by pytest-timeout and reports nothing.
+REACH_STATUS_FILE_TIMEOUT = 180.0
 POLL_INTERVAL = 0.5
 
 

--- a/tests/test_runner_interrupt.py
+++ b/tests/test_runner_interrupt.py
@@ -7,13 +7,20 @@ import os
 
 import pytest
 from test_runner import (  # noqa: E402  (tests/ is on sys.path via conftest)
-    REACH_SAMPLING_TIMEOUT,
+    REACH_STATUS_FILE_TIMEOUT,
     _poll_until,
     _write_ptde_config,
     kelt4_workdir,
 )
 
 from exozippy.gui import TERMINAL_PHASES, runner
+
+# Budget: 180 s to see the first status doc (no model compile is involved --
+# see test_runner.REACH_STATUS_FILE_TIMEOUT) + 60 s to reap a process that
+# stop(force=True) has already SIGINT-SIGINT-SIGKILLed (that call itself blocks
+# ~50 s) + 60 s for the same in teardown = ~350 s worst case, well under the
+# 900 s mark below, so a hang fails on the assertion rather than the guard.
+FORCE_EXIT_TIMEOUT = 60.0
 
 
 @pytest.mark.slow
@@ -38,17 +45,23 @@ def test_interrupt_during_prepare_leaves_terminal_phase(
             lambda: (
                 os.path.exists(handle.status_path) or not handle.is_alive()
             ),
-            timeout=REACH_SAMPLING_TIMEOUT,
+            timeout=REACH_STATUS_FILE_TIMEOUT,
         )
-        assert appeared, "run never wrote an initial status or exited"
+        assert appeared, (
+            f"run never wrote an initial status at {handle.status_path} nor "
+            f"exited within {REACH_STATUS_FILE_TIMEOUT}s; pid={handle.pid}"
+        )
 
         handle.stop(force=True)
-        rc = handle.wait(timeout=120.0)
-        assert rc is not None, "process did not exit after stop"
+        rc = handle.wait(timeout=FORCE_EXIT_TIMEOUT)
+        assert rc is not None, (
+            f"process {handle.pid} did not exit within {FORCE_EXIT_TIMEOUT}s "
+            "after stop(force=True) (which already SIGKILLed it)"
+        )
     finally:
         if handle.is_alive():
             handle.stop(force=True)
-            handle.wait(timeout=60.0)
+            handle.wait(timeout=FORCE_EXIT_TIMEOUT)
 
     final = handle.status()
     assert final["phase"] in TERMINAL_PHASES, (

--- a/tests/test_runner_lifecycle.py
+++ b/tests/test_runner_lifecycle.py
@@ -21,6 +21,24 @@ from test_runner import (  # noqa: E402  (tests/ is on sys.path via conftest)
 
 from exozippy.gui import TERMINAL_PHASES, runner
 
+# Poll budgets. Every wait here must add up to comfortably LESS than the
+# @pytest.mark.timeout below, or the guard kills the test before its own polls
+# give up and the failure is reported as a dead xdist worker with no test name
+# instead of the assertion that says what was actually stuck.
+#
+#   REACH_SAMPLING_TIMEOUT (360 s, from test_runner)  subprocess + imports +
+#       model build + a COLD pytensor compile + tune + 100 draws
+#   SNAPSHOT_TIMEOUT       30 s   file-visibility lag only (see below)
+#   GRACEFUL_EXIT_TIMEOUT  240 s  wrap-up: save trace + reports/plots
+#   FORCE_EXIT_TIMEOUT     30 s   reaping a process already sent SIGKILL
+#
+# Worst case, counting the ~50 s that handle.stop(force=True) itself blocks for
+# (graceful_timeout 30 + kill_timeout 10 + 10): 360 + 30 + 240 + 50 + 30 + 50 +
+# 30 = 790 s < 900 s. Warm, the whole test measures 57-81 s.
+SNAPSHOT_TIMEOUT = 30.0
+GRACEFUL_EXIT_TIMEOUT = 240.0
+FORCE_EXIT_TIMEOUT = 30.0
+
 
 @pytest.mark.slow
 @pytest.mark.timeout(900)
@@ -37,6 +55,7 @@ def test_run_lifecycle_status_snapshot_and_graceful_stop(
     config_name = _write_ptde_config(kelt4_workdir, out_prefix)
 
     handle = runner.start_run(config_name, cwd=kelt4_workdir)
+    forced = []  # records any force escalation, for the final message
     try:
         # 1. reaches a convergence check during sampling. gui.phase("sampling")
         # is written the instant sampling starts, but n_draws only appears once
@@ -54,16 +73,31 @@ def test_run_lifecycle_status_snapshot_and_graceful_stop(
             )
 
         assert _poll_until(_sampling_with_progress, REACH_SAMPLING_TIMEOUT), (
-            "run never reported n_draws>=100 during sampling"
+            f"run never reported n_draws>=100 during sampling within "
+            f"{REACH_SAMPLING_TIMEOUT}s; alive={handle.is_alive()}, "
+            f"last status: {handle.status()}"
         )
         status = handle.status()
         assert status["phase"] == "sampling", f"unexpected phase {status}"
         assert status["state"].get("n_draws", 0) >= 100
 
-        # 2. the snapshot artifacts written by that same convergence check exist.
+        # 2. the snapshot artifacts written by that same convergence check
+        # exist. The npz is written by the very convergence check that
+        # published n_draws>=100, so it is already on disk (or one atomic
+        # rename away) by the time the poll above returns: this budget covers
+        # file-visibility lag, not model work.
         snap_npz = os.path.join(handle.snapshot_dir, "partial.npz")
-        assert _poll_until(lambda: os.path.exists(snap_npz), timeout=60.0), (
-            "snapshot npz never appeared"
+        found = _poll_until(
+            lambda: os.path.exists(snap_npz), timeout=SNAPSHOT_TIMEOUT
+        )
+        listing = (
+            sorted(os.listdir(handle.snapshot_dir))
+            if os.path.isdir(handle.snapshot_dir)
+            else "<snapshot dir does not exist>"
+        )
+        assert found, (
+            f"snapshot npz {snap_npz} never appeared within "
+            f"{SNAPSHOT_TIMEOUT}s; snapshot dir contains {listing}"
         )
         snap = np.load(snap_npz)
         assert "_lp" in snap and any(k.endswith("_raw") for k in snap.files)
@@ -71,18 +105,29 @@ def test_run_lifecycle_status_snapshot_and_graceful_stop(
         # 3. graceful stop (single SIGINT) as early as possible -> the run
         # wraps up on its own (saves the partial trace, writes reports) and
         # exits on a terminal phase, without a premature force escalation.
+        # Wrap-up is ~20-30 s warm (trace save + report/plot generation, which
+        # compiles its own pytensor plotters); 240 s is ~8x that, room for a
+        # cold compile cache, and still leaves the escalation below inside the
+        # 900 s mark.
         handle.stop(force=False)
-        ended = _poll_until(lambda: not handle.is_alive(), timeout=600.0)
+        ended = _poll_until(
+            lambda: not handle.is_alive(), timeout=GRACEFUL_EXIT_TIMEOUT
+        )
         if not ended:
+            forced.append("graceful stop timed out; escalated to force")
             handle.stop(force=True)
-            handle.wait(timeout=60.0)
+            handle.wait(timeout=FORCE_EXIT_TIMEOUT)
     finally:
         if handle.is_alive():
+            forced.append("still alive at teardown; forced")
             handle.stop(force=True)
-            handle.wait(timeout=60.0)
+            handle.wait(timeout=FORCE_EXIT_TIMEOUT)
 
     final = handle.status()
-    assert final["phase"] in {"stopped", "done"}, f"non-terminal end: {final}"
+    assert final["phase"] in {"stopped", "done"}, (
+        f"non-terminal end: {final}"
+        + (f"; escalations: {forced}" if forced else "")
+    )
     assert final["phase"] in TERMINAL_PHASES
 
     # 4. a usable trace was written and opens in arviz.


### PR DESCRIPTION
Second half of the intermittent `-n6` suite-collapse work (PR #81 fixed the first half by switching `timeout_method` to `signal`).

Two tests had internal poll budgets EXCEEDING their own `@pytest.mark.timeout(900)`, so on a slow box they could not fail cleanly -- they blew the guard before their own polls gave up, and the guard killed the worker instead of letting the test report:

| test | old budget | mark |
|---|---|---|
| `test_runner_lifecycle::test_run_lifecycle_status_snapshot_and_graceful_stop` | ~1140 s | 900 s |
| `test_run_endpoints::test_endpoint_run_lifecycle_start_sampling_stop` | ~1130 s | 900 s |

## Principle

**Exactly one poll per test spans a pytensor compile** -- the "reach sampling with n_draws>=100" wait. That one KEEPS its 360 s, because the cold-cache multiplier (~6x; 310 s and 213 s were measured on a cold cache vs 52 s / 45 s warm) lands there and nowhere else. Everything downstream runs after the model is built and compiled, so those budgets were sized against wrap-up work and that is where all the slack was.

Budgets are cut, NOT the marks raised.

### test_runner_lifecycle

| poll | old | new | why |
|---|---|---|---|
| reach sampling | 360 | **360** | only compile-spanning wait; needs the cold headroom |
| snapshot npz appears | 60 | **30** | written by the same convergence check that just published `n_draws>=100`; covers file-visibility lag, not model work |
| graceful exit after SIGINT | 600 | **240** | wrap-up is ~20-30 s warm out of an 87 s test; 240 is ~8x, enough for a cold plotter compile |
| force-escalation wait (x2) | 60 | **30** | only reaps an already-SIGKILLed process |

New worst case **790 s < 900 s** (including two 50 s terms for `stop(force=True)`'s own internal blocking -- see below).

### test_run_endpoints

| poll | old | new |
|---|---|---|
| reach sampling | 360 | **360** |
| terminal phase after graceful stop | 600 | **240** |
| terminal phase after force stop | 120 | **45** |

New worst case **745 s < 900 s**.

### The other two files

- `test_runner_interrupt.py` waited on `REACH_SAMPLING_TIMEOUT`'s 360 s for the child's **first status doc** -- interpreter start + import + config load, everything *before* `build_model`. Split out `REACH_STATUS_FILE_TIMEOUT = 180.0` (whole test measures 23 s, no compile in the path) and trimmed the post-SIGKILL reap 120 -> 60 s.
- `test_runner.py::test_run_without_flag_writes_no_status` **left at 600 s**: it is not a milestone poll but the whole-fit `subprocess.run(timeout=...)`, its `TimeoutExpired` is already a clean named report at ~610 s < 900 s, and 213 s has been seen cold.

## Failure messages

Every touched poll now names what it waited for, how long, and what it last saw -- last full status doc + liveness, the snapshot dir listing (or "does not exist"), the pid for the interrupt reap. The final terminal-phase assertion now also reports whether the graceful stop was honored or had to be force-escalated: **previously a run that only ever died under SIGKILL looked identical to a clean graceful stop.**

## An error in the original accounting

`stop(force=True)` blocks ~50 s **inside the test body** (`RunHandle`'s `graceful_timeout=30` + `kill_timeout=10`), invisible from the poll constants. Any budget arithmetic that ignores it under-counts by up to 100 s per test. It is now written into the totals.

## Measured (idle box, warm cache, -n0)

`test_runner_lifecycle` 86.8 s | `test_run_endpoints` 55.4 s | `test_runner_interrupt` 23.1 s | `test_runner` 48.2 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)