### PR TITLE
modes: fix evidence weighting (review 1.13) and report how much the relative weights can be trusted

### DIFF
--- a/src/exozippy/outputs/autocorr.py
+++ b/src/exozippy/outputs/autocorr.py
@@ -1,0 +1,171 @@
+"""Integrated autocorrelation time of a Monte Carlo estimator's mean.
+
+Shared by ``outputs/evidence.py`` -- which inflates the bridge-sampling error
+bar by the IACT of its posterior-side bridge function -- and by
+``outputs/modes.py``, which turns the IACT of a mode-indicator series into an
+effective sample size for that mode's occupancy weight.
+
+Both callers want the same number: the factor by which the variance of the
+sample MEAN exceeds the i.i.d. value ``var/N``.  Two things inflate it, and
+both are counted here:
+
+  * **within-chain autocorrelation** -- the chain-averaged autocovariance,
+    truncated by Geyer's initial positive/monotone rule on the pair sums
+    ``rho_2t + rho_2t+1``;
+  * **between-chain scatter of the chain means**, beyond what the
+    within-chain autocorrelation predicts.  For chains stuck in different
+    modes this term is the entire answer: every chain is internally constant,
+    so a within-chain-only estimate would report ``tau = 1`` and hand back an
+    absurdly tight error bar on a weight that is pure initialization.
+
+Chains may be **ragged** (a mode does not occupy the same number of draws in
+every chain, and invalid draws are dropped), so nothing here assumes a
+rectangular array.
+
+ORDER IS THE INPUT.  Reordering a series -- subsampling it with an unsorted
+``rng.choice``, say -- destroys precisely the structure being measured, and
+any autocorrelated series then reads ``tau ~ 1``.  If a series must be
+shortened, thin it with a stride: the IACT measured on the strided series is
+the correct inflation factor for the mean OF THAT SERIES, which is what the
+caller actually averages, so no separate thinning correction is needed.  (A
+useful invariant: ``tau_thinned / N_thinned`` tracks ``tau_full / N_full``
+until the stride exceeds the correlation time, past which the thinned answer
+is merely conservative.)
+"""
+
+import numpy as np
+
+
+def _as_chains(chains):
+    """Normalize the input to a list of 1-D float arrays, one per chain."""
+    if isinstance(chains, np.ndarray):
+        a = np.asarray(chains, dtype=float)
+        if a.ndim == 0:
+            return [a.reshape(1)]
+        if a.ndim == 1:
+            return [a]
+        if a.ndim == 2:
+            return [a[c] for c in range(a.shape[0])]
+        raise ValueError(
+            f"autocorr: expected a 1-D or (chain, draw) 2-D array, got "
+            f"shape {a.shape}"
+        )
+    return [np.asarray(c, dtype=float).ravel() for c in chains]
+
+
+def _autocov(x, n_lag):
+    """Biased autocovariance of a centered 1-D series at lags 0..n_lag-1."""
+    n = x.size
+    y = x - x.mean()
+    nfft = 1
+    while nfft < 2 * n:
+        nfft *= 2
+    f = np.fft.rfft(y, nfft)
+    acov = np.fft.irfft(f * np.conjugate(f), nfft)[:n] / n
+    out = np.zeros(n_lag)
+    out[: min(n_lag, n)] = acov[: min(n_lag, n)]
+    return out
+
+
+def iact(chains):
+    """Variance-inflation factor of the mean over one or more chains (>= 1).
+
+    Parameters
+    ----------
+    chains : 1-D array (one chain), 2-D array of shape (chain, draw), or a
+        sequence of 1-D arrays of possibly different lengths.
+
+    Returns
+    -------
+    float
+        ``tau`` such that ``Var(mean) = tau * Var(x) / N``, where ``N`` is
+        the total number of values across all chains.
+
+    Notes
+    -----
+    This is the Vehtari et al. (2021) multi-chain construction, generalized
+    to ragged chain lengths, with Geyer's initial positive/monotone pair
+    truncation.  Its virtue over "take the larger of a within-chain and a
+    between-chain estimate" is that the between-chain variance B enters only
+    as ``B / n_bar`` inside ``var_plus``.  On well-mixed chains that term is
+    O(tau/n) and changes nothing, so the chi-square noise of a (C-1)-degree-
+    of-freedom quantity cannot inflate a perfectly good error bar; on chains
+    stuck in different modes the within-chain variance W collapses, ``B/n``
+    dominates, every ``rho_t`` stays pinned at 1, and tau grows until the
+    effective sample size is of order the number of chains -- which is the
+    honest answer there.
+    """
+    segs = [c for c in _as_chains(chains) if c.size > 0]
+    segs = [c[np.isfinite(c)] for c in segs]
+    segs = [c for c in segs if c.size > 0]
+    n_chain = len(segs)
+    n_total = sum(c.size for c in segs)
+    if n_chain == 0 or n_total < 4:
+        return 1.0
+
+    lengths = np.array([c.size for c in segs], dtype=float)
+    means = np.array([float(c.mean()) for c in segs])
+    grand_mean = float((lengths * means).sum() / n_total)
+
+    # W: pooled within-chain variance.  B: between-chain variance, written in
+    # the ragged-safe form that reduces to n * var(chain means, ddof=1) when
+    # every chain has the same length.
+    dof = float((lengths - 1).sum())
+    if dof <= 0:
+        return 1.0
+    W = sum(float(((c - c.mean()) ** 2).sum()) for c in segs) / dof
+    if n_chain > 1:
+        B = float((lengths * (means - grand_mean) ** 2).sum()) / (n_chain - 1)
+    else:
+        B = 0.0
+    n_bar = n_total / n_chain
+    var_plus = ((n_bar - 1.0) * W + B) / n_bar
+    if not np.isfinite(var_plus) or var_plus <= 0:
+        return 1.0
+
+    # Chain-averaged autocovariance, weighted by chain length; at lag t only
+    # the chains long enough to have that lag contribute.
+    n_lag = max(4, int(n_bar))
+    acov_sum = np.zeros(n_lag)
+    weight = np.zeros(n_lag)
+    for c in segs:
+        m = min(n_lag, c.size)
+        acov_sum[:m] += c.size * _autocov(c, n_lag)[:m]
+        weight[:m] += c.size
+    valid = weight > 0
+    acov_bar = np.zeros(n_lag)
+    acov_bar[valid] = acov_sum[valid] / weight[valid]
+    n_lag = int(valid.sum()) if valid.all() else int(np.argmin(valid))
+    if n_lag < 2:
+        return 1.0
+
+    rho = 1.0 - (W - acov_bar[:n_lag]) / var_plus
+
+    # Geyer initial positive sequence on the pair sums, with the initial
+    # monotone clamp: truncating on pairs is far less noisy than the per-lag
+    # "rho_k <= 0" rule, which on a long correlated series stops early on a
+    # single negative sample.
+    tau = -1.0
+    prev = np.inf
+    t = 0
+    while t + 1 < n_lag:
+        p = rho[t] + rho[t + 1]
+        if t > 0 and p <= 0:
+            break
+        p = min(p, prev)  # initial monotone sequence
+        prev = p
+        tau += 2.0 * p
+        t += 2
+
+    if not np.isfinite(tau):
+        return 1.0
+    return float(min(max(tau, 1.0), float(n_total)))
+
+
+def ess(chains):
+    """Effective sample size of the mean: total draws divided by ``iact``."""
+    segs = [c for c in _as_chains(chains) if c.size > 0]
+    n_total = sum(c.size for c in segs)
+    if n_total == 0:
+        return 0.0
+    return n_total / iact(segs)

--- a/src/exozippy/outputs/evidence.py
+++ b/src/exozippy/outputs/evidence.py
@@ -50,6 +50,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from .autocorr import iact as _iact
+
 logger = logging.getLogger(__name__)
 
 
@@ -93,45 +95,57 @@ def _logmeanexp(a):
     return m + np.log(np.mean(np.exp(a - m)))
 
 
-def _iact(x):
-    """Integrated autocorrelation time of a 1-D series (>= 1).
+# Fixed-point convergence tolerance, RELATIVE to the magnitude of lr itself.
+# lr is a log-evidence at raw model-logp scale (|lr| ~ 1e4..1e6 on real
+# datasets), and it is only ever known to float64 relative precision: at
+# |lr| = 1e6 one ULP is already 1.2e-10, so the ABSOLUTE 1e-10 test this
+# replaced sat inside the round-off floor of its own arithmetic and reported
+# spurious non-convergence on ~25% of otherwise perfect estimates (measured;
+# see tests).  1e-10 relative is ~4.5e5 ULPs -- comfortably above the
+# sqrt(N)-term summation noise of the two _logmeanexp calls -- while the
+# absolute step it admits, 1e-10 * |lnZ|, is 1e-4 nat even at |lnZ| = 1e6:
+# four orders of magnitude below the 0.5-nat error bar at which a mode is
+# refused, so nothing statistically meaningful can hide under it.  A bridge
+# iteration that has genuinely not converged is still moving by O(0.01-1)
+# nat per step, which is many orders above this at any scale.
+DEFAULT_BRIDGE_RTOL = 1e-10
 
-    Sums the normalized autocorrelation with Geyer's initial-positive-sequence
-    truncation.  Used to inflate the bridge error bar for autocorrelated
-    posterior draws; returns ~1 for i.i.d. input.
+
+def _segments(values, mask, lengths):
+    """Split ``values`` (already reduced by ``mask``) back into chain segments.
+
+    ``lengths`` describes the un-filtered array; ``mask`` says which of its
+    entries survived.  Returns one 1-D array per chain, in sampling order.
     """
-    x = np.asarray(x, dtype=float)
-    n = x.size
-    if n < 4:
-        return 1.0
-    x = x - x.mean()
-    var = np.dot(x, x) / n
-    if var <= 0:
-        return 1.0
-    # autocovariance via FFT
-    nfft = 1
-    while nfft < 2 * n:
-        nfft *= 2
-    f = np.fft.rfft(x, nfft)
-    acov = np.fft.irfft(f * np.conjugate(f), nfft)[:n] / n
-    rho = acov / acov[0]
-    tau = 1.0
-    for k in range(1, n):
-        if rho[k] <= 0:
-            break
-        tau += 2.0 * rho[k]
-    return max(tau, 1.0)
+    if lengths is None:
+        return [values]
+    out = []
+    pos = 0  # cursor in the original array
+    fpos = 0  # cursor in the filtered array
+    for length in lengths:
+        kept = int(mask[pos : pos + length].sum())
+        out.append(values[fpos : fpos + kept])
+        pos += length
+        fpos += kept
+    return out
 
 
-def bridge_lnZ(l1, l2, maxiter=1000, tol=1e-10):
+def bridge_lnZ(l1, l2, maxiter=1000, tol=DEFAULT_BRIDGE_RTOL, l1_chains=None):
     """Optimal iterative bridge-sampling estimate of a log normalizing constant.
 
     Parameters
     ----------
     l1 : array, log(unnormalized target) - log(proposal) at the *posterior*
-        draws (samples from the target).
+        draws (samples from the target), **in sampling order**.
     l2 : array, the same log-ratio at fresh draws from the *proposal*.
-    maxiter, tol : iteration controls for the fixed-point update.
+    l1_chains : sequence of int, optional -- the per-chain lengths that
+        partition ``l1`` (they must sum to ``len(l1)``).  Given, the IACT that
+        inflates the posterior-side error term is measured chain by chain and
+        combined; omitted, ``l1`` is treated as one long chain, which
+        concatenates independent chains end to end and biases the IACT.
+    maxiter : maximum fixed-point iterations.
+    tol : RELATIVE convergence tolerance on lr (see DEFAULT_BRIDGE_RTOL);
+        the effective absolute threshold is ``tol * max(1, |lr|)``.
 
     Returns
     -------
@@ -140,11 +154,34 @@ def bridge_lnZ(l1, l2, maxiter=1000, tol=1e-10):
         (normalized) proposal; re2 is the approximate relative mean-squared
         error of the Z estimate (Fruhwirth-Schnatter 2004) and
         lnZ_err = sqrt(re2).
+
+    Notes
+    -----
+    Everything downstream of the fixed point is computed **recentered by lr**.
+    The textbook bridge diagnostic is written with
+
+        f1 = exp(l2) / (s1 exp(l2) + s2 r),   f2 = 1 / (s1 exp(l1) + s2 r)
+
+    at r = exp(lr), and both expressions overflow or underflow to nan/inf as
+    soon as |lr| or |l| exceeds ~709 -- which is *always*, since l1 and l2
+    carry the raw model logp (-1e4 .. -1e6 for any real dataset).  Dividing
+    through by exp(l2) and by r respectively gives the algebraically identical
+
+        f1 = 1 / (s1 + s2 exp(lr - l2)),      f2' = 1 / (s1 exp(l1 - lr) + s2)
+
+    where every exponent is a *difference* of same-scale log quantities and so
+    stays O(1).  f1 is unchanged; f2' = r * f2 is f2 rescaled by a constant,
+    and only the scale-free ratios ``var/mean^2`` (and the IACT, which is
+    computed from the normalized autocorrelation) enter re2 -- so re2 and
+    lnZ_err are exactly the quantities the unrecentered form intends, and
+    reproduce it to float precision wherever it was representable at all.
     """
     l1 = np.asarray(l1, dtype=float)
     l2 = np.asarray(l2, dtype=float)
-    l1 = l1[np.isfinite(l1)]
-    l2 = l2[np.isfinite(l2)]
+    finite1 = np.isfinite(l1)
+    finite2 = np.isfinite(l2)
+    l1 = l1[finite1]
+    l2 = l2[finite2]
     N1, N2 = l1.size, l2.size
     if N1 < 2 or N2 < 2:
         return np.nan, np.inf, np.inf, False
@@ -161,22 +198,29 @@ def bridge_lnZ(l1, l2, maxiter=1000, tol=1e-10):
         lr_new = _logmeanexp(log_num) - _logmeanexp(log_den)
         if not np.isfinite(lr_new):
             return np.nan, np.inf, np.inf, False
-        if abs(lr_new - lr) < tol:
+        if abs(lr_new - lr) < tol * max(1.0, abs(lr_new)):
             lr = lr_new
             converged = True
             break
         lr = lr_new
 
-    r = np.exp(lr)
     s1 = N1 / (N1 + N2)
     s2 = N2 / (N1 + N2)
-    # f1 over proposal samples, f2 over posterior samples (converged r)
-    f1 = np.exp(l2) / (s1 * np.exp(l2) + s2 * r)
-    f2 = 1.0 / (s1 * np.exp(l1) + s2 * r)
+    # Recentered bridge functions -- see the Notes above.  f1 lives on the
+    # proposal draws (i.i.d. by construction), f2 on the posterior draws.
+    with np.errstate(over="ignore"):
+        f1 = 1.0 / (s1 + s2 * np.exp(lr - l2))
+        f2 = 1.0 / (s1 * np.exp(l1 - lr) + s2)
     m1, m2 = f1.mean(), f2.mean()
     if not (np.isfinite(m1) and np.isfinite(m2)) or m1 <= 0 or m2 <= 0:
-        return lr, np.inf, np.inf, converged
-    tau = _iact(f2)
+        return float(lr), np.inf, np.inf, converged
+    # f2 is a POSTERIOR-draw series: it inherits the sampler's
+    # autocorrelation, so its contribution to the estimator variance is
+    # inflated by the IACT.  The caller must hand the posterior draws over in
+    # sampling order, one entry per chain (see _posterior_chains); measuring
+    # the IACT of a reordered series silently returns ~1 and understates the
+    # error bar by sqrt(tau).
+    tau = _iact(_segments(f2, finite1, l1_chains))
     term1 = (f1.var() / m1**2) / N2
     term2 = tau * (f2.var() / m2**2) / N1
     re2 = float(term1 + term2)
@@ -355,6 +399,43 @@ def _get_labels(idata, mode_report):
     return np.asarray(mode_report.labels, dtype=int).reshape(-1)
 
 
+def _mode_draw_index(labels, mode, n_chain, n_draw, max_draws):
+    """Row indices of ``mode``'s draws, in sampling order, thinned by stride.
+
+    Returns ``(index, chain_lengths)``: ``index`` selects rows of the
+    (chain, draw) row-major posterior matrix, grouped by chain and ascending
+    in draw within each chain; ``chain_lengths`` partitions it back into
+    chains for the IACT.
+
+    The thinning is a **uniform stride applied within each chain**, never an
+    unsorted ``rng.choice``: the retained series has to stay a time series or
+    the IACT of the bridge function reads ~1 whatever the sampler did, and
+    the posterior-side error term is then understated by sqrt(tau) (a factor
+    of ~20 on a chain with tau ~ 400).  No separate thinning correction is
+    needed downstream -- the mean the estimator forms is the mean of exactly
+    this strided series, so its own IACT is the right inflation factor.
+
+    A mode's draws within a chain need not be contiguous (the chain may have
+    left and returned); the retained subsequence is treated as a stationary
+    series, which is the same approximation the stride already makes.
+    """
+    sel_idx = np.flatnonzero(labels == mode)
+    if sel_idx.size == 0:
+        return sel_idx, []
+    stride = max(1, int(np.ceil(sel_idx.size / max(max_draws, 1))))
+    chain_of = sel_idx // n_draw
+    kept = []
+    chain_lengths = []
+    for c in range(n_chain):
+        idx_c = sel_idx[chain_of == c][::stride]
+        if idx_c.size:
+            kept.append(idx_c)
+            chain_lengths.append(int(idx_c.size))
+    if not kept:
+        return np.zeros(0, dtype=int), []
+    return np.concatenate(kept), chain_lengths
+
+
 def estimate_mode_evidences(
     model,
     idata,
@@ -374,8 +455,9 @@ def estimate_mode_evidences(
     mode_report : the ModeReport whose modes are to be weighted.
     n_proposal : proposal draws per mode (default: match the mode's posterior
         draw count, capped at max_posterior_draws).
-    max_posterior_draws : subsample each mode's posterior draws to at most this
-        many for the (many) logp evaluations.
+    max_posterior_draws : thin each mode's posterior draws to at most this
+        many for the (many) logp evaluations.  Thinning is a per-chain stride
+        so the retained draws stay a time series (see _mode_draw_index).
     re2_max : refuse a mode whose bridge relative-MSE exceeds this.
     seed : RNG seed for reproducible proposal draws.
 
@@ -410,25 +492,26 @@ def estimate_mode_evidences(
 
     Xall = _posterior_matrix(idata, layout, D)
     labels = _get_labels(idata, mode_report)
+    n_chain = int(idata.posterior.sizes["chain"])
+    n_draw = int(idata.posterior.sizes["draw"])
 
     # Fit proposals and stage every point that needs a logp evaluation, so all
     # modes' posterior + proposal points share a single fork-parallel logp pass.
-    stage = []  # (mode, kind, X1, Y, mu, S)
+    stage = []  # (mode, kind, X1, Y, mu, S, chain_lengths)
     all_points = []
     for k in range(mode_report.n_modes):
-        sel = labels == k
-        X1 = Xall[sel]
+        sel_idx, chain_lengths = _mode_draw_index(
+            labels, k, n_chain, n_draw, max_posterior_draws
+        )
+        X1 = Xall[sel_idx]
         if X1.shape[0] < 4:
-            stage.append((k, None, X1, None, None, None))
+            stage.append((k, None, X1, None, None, None, None))
             continue
-        if X1.shape[0] > max_posterior_draws:
-            idx = rng.choice(X1.shape[0], max_posterior_draws, replace=False)
-            X1 = X1[idx]
         mu, S = _fit_gaussian(X1)
         n2 = n_proposal or X1.shape[0]
         n2 = int(min(n2, max_posterior_draws))
         Y = _sample_gaussian(mu, S, n2, rng)
-        stage.append((k, "ok", X1, Y, mu, S))
+        stage.append((k, "ok", X1, Y, mu, S, chain_lengths))
         all_points.append(X1)
         all_points.append(Y)
 
@@ -439,7 +522,7 @@ def estimate_mode_evidences(
         logp_all = np.zeros(0)
 
     cursor = 0
-    for k, kind, X1, Y, mu, S in stage:
+    for k, kind, X1, Y, mu, S, chain_lengths in stage:
         if kind is None:
             results.append(
                 EvidenceResult(
@@ -465,7 +548,9 @@ def estimate_mode_evidences(
         l1 = logp1 - logq1
         l2 = logp2 - logq2
 
-        lnZ, lnZ_err, re2, converged = bridge_lnZ(l1, l2)
+        lnZ, lnZ_err, re2, converged = bridge_lnZ(
+            l1, l2, l1_chains=chain_lengths
+        )
 
         refused = False
         reason = ""
@@ -511,7 +596,9 @@ def softmax_weights(lnZ, lnZ_err):
     return w, dw
 
 
-def apply_evidence_weighting(mode_report, results, re2_max=DEFAULT_RE2_MAX):
+def apply_evidence_weighting(
+    mode_report, results, re2_max=DEFAULT_RE2_MAX, idata=None
+):
     """Replace occupancy weights with softmax evidence weights, if confident.
 
     Softmax evidence weights need every mode's lnZ, so a single refused mode
@@ -519,6 +606,16 @@ def apply_evidence_weighting(mode_report, results, re2_max=DEFAULT_RE2_MAX):
     provenance are kept unchanged (with a note), honoring the project
     invariant that a shaky weight is never emitted.  Returns True iff evidence
     weights were applied.
+
+    Each mode's occupancy weight and its mixing-derived error bar survive on
+    ``ModeInfo.occ_weight`` / ``occ_weight_err`` either way, so the report can
+    print the two side by side -- evidence weighting is a CROSS-CHECK on
+    occupancy, and the comparison is the point.
+
+    ``idata``, when given, has its ``posterior['mode'].attrs`` refreshed: that
+    variable is built by ``ModeReport.attach`` at identify_modes time and
+    would otherwise keep advertising the superseded occupancy weights and
+    provenance to anything reading the trace back from disk.
     """
     if not results or len(results) != mode_report.n_modes:
         return False
@@ -541,12 +638,19 @@ def apply_evidence_weighting(mode_report, results, re2_max=DEFAULT_RE2_MAX):
             "falling back to occupancy",
             ids,
         )
+        if idata is not None:
+            mode_report.attach(idata)
         return False
 
     lnZ = np.array([r.lnZ for r in results], dtype=float)
     err = np.array([r.lnZ_err for r in results], dtype=float)
     w, dw = softmax_weights(lnZ, err)
     for k, m in enumerate(mode_report.modes):
+        if not np.isfinite(m.occ_weight):
+            # Reports built before this ran (or by hand) still get a record
+            # of what occupancy said, so the cross-check stays possible.
+            m.occ_weight = float(m.weight)
+            m.occ_weight_err = float(m.weight_err)
         m.weight = float(w[k])
         m.weight_err = float(dw[k])
         m.lnZ = float(lnZ[k])
@@ -567,6 +671,35 @@ def apply_evidence_weighting(mode_report, results, re2_max=DEFAULT_RE2_MAX):
             for r in results
         )
     )
+    # Cross-check line: evidence weighting needs no mode transitions at all,
+    # occupancy needs them and reports its own mixing-derived error bar, so
+    # disagreement beyond the two error bars localizes the problem (ladder
+    # tuning on the occupancy side, proposal fit on the evidence side).
+    disagree = []
+    for m in mode_report.modes:
+        if not np.isfinite(m.occ_weight):
+            continue
+        spread = np.hypot(
+            m.weight_err if np.isfinite(m.weight_err) else 0.0,
+            m.occ_weight_err if np.isfinite(m.occ_weight_err) else 0.0,
+        )
+        gap = abs(m.weight - m.occ_weight)
+        disagree.append(
+            f"mode {m.index + 1}: evidence {m.weight:.3f}+/-"
+            f"{m.weight_err:.3f} vs occupancy {m.occ_weight:.3f}+/-"
+            f"{m.occ_weight_err:.3f}"
+            + (
+                "  <-- differ by > 3 sigma"
+                if gap > 3 * max(spread, 1e-12)
+                else ""
+            )
+        )
+    if disagree:
+        mode_report.notes.append(
+            "evidence-vs-occupancy cross-check -- " + "; ".join(disagree)
+        )
+    if idata is not None:
+        mode_report.attach(idata)
     logger.info(
         "evidence weighting applied: weights=%s", [f"{x:.3f}" for x in w]
     )

--- a/src/exozippy/outputs/latex.py
+++ b/src/exozippy/outputs/latex.py
@@ -33,6 +33,44 @@ def _multimodal(mode_report):
     return mode_report is not None and mode_report.n_modes > 1
 
 
+def _weight_err_cell(mode_info):
+    """CSV cell for a mode weight's 1-sigma; blank when unavailable."""
+    err = getattr(mode_info, "weight_err", np.nan)
+    return round(float(err), 4) if np.isfinite(err) else ""
+
+
+def _mixing_sentence(mode_report):
+    """One sentence of mode-mixing context for the table comments.
+
+    Occupancy weighting is unbiased when the sampler mixes between modes, but
+    its precision comes from the number of independent mode TRANSITIONS, not
+    from the number of draws -- so the transition count and the number of
+    chains that never switched belong next to the weights, in every format
+    that prints them.  Returns '' (no sentence) for a report predating these
+    fields.
+    """
+    per_chain = getattr(mode_report, "transitions_per_chain", None)
+    if per_chain is None:
+        return ""
+    text = (
+        f"Mode changes in the stored draws: {mode_report.n_transitions} "
+        f"({mode_report.n_round_trips} round trips); "
+        f"{mode_report.n_chains_no_switch} of "
+        f"{mode_report.n_chains_with_draws} chains never changed mode. "
+    )
+    if getattr(mode_report, "thin_factor", 1) > 1:
+        text += (
+            f"Draws are stored thinned by {mode_report.thin_factor}, so that "
+            f"count is a lower bound. "
+        )
+    elif not getattr(mode_report, "thin_known", True):
+        text += (
+            "The trace does not record its storage thinning; that count "
+            "assumes every sampler step was stored. "
+        )
+    return text
+
+
 def _ensure_mode_summaries(system, p, mode_report):
     """Compute per-mode summaries for a sampled parameter if missing."""
     if p.posterior is None or p.mode_summaries is not None:
@@ -50,9 +88,13 @@ def build_csv_output(system, csv_filename, mode_report=None):
     """Write a machine-readable CSV of posterior results.
 
     Comment header line lists columns: parname, value, up_err, low_err.
-    With a multimodal ``mode_report``, two extra leading columns (mode,
-    weight) are added; each parameter gets one row per mode plus a combined
-    row (mode 'all', weight 1).  Fixed parameters have empty error columns.
+    With a multimodal ``mode_report``, three extra leading columns (mode,
+    weight, weight_err) are added; each parameter gets one row per mode plus
+    a combined row (mode 'all', weight 1).  Fixed parameters have empty error
+    columns.  ``weight_err`` is the weight's 1-sigma -- from the mode
+    indicator's effective sample size for occupancy weights, from the
+    propagated lnZ error for evidence weights -- and is blank only when the
+    report predates it.
     """
     multimodal = _multimodal(mode_report)
 
@@ -81,13 +123,21 @@ def build_csv_output(system, csv_filename, mode_report=None):
                 if p.summary is not None:
                     med, ep, em = summ_at(p.summary).format(sigfigs=2)
                     if multimodal:
-                        rows.append((name, "all", 1.0, med, ep, em))
+                        rows.append((name, "all", 1.0, "", med, ep, em))
                         for k, m in enumerate(mode_report.modes):
                             med, ep, em = summ_at(p.mode_summaries[k]).format(
                                 sigfigs=2
                             )
                             rows.append(
-                                (name, k + 1, round(m.weight, 4), med, ep, em)
+                                (
+                                    name,
+                                    k + 1,
+                                    round(m.weight, 4),
+                                    _weight_err_cell(m),
+                                    med,
+                                    ep,
+                                    em,
+                                )
                             )
                     else:
                         rows.append((name, med, ep, em))
@@ -97,7 +147,7 @@ def build_csv_output(system, csv_filename, mode_report=None):
                         inits[index] if index < len(inits) else inits[-1]
                     )
                     if multimodal:
-                        rows.append((name, "all", 1.0, val, "", ""))
+                        rows.append((name, "all", 1.0, "", val, "", ""))
                     else:
                         rows.append((name, val, "", ""))
 
@@ -110,7 +160,13 @@ def build_csv_output(system, csv_filename, mode_report=None):
     with open(csv_filename, "w", newline="") as f:
         writer = csv.writer(f, lineterminator="\n")
         if multimodal:
-            f.write("# parname, mode, weight, value, up_err, low_err\n")
+            f.write(
+                "# parname, mode, weight, weight_err, value, up_err, low_err\n"
+            )
+            f.write("# mode weights: " + mode_report.provenance + "\n")
+            mixing = _mixing_sentence(mode_report)
+            if mixing:
+                f.write("# " + mixing.strip() + "\n")
         else:
             f.write("# parname, value, up_err, low_err\n")
         writer.writerows(rows)
@@ -247,13 +303,32 @@ def build_latex_output(
 
     if multimodal:
         # Mode weights are citable macros too, and lead the table as a row.
+        # Each weight carries its 1-sigma: for occupancy weighting that is
+        # set by the number of independent mode transitions (NOT by the draw
+        # count), and for evidence weighting it is the propagated lnZ error.
+        # A weight printed bare invites reading 0.7 +/- 0.3 as 0.7 +/- 0.02.
         for k, m in enumerate(mode_report.modes):
+            suffix = _idx_to_words(k + 1)
             all_defs.append(
-                rf"\providecommand{{\ezmodeweight{_idx_to_words(k + 1)}}}"
+                rf"\providecommand{{\ezmodeweight{suffix}}}"
                 rf"{{\ensuremath{{{m.weight:.3f}}}}}" + "\n"
             )
+            if np.isfinite(getattr(m, "weight_err", np.nan)):
+                all_defs.append(
+                    rf"\providecommand{{\ezmodeweighterr{suffix}}}"
+                    rf"{{\ensuremath{{{m.weight_err:.3f}}}}}" + "\n"
+                )
+        # \pm needs math mode; the macros are each \ensuremath already, so
+        # wrap the pair (nested \ensuremath is a no-op inside math mode).
         weight_cells = " & ".join(
-            rf"\ezmodeweight{_idx_to_words(k + 1)}\dotfill"
+            (
+                rf"\ensuremath{{\ezmodeweight{_idx_to_words(k + 1)} \pm "
+                rf"\ezmodeweighterr{_idx_to_words(k + 1)}}}\dotfill"
+                if np.isfinite(
+                    getattr(mode_report.modes[k], "weight_err", np.nan)
+                )
+                else rf"\ezmodeweight{_idx_to_words(k + 1)}\dotfill"
+            )
             for k in range(mode_report.n_modes)
         )
         weight_row = (
@@ -266,7 +341,11 @@ def build_latex_output(
         all_table_lines.insert(0, weight_row)
 
         provenance_note = (
-            "Mode weights: " + mode_report.provenance + ". Combined "
+            "Mode weights: "
+            + mode_report.provenance
+            + ". "
+            + _mixing_sentence(mode_report)
+            + "Combined "
             "(pooled-across-modes) parameter values are suppressed above "
             "because pooled values inherit the mode-weight provenance; see "
             "the per-mode columns."

--- a/src/exozippy/outputs/ledger.py
+++ b/src/exozippy/outputs/ledger.py
@@ -272,10 +272,12 @@ def ledger_to_text(ledger):
 def append_ledger_csv(ledger, csv_filename):
     """Append rejected-mode Laplace rows to the results CSV.
 
-    Row shape matches build_csv_output: name, mode, weight, value, +err,
-    -err -- with mode = 'rejected-seed<k>' and weight the Laplace weight
-    relative to the best seed (an upper-bound-flavored estimate, labeled
-    by the mode column itself).
+    Row shape matches build_csv_output: name, mode, weight, weight_err,
+    value, +err, -err -- with mode = 'rejected-seed<k>' and weight the
+    Laplace weight relative to the best seed (an upper-bound-flavored
+    estimate, labeled by the mode column itself).  weight_err is left blank:
+    a Laplace ratio carries no sampling error bar of the kind the surviving
+    modes' weights do.
     """
     rej = rejected_records(ledger)
     if not rej:
@@ -289,7 +291,7 @@ def append_ledger_csv(ledger, csv_filename):
                 sigs = np.asarray(r.phys_sigma[name]).reshape(-1)
                 for i in r.sampled_idx.get(name, range(vals.size)):
                     f.write(
-                        f"{name},rejected-seed{r.seed_index},{w:.3g},"
+                        f"{name},rejected-seed{r.seed_index},{w:.3g},,"
                         f"{vals[i]:.6g},{sigs[i]:.3g},{sigs[i]:.3g}\n"
                     )
     logger.info(

--- a/src/exozippy/outputs/modes.py
+++ b/src/exozippy/outputs/modes.py
@@ -37,6 +37,8 @@ from typing import Any, List, Optional
 
 import numpy as np
 
+from .autocorr import iact
+
 logger = logging.getLogger(__name__)
 
 # Draws whose |lp| exceeds this are numerically broken, not a mode.  A real
@@ -70,6 +72,13 @@ DEFAULT_LP_EXEMPT_MARGIN = 50.0
 DEFAULT_MAX_INVALID_FRAC = 0.01
 
 _INVALID_REASONS = ("nonfinite-raw", "nonfinite-lp", "lp-ceiling", "raw-z")
+
+# Below this effective sample size the occupancy weights carry an error bar
+# comparable to the weights themselves and the report says so in plain
+# language.  ADVISORY ONLY: the weights are still reported, with their
+# uncertainty, and nothing is substituted or suppressed -- the project warns
+# rather than blocks.  N_eff = 30 puts sigma_w at ~0.09 for w = 0.5.
+DEFAULT_MIN_WEIGHT_ESS = 30.0
 
 
 def _idx_to_words(n):
@@ -121,6 +130,14 @@ def check_invalid_frac(
     )
 
 
+def _fmt_pm(value, err, fmt="{:.4f}"):
+    """'0.7000 +/- 0.1400', or just the value when the error is unavailable."""
+    text = fmt.format(value)
+    if err is not None and np.isfinite(err):
+        text += " +/- " + fmt.format(err)
+    return text
+
+
 def mode_suffix(k):
     """LaTeX-macro-safe suffix for mode ``k`` (0-based): 'modeone', ..."""
     return "mode" + _idx_to_words(k + 1)
@@ -148,11 +165,23 @@ class ModeInfo:
     # posteriors the marginal median sits tens of conditional sigmas from
     # the basin peak, so normalizing by the seed widths alone falsely
     # rejects seeds whose basins plainly survived.
+    # 1-sigma on `weight`, whatever its provenance: identify_modes fills it
+    # from the mode indicator's effective sample size (occupancy weighting),
+    # and outputs.evidence.apply_evidence_weighting overwrites it with the
+    # lnZ-propagated value when evidence weights replace the occupancy ones.
+    weight_err: float = float("nan")
+    # The occupancy weight and its uncertainty are ALWAYS kept, even after
+    # evidence weighting overwrites `weight`: reporting the two side by side
+    # is what makes evidence weighting a usable cross-check on occupancy
+    # (agreement means the weights can be trusted; disagreement localizes the
+    # problem to ladder tuning or to the bridge proposal).
+    occ_weight: float = float("nan")
+    occ_weight_err: float = float("nan")
+    weight_ess: float = float("nan")  # effective draws behind occ_weight
+    weight_iact: float = float("nan")  # IACT of this mode's indicator series
     # Optional evidence-weighting fields (populated by
     # outputs.evidence.apply_evidence_weighting when modes: {weights: evidence}
-    # is requested and every mode's bridge estimate is trustworthy).  weight is
-    # then the softmax evidence weight and weight_err its propagated 1-sigma.
-    weight_err: float = float("nan")  # 1-sigma on weight (evidence weighting)
+    # is requested and every mode's bridge estimate is trustworthy).
     lnZ: float = float("nan")  # local log-evidence (bridge sampling)
     lnZ_err: float = float("nan")  # 1-sigma on lnZ
 
@@ -171,6 +200,19 @@ class ModeReport:
     notes: List[str] = field(default_factory=list)
     invalid_reason_counts: dict = field(default_factory=dict)
     invalid_per_chain: Optional[np.ndarray] = None
+    # Mode-change bookkeeping (see transition_stats).  These are counts of
+    # MODE changes in the stored draws, not the sampler's temperature-swap
+    # statistics; ladder_round_trips below carries the latter when the
+    # sampler recorded it, purely as context.
+    transitions_per_chain: Optional[np.ndarray] = None
+    n_round_trips: int = 0
+    # Storage thinning of the trace these labels came from.  1 = stored every
+    # sampler step.  thin_known=False means nothing recorded it and 1 was
+    # assumed, which the report says out loud rather than quietly implying.
+    thin_factor: int = 1
+    thin_known: bool = True
+    ladder_round_trips: Optional[int] = None
+    ladder_swap_rounds: Optional[int] = None
 
     @property
     def n_modes(self):
@@ -181,12 +223,40 @@ class ModeReport:
         return [m.weight for m in self.modes]
 
     @property
+    def weight_errs(self):
+        return [m.weight_err for m in self.modes]
+
+    @property
     def invalid_frac(self):
         n_total = self.labels.size
         return self.n_invalid / n_total if n_total else 0.0
 
+    @property
+    def n_chains_no_switch(self):
+        """Chains holding assigned draws that never changed mode."""
+        if self.transitions_per_chain is None:
+            return 0
+        has_draws = np.array(
+            [bool((row >= 0).any()) for row in np.atleast_2d(self.labels)]
+        )
+        return int(
+            ((np.asarray(self.transitions_per_chain) == 0) & has_draws).sum()
+        )
+
+    @property
+    def n_chains_with_draws(self):
+        return int(
+            sum(bool((row >= 0).any()) for row in np.atleast_2d(self.labels))
+        )
+
     def attach(self, idata):
-        """Store labels as posterior variable ``mode`` on the InferenceData."""
+        """Store labels as posterior variable ``mode`` on the InferenceData.
+
+        Idempotent, and deliberately re-callable: ``apply_evidence_weighting``
+        rewrites the weights and provenance on this report in place, so it
+        calls back here to keep ``idata.posterior['mode'].attrs`` from holding
+        the superseded occupancy values.
+        """
         import xarray as xr
 
         post = idata.posterior
@@ -197,8 +267,15 @@ class ModeReport:
         )
         da.attrs["n_modes"] = self.n_modes
         da.attrs["weights"] = [float(w) for w in self.weights]
+        da.attrs["weight_errs"] = [float(e) for e in self.weight_errs]
+        da.attrs["occupancy_weights"] = [
+            float(m.occ_weight) for m in self.modes
+        ]
         da.attrs["provenance"] = self.provenance
         da.attrs["n_invalid"] = int(self.n_invalid)
+        da.attrs["n_transitions"] = int(self.n_transitions)
+        da.attrs["n_round_trips"] = int(self.n_round_trips)
+        da.attrs["n_chains_no_switch"] = int(self.n_chains_no_switch)
         post["mode"] = da
         return idata
 
@@ -223,13 +300,25 @@ class ModeReport:
             lines.append("")
         lines.append(f"modes found: {self.n_modes}")
         lines.append(f"weight provenance: {self.provenance}")
-        lines.append(
-            f"inter-mode transitions (all chains): {self.n_transitions}"
-        )
+        lines.extend(self._mixing_lines())
         for m in self.modes:
             lines.append("")
             lines.append(f"mode {m.index + 1}:")
-            lines.append(f"  weight   = {m.weight:.4f}")
+            lines.append(f"  weight   = {_fmt_pm(m.weight, m.weight_err)}")
+            if np.isfinite(m.occ_weight) and np.isfinite(m.weight_ess):
+                extra = ""
+                if np.isfinite(m.lnZ):
+                    extra = (
+                        f"; evidence weight "
+                        f"{_fmt_pm(m.weight, m.weight_err)} "
+                        f"(lnZ = {_fmt_pm(m.lnZ, m.lnZ_err)})"
+                    )
+                lines.append(
+                    f"    occupancy weight "
+                    f"{_fmt_pm(m.occ_weight, m.occ_weight_err)} "
+                    f"from N_eff = {m.weight_ess:.1f} independent draws "
+                    f"(IACT {m.weight_iact:.1f}){extra}"
+                )
             lines.append(f"  n_draws  = {m.n_draws}")
             lines.append(
                 f"  lp med/max = {m.lp_med:.2f} / {m.lp_max:.2f}"
@@ -249,10 +338,90 @@ class ModeReport:
                 lines.append(f"  - {n}")
         return "\n".join(lines) + "\n"
 
+    def _mixing_lines(self):
+        """The mode-mixing block: how much the relative weights can be trusted.
+
+        Deliberately spells out what it is counting.  'Swap' is ambiguous in a
+        parallel-tempering run, so the mode-change counts and the ladder's own
+        temperature round trips are labelled separately and never added.
+        """
+        lines = [
+            f"inter-mode transitions (mode changes in the stored draws, "
+            f"all chains): {self.n_transitions}"
+            + (
+                f"; round trips (k -> j -> k): {self.n_round_trips}"
+                if self.n_modes > 1
+                else ""
+            )
+        ]
+        if self.transitions_per_chain is not None:
+            per = np.asarray(self.transitions_per_chain).tolist()
+            lines.append(f"  per chain: {per}")
+            lines.append(
+                f"  chains that never changed mode: "
+                f"{self.n_chains_no_switch}/{self.n_chains_with_draws}"
+            )
+        if self.thin_factor > 1:
+            lines.append(
+                f"  NOTE: draws are stored thinned by {self.thin_factor}, so "
+                f"the transition count above is a LOWER BOUND -- mode changes "
+                f"inside a thinning block are invisible.  N_eff below is "
+                f"measured on the stored series and is unaffected (thinning "
+                f"divides both the draw count and the IACT), or conservative "
+                f"once the thinning exceeds the correlation time."
+            )
+        elif not self.thin_known:
+            lines.append(
+                "  NOTE: the trace does not record its storage thinning; "
+                "these counts assume every sampler step was stored.  If it "
+                "was thinned, the transition count is a lower bound."
+            )
+        if self.ladder_round_trips is not None:
+            lines.append(
+                f"  for context, the sampler's own ladder statistic "
+                f"(temperature round trips of a replica, T=1 -> T=max -> "
+                f"T=1 -- NOT mode changes): {self.ladder_round_trips}"
+                + (
+                    f" over {self.ladder_swap_rounds} swap rounds"
+                    if self.ladder_swap_rounds is not None
+                    else ""
+                )
+            )
+        return lines
+
 
 # ----------------------------
 # internals
 # ----------------------------
+
+
+def _int_attr(idata, name):
+    """Integer posterior-group attribute, or None if the trace lacks it."""
+    try:
+        value = idata.posterior.attrs.get(name)
+    except AttributeError:
+        return None
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _trace_thinning(idata):
+    """Storage thinning of the trace: ``(thin_factor, known)``.
+
+    ``run.py`` stamps ``posterior.attrs['nthin']`` on every freshly sampled
+    trace; older traces carry nothing, and the difference matters -- consecutive
+    stored draws that are really ``t`` sampler steps apart make mode changes
+    look more independent than they are, so an unknown thinning is reported as
+    unknown rather than silently assumed to be 1.
+    """
+    value = _int_attr(idata, "nthin")
+    if value is None or value < 1:
+        return 1, False
+    return value, True
 
 
 def _feature_matrix(post, feature_vars):
@@ -402,12 +571,112 @@ def _dip_merge(X, labels, centers, merge_ratio):
 
 def _count_transitions(labels_2d):
     """Inter-mode label changes along each chain, skipping unassigned draws."""
-    n = 0
-    for row in labels_2d:
+    return int(transition_stats(labels_2d)[0])
+
+
+def transition_stats(labels_2d):
+    """Mode-change bookkeeping for a (chain, draw) label array.
+
+    Returns ``(n_transitions, per_chain, n_round_trips)``:
+
+    * ``n_transitions`` -- total inter-mode label changes along the chains,
+      skipping unassigned (-1) draws;
+    * ``per_chain`` -- the same count for each chain, because a chain that
+      never leaves one mode contributes **zero** information about the
+      relative weights no matter how many draws it holds;
+    * ``n_round_trips`` -- returns of the form k -> j -> k, counted on the
+      run-length-compressed visit sequence.  This is the stricter quantity:
+      a single one-way crossing tells you the two modes communicate, but only
+      a round trip says the chain sampled the ratio of their masses.
+
+    These are counts of MODE changes in the stored draws.  For a parallel
+    tempering run they are not the sampler's temperature-swap or ladder
+    round-trip statistics -- a T=1 replica can change mode precisely because
+    it swapped with a hotter rung, and it is the resulting mode change in the
+    stored T=1 draws that occupancy weighting rests on.
+    """
+    labels_2d = np.atleast_2d(np.asarray(labels_2d))
+    per_chain = np.zeros(labels_2d.shape[0], dtype=int)
+    round_trips = 0
+    for c, row in enumerate(labels_2d):
         assigned = row[row >= 0]
-        if assigned.size > 1:
-            n += int((np.diff(assigned) != 0).sum())
-    return n
+        if assigned.size < 2:
+            continue
+        change_at = np.flatnonzero(np.diff(assigned) != 0)
+        per_chain[c] = int(change_at.size)
+        # run-length-compressed sequence of visited modes
+        visits = assigned[np.concatenate(([0], change_at + 1))]
+        if visits.size >= 3:
+            round_trips += int((visits[:-2] == visits[2:]).sum())
+    return int(per_chain.sum()), per_chain, round_trips
+
+
+def mode_indicator_chains(labels_2d, mode):
+    """Per-chain 0/1 indicator series for ``mode``, over assigned draws only.
+
+    Unassigned (-1) draws are dropped rather than zeroed: they are rejected
+    runaways, not evidence that the chain was somewhere else.
+    """
+    out = []
+    for row in np.atleast_2d(np.asarray(labels_2d)):
+        assigned = row[row >= 0]
+        if assigned.size:
+            out.append((assigned == mode).astype(float))
+    return out
+
+
+def weight_ess(labels_2d, mode):
+    """Effective sample size behind ``mode``'s occupancy weight.
+
+    Occupancy weighting is unbiased when the sampler mixes between modes, but
+    its PRECISION is set by the number of independent mode transitions, not
+    by the number of draws: a 50000-draw run that changed mode five times
+    knows the weight to roughly 40%.  Treating the mode indicator as a time
+    series and dividing its length by its IACT is exactly that statement.
+
+    Returns ``(n_eff, tau)``.  ``outputs.autocorr.iact`` supplies both the
+    within-chain autocorrelation and the between-chain scatter of the chain
+    means, and the second term is what makes chains stuck in different modes
+    come out at ``n_eff ~ n_chains``, rather than ``n_eff = n_draws`` with a
+    spuriously tight weight.
+    """
+    segs = mode_indicator_chains(labels_2d, mode)
+    n_total = sum(s.size for s in segs)
+    if n_total == 0:
+        return 0.0, 1.0
+    tau = iact(segs)
+    return n_total / tau, tau
+
+
+def markov_indicator_iact(labels_2d, mode):
+    """IACT of the mode indicator under a two-state Markov approximation.
+
+    For a two-state chain with transition probabilities p01 (enter ``mode``)
+    and p10 (leave it), the indicator's IACT is exactly ``2/(p01+p10) - 1``.
+    Estimating p01/p10 from the observed one-step transition counts gives an
+    independent cross-check on the time-series estimate in ``weight_ess``:
+    the two should agree to within their sampling noise on a chain that is
+    close to Markov in the mode label.  Returns NaN when either state is
+    never entered (no transitions to estimate from).
+    """
+    n01 = n0 = n10 = n1 = 0
+    for row in np.atleast_2d(np.asarray(labels_2d)):
+        assigned = row[row >= 0]
+        if assigned.size < 2:
+            continue
+        ind = assigned == mode
+        a, b = ind[:-1], ind[1:]
+        n0 += int((~a).sum())
+        n1 += int(a.sum())
+        n01 += int((~a & b).sum())
+        n10 += int((a & ~b).sum())
+    if n0 == 0 or n1 == 0:
+        return float("nan")
+    p01 = n01 / n0
+    p10 = n10 / n1
+    if p01 + p10 <= 0:
+        return float("inf")
+    return 2.0 / (p01 + p10) - 1.0
 
 
 # ----------------------------
@@ -644,10 +913,21 @@ def identify_modes(
             center_scale_raw[name] = float(
                 1.4826 * np.median(np.abs(col - np.median(col)))
             )
+        # Occupancy weight uncertainty.  The weight is a mean of the mode
+        # indicator, so its variance is w(1-w)/N_eff with N_eff = N/IACT --
+        # governed by the number of independent mode transitions, NOT by the
+        # number of draws.
+        w_m = float(w_assigned[m])
+        n_eff, tau_m = weight_ess(labels_2d, m)
+        sigma_w = (
+            float(np.sqrt(w_m * (1.0 - w_m) / max(n_eff, 1.0)))
+            if n_modes > 1
+            else 0.0
+        )
         modes.append(
             ModeInfo(
                 index=m,
-                weight=float(w_assigned[m]),
+                weight=w_m,
                 n_draws=int(sel.sum()),
                 lp_med=float(np.median(lp_m)) if lp_m.size else np.nan,
                 lp_max=float(lp_m.max()) if lp_m.size else np.nan,
@@ -657,11 +937,26 @@ def identify_modes(
                 per_chain_weight=per_chain,
                 center=center_raw,
                 center_scale=center_scale_raw,
+                weight_err=sigma_w,
+                occ_weight=w_m,
+                occ_weight_err=sigma_w,
+                weight_ess=float(n_eff),
+                weight_iact=float(tau_m),
             )
         )
 
     # ---- mixing diagnostics / weight provenance --------------------------
-    n_transitions = _count_transitions(labels_2d)
+    n_transitions, transitions_per_chain, n_round_trips = transition_stats(
+        labels_2d
+    )
+    thin_factor, thin_known = _trace_thinning(idata)
+    n_no_switch = int(
+        (
+            (transitions_per_chain == 0)
+            & np.array([bool((row >= 0).any()) for row in labels_2d])
+        ).sum()
+    )
+    min_ess = min((m_.weight_ess for m_ in modes), default=float("nan"))
     if n_modes <= 1:
         provenance = "unimodal"
         reliable = True
@@ -673,21 +968,49 @@ def identify_modes(
         )
         enough_transitions = n_transitions >= 10 * (n_modes - 1)
         reliable = chains_visiting_all and enough_transitions
+        mixing = (
+            f"{n_transitions} mode changes in the stored draws, "
+            f"{n_round_trips} round trips, "
+            f"{n_no_switch}/{int((transitions_per_chain >= 0).sum())} chains "
+            f"never switched; N_eff for the weights >= {min_ess:.1f}"
+        )
         if reliable:
-            provenance = (
-                f"occupancy (validated: {n_transitions} inter-mode "
-                f"transitions; every chain visits every mode)"
-            )
+            provenance = f"occupancy (validated: {mixing})"
         else:
             provenance = (
-                "occupancy (UNRELIABLE: chains do not mix between modes -- "
-                "weights reflect initialization, not posterior mass; use "
-                "per-mode evidence weighting or a folded likelihood)"
+                f"occupancy (UNRELIABLE: chains do not mix between modes -- "
+                f"weights reflect initialization, not posterior mass; use "
+                f"per-mode evidence weighting or a folded likelihood) "
+                f"[{mixing}]"
             )
             notes.append(
                 "relative mode weights are NOT trustworthy: "
                 f"{n_transitions} inter-mode transitions; "
                 "see provenance"
+            )
+        # Advisory verdict, never a gate: the weights are always reported.
+        if not np.isfinite(min_ess) or min_ess < DEFAULT_MIN_WEIGHT_ESS:
+            worst = max(
+                (m_ for m_ in modes),
+                key=lambda m_: (
+                    m_.occ_weight_err
+                    if np.isfinite(m_.occ_weight_err)
+                    else -1.0
+                ),
+            )
+            notes.append(
+                f"mode-weight precision: the mode-label series is worth only "
+                f"N_eff ~ {min_ess:.1f} independent draws ({n_transitions} "
+                f"mode changes, {n_round_trips} round trips, "
+                f"{n_no_switch} chain(s) never switched), so the occupancy "
+                f"weights carry ~{worst.occ_weight_err:.2f} 1-sigma "
+                f"(mode {worst.index + 1}: "
+                f"{_fmt_pm(worst.occ_weight, worst.occ_weight_err)}). "
+                f"The weights above are still the best estimate available -- "
+                f"treat their ORDERING as informative and their VALUES as "
+                f"uncertain at that level. A longer run, a better-tuned "
+                f"temperature ladder, or per-mode evidence weighting "
+                f"(modes: {{weights: evidence}}) would tighten them."
             )
 
     report = ModeReport(
@@ -703,13 +1026,19 @@ def identify_modes(
         notes=notes,
         invalid_reason_counts=invalid_reason_counts,
         invalid_per_chain=invalid_per_chain,
+        transitions_per_chain=transitions_per_chain,
+        n_round_trips=n_round_trips,
+        thin_factor=thin_factor,
+        thin_known=thin_known,
+        ladder_round_trips=_int_attr(idata, "ptde_ladder_round_trips"),
+        ladder_swap_rounds=_int_attr(idata, "ptde_swap_rounds"),
     )
     if attach:
         report.attach(idata)
     logger.info(
         "identify_modes: %d mode(s), weights=%s, %s",
         report.n_modes,
-        [f"{w:.3f}" for w in report.weights],
+        [f"{m_.weight:.3f}+/-{m_.weight_err:.3f}" for m_ in report.modes],
         provenance,
     )
     return report

--- a/src/exozippy/outputs/report_pipeline.py
+++ b/src/exozippy/outputs/report_pipeline.py
@@ -158,7 +158,12 @@ def build_mode_reports(
             )
 
             evidences = estimate_mode_evidences(model, idata, mode_report)
-            applied = apply_evidence_weighting(mode_report, evidences)
+            # idata= keeps posterior['mode'].attrs in step with the rewritten
+            # weights/provenance instead of leaving the occupancy values
+            # attached to the trace that ships to disk.
+            applied = apply_evidence_weighting(
+                mode_report, evidences, idata=idata
+            )
             # Refresh the human-readable mode report with the new weights.
             modes_path.write_text(mode_report.to_text(), encoding="utf-8")
             logger.info(

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -568,6 +568,12 @@ def _run_fit(config, gui, user_params=None):
                     signal.signal(signal.SIGTERM, old_sigterm)
             if nthin > 1:
                 idata = idata.sel(draw=slice(None, None, nthin))
+            # Record the storage thinning on the trace.  Consecutive stored
+            # draws that are really nthin sampler steps apart make mode
+            # changes look more independent than they are, so outputs.modes
+            # must be told rather than left to assume 1 (see
+            # ModeReport.thin_factor / thin_known).
+            idata.posterior.attrs["nthin"] = int(nthin)
             # Ensure lp is in sample_stats; compute and persist if missing.
             ss_vars = (
                 list(idata.sample_stats.data_vars)

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -1099,6 +1099,14 @@ def ptde_sample(
         logger,
     )
 
+    # Ladder communication statistics, stamped on the trace so the mode
+    # report can quote them as context.  These are TEMPERATURE round trips of
+    # a replica (T=1 -> T=max -> T=1), NOT mode changes: outputs.modes counts
+    # the latter itself from the stored T=1 labels and labels the two
+    # separately, because "swap" is ambiguous between them.
+    idata.posterior.attrs["ptde_ladder_round_trips"] = int(round_trips[0])
+    idata.posterior.attrs["ptde_swap_rounds"] = int(n_swap_rounds)
+
     ar_T1 = float(n_accept[0] / max(n_propose[0], 1))
     sr_all = n_swap_accept / np.maximum(n_swap_propose, 1)
     rt_rate = round_trips[0] / max(n_swap_rounds, 1)

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -795,6 +795,14 @@ def ptde_async_sample(
                 "accumulated (draws too small for the thinning factor?)"
             )
 
+    # Ladder communication statistics, stamped on the trace so the mode
+    # report can quote them as context.  These are TEMPERATURE round trips of
+    # a replica (T=1 -> T=max -> T=1), NOT mode changes: outputs.modes counts
+    # the latter itself from the stored T=1 labels and labels the two
+    # separately, because "swap" is ambiguous between them.
+    idata.posterior.attrs["ptde_ladder_round_trips"] = int(round_trips[0])
+    idata.posterior.attrs["ptde_swap_rounds"] = int(n_swap_rounds[0])
+
     ar_T1 = float(n_accept[0] / max(n_propose[0], 1))
     sr_all = n_swap_accept / np.maximum(n_swap_propose, 1)
     rt_rate = round_trips[0] / max(n_swap_rounds[0], 1)

--- a/tests/test_mode_evidence.py
+++ b/tests/test_mode_evidence.py
@@ -22,6 +22,22 @@ Validation strategy:
   - Refusal is checked both at the core (a proposal far narrower than the
     target -> huge relative MSE) and end-to-end (a heavy-tailed Cauchy target
     whose Gaussian proposal cannot support the tails).
+
+The "realistic scale" block near the bottom covers review item 1.13, whose
+three defects all lived where the tests above never went -- |lnZ| of order
+1e4..1e6, i.e. the raw model-logp scale of any actual dataset, and posterior
+draws that are actually autocorrelated:
+
+  (a) the relative-MSE diagnostic exponentiated unrecentered log-ratios, so
+      anywhere |lnZ| > ~709 it returned nan/inf and EVERY mode was refused
+      with the misleading reason "proposal poorly supports the target";
+  (b) the fixed-point convergence test was ABSOLUTE at 1e-10, which at
+      |lnZ| = 1e6 sits inside the float64 ULP spacing of lr itself, so ~25%
+      of otherwise perfect estimates reported spurious non-convergence;
+  (c) the IACT that inflates the posterior-side error term was measured on a
+      series whose order had been destroyed by an unsorted rng.choice
+      subsample, so it read ~1 whatever the sampler did and the error bar was
+      understated by sqrt(tau) -- up to ~20x on a strongly correlated chain.
 """
 
 import arviz as az
@@ -31,14 +47,17 @@ import pytensor.tensor as pt
 import pytest
 
 from conftest import requires_fork
+from exozippy.outputs.autocorr import iact
 from exozippy.outputs.evidence import (
     EvidenceResult,
+    _mode_draw_index,
+    _segments,
     apply_evidence_weighting,
     bridge_lnZ,
     estimate_mode_evidences,
     softmax_weights,
 )
-from exozippy.outputs.latex import build_latex_output
+from exozippy.outputs.latex import build_csv_output, build_latex_output
 from exozippy.outputs.modes import ModeInfo, ModeReport, identify_modes
 
 
@@ -299,6 +318,243 @@ def test_evidence_refuses_heavy_tailed_mode():
 
 
 # ----------------------------------------------------------------------
+# realistic model-logp scale (review 1.13)
+# ----------------------------------------------------------------------
+
+
+def _gaussian_bridge_inputs(logC, sigma_target, n, seed, shift=0.0):
+    """Log-ratios for a N(shift, sigma_target) target of evidence exp(logC)
+    against a standard-normal proposal.  logC enters as a pure additive
+    offset, so the analytic answer is lnZ = logC at any scale."""
+    rng = np.random.default_rng(seed)
+    x1 = rng.normal(shift, sigma_target, n)
+    y2 = rng.normal(0.0, 1.0, n)
+    l1 = (
+        logC
+        + _normal_logpdf(x1, shift, sigma_target)
+        - _normal_logpdf(x1, 0.0, 1.0)
+    )
+    l2 = (
+        logC
+        + _normal_logpdf(y2, shift, sigma_target)
+        - _normal_logpdf(y2, 0.0, 1.0)
+    )
+    return l1, l2
+
+
+def _unrecentered_re2(l1, l2, lr):
+    """The pre-fix relative-MSE expression, verbatim, for the equivalence
+    check.  Exponentiates l1/l2/lr directly, which is exactly why it
+    overflows once the log-ratios reach real model-logp scale."""
+    n1, n2 = l1.size, l2.size
+    s1, s2 = n1 / (n1 + n2), n2 / (n1 + n2)
+    # The overflow IS the defect being reproduced, so silence the warnings.
+    with np.errstate(over="ignore", invalid="ignore"):
+        r = np.exp(lr)
+        f1 = np.exp(l2) / (s1 * np.exp(l2) + s2 * r)
+        f2 = 1.0 / (s1 * np.exp(l1) + s2 * r)
+        term1 = (f1.var() / f1.mean() ** 2) / n2
+        term2 = iact(f2) * (f2.var() / f2.mean() ** 2) / n1
+    return term1 + term2
+
+
+@pytest.mark.parametrize("logC", [7.0e2, 1.0e3, 1.0e4, 1.0e5, 1.0e6])
+def test_diagnostic_is_finite_at_realistic_logp_scale(logC):
+    """
+    Given bridge inputs at the raw model-logp scale of a real dataset
+      (|lnZ| from 700 to 1e6 nats), where exp(lnZ) is not representable,
+    When bridge_lnZ runs,
+    Then it returns a finite relative-MSE diagnostic and error bar (the
+      unrecentered expression returns nan/inf here, which refused every mode
+      on every real fit).
+    """
+    l1, l2 = _gaussian_bridge_inputs(logC, 1.3, 3000, seed=0)
+
+    lnZ, err, re2, converged = bridge_lnZ(l1, l2)
+
+    assert converged
+    assert abs(lnZ - logC) <= max(1e-6, 5 * err)  # Monte Carlo error only
+    assert np.isfinite(re2) and re2 > 0
+    assert np.isfinite(err) and err > 0
+    assert re2 < 0.25  # a well-matched proposal must NOT be refused
+    # the expression this replaced could not even be evaluated here
+    assert not np.isfinite(_unrecentered_re2(l1, l2, lnZ))
+
+
+def test_recentered_diagnostic_equals_the_old_one_where_the_old_one_worked():
+    """
+    Given bridge inputs across the range of |lnZ| where the unrecentered
+      relative-MSE expression was still representable in float64,
+    When bridge_lnZ's recentered diagnostic is compared with it,
+    Then the two agree to float precision -- only the scale-free ratios
+      var/mean^2 enter re2, so dividing f1 through by exp(l2) and f2 by
+      exp(lr) cannot change the answer.
+    """
+    worst_rel = 0.0
+    n_compared = 0
+    for logC in (-5.0, -0.5, 0.0, 2.0, 50.0, 200.0, 500.0):
+        for sigma in (1.05, 1.3, 2.0, 3.0):
+            l1, l2 = _gaussian_bridge_inputs(
+                logC, sigma, 3000, seed=int(abs(logC) + 100 * sigma)
+            )
+            lnZ, _err, re2, converged = bridge_lnZ(l1, l2)
+            old = _unrecentered_re2(l1, l2, lnZ)
+            assert converged
+            # Skip the degenerate target == proposal case: there re2 is
+            # exactly zero and both forms return ~1e-32 of pure round-off,
+            # so a RELATIVE comparison of two noise floors is meaningless.
+            if not np.isfinite(old) or old <= 1e-20:
+                assert abs(re2 - old) < 1e-25 if np.isfinite(old) else True
+                continue
+            n_compared += 1
+            worst_rel = max(worst_rel, abs(re2 - old) / old)
+
+    assert n_compared >= 20
+    assert worst_rel < 1e-12, f"recentering changed re2 by {worst_rel:.3e}"
+
+
+@pytest.mark.parametrize("logC", [1.0e4, 1.0e6, 1.0e8])
+def test_relative_tolerance_converges_at_large_lnZ(logC):
+    """
+    Given a well-matched proposal at |lnZ| far above the float64 ULP scale of
+      the absolute 1e-10 tolerance this replaced,
+    When bridge_lnZ runs over many independent realizations,
+    Then every one of them converges (the absolute test failed ~25% of them
+      at |lnZ| >= 1e6, purely because the fixed point cannot be pinned to
+      1e-10 when one ULP of lr is already 1.2e-10).
+    """
+    failures = [
+        seed
+        for seed in range(50)
+        if not bridge_lnZ(
+            *_gaussian_bridge_inputs(logC, 2.0, 2000, seed=seed)
+        )[3]
+    ]
+
+    assert failures == []
+
+
+@pytest.mark.parametrize("logC", [0.0, 1.0e6])
+def test_relative_tolerance_still_reports_genuine_non_convergence(logC):
+    """
+    Given a proposal that barely overlaps the target, so the optimal-bridge
+      fixed point never settles,
+    When bridge_lnZ runs to maxiter at both zero and realistic |lnZ|,
+    Then it reports converged=False -- the relative tolerance loosens the
+      test by the float64 resolution of lr, not by anything a genuinely
+      unconverged iteration (still moving O(0.01-1) nat per step) could hide
+      under.
+    """
+    l1, l2 = _gaussian_bridge_inputs(logC, 1.0, 3000, seed=1, shift=0.0)
+    rng = np.random.default_rng(1)
+    y2 = rng.normal(9.0, 1.0, 3000)
+    l2 = logC + _normal_logpdf(y2, 0.0, 1.0) - _normal_logpdf(y2, 9.0, 1.0)
+    x1 = rng.normal(0.0, 1.0, 3000)
+    l1 = logC + _normal_logpdf(x1, 0.0, 1.0) - _normal_logpdf(x1, 9.0, 1.0)
+
+    lnZ, err, re2, converged = bridge_lnZ(l1, l2)
+
+    assert not converged
+    assert re2 > 0.25  # and it is refused on the diagnostic too
+
+
+def _ar1(n, phi, rng):
+    """AR(1) series with integrated autocorrelation time (1+phi)/(1-phi)."""
+    x = np.empty(n)
+    x[0] = rng.normal(0.0, 1.0 / np.sqrt(1.0 - phi**2))
+    for i in range(1, n):
+        x[i] = phi * x[i - 1] + rng.normal()
+    return x
+
+
+@pytest.mark.parametrize("phi,true_tau", [(0.9, 19.0), (0.98, 99.0)])
+def test_iact_survives_the_real_subsampling_path(phi, true_tau):
+    """
+    Given an AR(1) series of KNOWN integrated autocorrelation time, laid out
+      exactly as estimate_mode_evidences lays out a mode's posterior draws
+      (chain-major rows of the (chain, draw) posterior matrix),
+    When it is reduced to max_posterior_draws through the real index helper
+      and measured with the shared IACT estimator,
+    Then the IACT reflects the autocorrelation of the retained series
+      (roughly true_tau/stride), whereas the unsorted rng.choice subsample it
+      replaced reads ~1 and understates the bridge error bar by sqrt(tau).
+    """
+    rng = np.random.default_rng(11)
+    n_chain, n_draw, max_draws = 4, 5000, 4000
+    chains = np.array([_ar1(n_draw, phi, rng) for _ in range(n_chain)])
+    flat = chains.reshape(-1)  # (chain, draw) row-major, as _posterior_matrix
+    labels = np.zeros(flat.size, dtype=int)
+
+    index, chain_lengths = _mode_draw_index(
+        labels, 0, n_chain, n_draw, max_draws
+    )
+    kept = flat[index]
+    tau_new = iact(_segments(kept, np.ones(kept.size, bool), chain_lengths))
+
+    shuffled = np.random.default_rng(1).choice(
+        flat.size, max_draws, replace=False
+    )
+    tau_old = iact(flat[shuffled])
+
+    stride = int(np.ceil(flat.size / max_draws))
+    tau_expected = (1 + phi**stride) / (1 - phi**stride)
+
+    assert index.size <= max_draws + n_chain
+    assert sum(chain_lengths) == index.size
+    # order preserved: indices ascend within each chain's block
+    start = 0
+    for length in chain_lengths:
+        block = index[start : start + length]
+        assert np.all(np.diff(block) > 0)
+        start += length
+    assert tau_old < 1.5  # the defect: order destroyed -> tau reads ~1
+    assert tau_new > 0.4 * tau_expected
+    assert tau_new > 2.0 * tau_old
+
+
+def test_iact_recovers_a_known_ar1_autocorrelation():
+    """
+    Given AR(1) series with analytically known IACT (1+phi)/(1-phi),
+    When the shared estimator measures them in order,
+    Then it recovers the true value to within the estimator's own noise.
+    """
+    rng = np.random.default_rng(3)
+    for phi in (0.5, 0.9, 0.98):
+        true_tau = (1 + phi) / (1 - phi)
+        chains = np.array([_ar1(40000, phi, rng) for _ in range(4)])
+
+        tau = iact(chains)
+
+        assert 0.7 * true_tau < tau < 1.5 * true_tau, (phi, tau, true_tau)
+
+
+def test_bridge_error_bar_grows_with_posterior_autocorrelation():
+    """
+    Given two bridge problems with identical marginal log-ratios but one
+      drawn i.i.d. and one drawn as a strongly autocorrelated series,
+    When bridge_lnZ measures each with its chain structure declared,
+    Then the autocorrelated one carries the larger error bar -- the whole
+      point of the IACT term, and exactly what the destroyed ordering hid.
+    """
+    rng = np.random.default_rng(21)
+    n = 4000
+    y2 = rng.normal(0.0, 1.0, n)
+    l2 = _normal_logpdf(y2, 0.0, 1.3) - _normal_logpdf(y2, 0.0, 1.0)
+
+    iid = rng.normal(0.0, 1.3, n)
+    correlated = 1.3 * _ar1(n, 0.98, rng)
+    l1_iid = _normal_logpdf(iid, 0.0, 1.3) - _normal_logpdf(iid, 0.0, 1.0)
+    l1_cor = _normal_logpdf(correlated, 0.0, 1.3) - _normal_logpdf(
+        correlated, 0.0, 1.0
+    )
+
+    _z, err_iid, _re2, _c = bridge_lnZ(l1_iid, l2, l1_chains=[n])
+    _z, err_cor, _re2, _c = bridge_lnZ(l1_cor, l2, l1_chains=[n])
+
+    assert err_cor > 3.0 * err_iid
+
+
+# ----------------------------------------------------------------------
 # output wiring smoke test
 # ----------------------------------------------------------------------
 
@@ -339,6 +595,83 @@ def test_evidence_provenance_replaces_occupancy_in_output(tmp_path):
     assert "0.750" in defs and "0.250" in defs
     assert "evidence (bridge sampling" in tmpl
     assert "occupancy" not in tmpl
+
+
+def test_weight_err_reaches_text_latex_and_csv(tmp_path):
+    """
+    Given a 2-mode report re-weighted by evidence, so every mode carries a
+      propagated weight uncertainty,
+    When the text report, the LaTeX definitions/table and the CSV are built,
+    Then all three carry the uncertainty next to the weight -- it used to be
+      computed and then printed nowhere at all.
+    """
+    report = _fake_two_mode_report(w0_occ=0.5, w1_occ=0.5)
+    results = [
+        EvidenceResult(0, np.log(0.75), 0.03, 0.001, 800, 800, False),
+        EvidenceResult(1, np.log(0.25), 0.05, 0.002, 800, 800, False),
+    ]
+    assert apply_evidence_weighting(report, results)
+    dw0 = report.modes[0].weight_err
+    assert np.isfinite(dw0) and dw0 > 0
+
+    text = report.to_text()
+    var_file = tmp_path / "defs.tex"
+    tmpl_file = tmp_path / "table.tex"
+    csv_file = tmp_path / "results.csv"
+    build_latex_output(
+        _StubSystem(),
+        var_filename=str(var_file),
+        template_filename=str(tmpl_file),
+        mode_report=report,
+    )
+    build_csv_output(_StubSystem(), str(csv_file), mode_report=report)
+
+    assert f"0.7500 +/- {dw0:.4f}" in text
+    defs = var_file.read_text()
+    assert r"\ezmodeweighterrone" in defs
+    assert f"{dw0:.3f}" in defs
+    assert r"\ezmodeweighterrone" in tmpl_file.read_text()
+    header = csv_file.read_text().splitlines()[0]
+    assert "weight_err" in header
+
+
+def test_evidence_weighting_updates_the_attached_mode_attrs():
+    """
+    Given an idata carrying identify_modes' occupancy weights in
+      posterior['mode'].attrs,
+    When apply_evidence_weighting replaces the weights and is handed the idata,
+    Then the attrs hold the EVIDENCE weights and provenance, not the stale
+      occupancy values the DataArray was built with, and the occupancy values
+      remain available separately for the cross-check.
+    """
+    rng = np.random.default_rng(17)
+    x = np.concatenate(
+        [rng.normal(0.0, 1.0, N // 2), rng.normal(8.0, 1.0, N // 2)]
+    )
+    lp = _mixture_lp(x[:, None], np.array([0.0]), np.array([8.0]), 0.5, 0.5)
+    idata = az.from_dict(
+        {
+            "posterior": {"x_raw": x.reshape(N_CHAIN, N_DRAW)},
+            "sample_stats": {"lp": lp.reshape(N_CHAIN, N_DRAW)},
+        }
+    )
+    report = identify_modes(idata)
+    assert report.n_modes == 2
+    occupancy = list(idata.posterior["mode"].attrs["weights"])
+    results = [
+        EvidenceResult(0, np.log(0.9), 0.03, 0.001, 800, 800, False),
+        EvidenceResult(1, np.log(0.1), 0.05, 0.002, 800, 800, False),
+    ]
+
+    assert apply_evidence_weighting(report, results, idata=idata)
+
+    attrs = idata.posterior["mode"].attrs
+    assert attrs["weights"] == pytest.approx([0.9, 0.1], abs=1e-9)
+    assert attrs["weights"] != pytest.approx(occupancy, abs=1e-3)
+    assert "evidence (bridge sampling" in attrs["provenance"]
+    assert attrs["weight_errs"][0] > 0
+    # occupancy survives for the cross-check
+    assert attrs["occupancy_weights"] == pytest.approx(occupancy, abs=1e-9)
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_mode_report.py
+++ b/tests/test_mode_report.py
@@ -17,18 +17,30 @@ import numpy as np
 import pytest
 
 from exozippy.components.parameter import Parameter
-from exozippy.outputs.latex import build_latex_output
+from exozippy.outputs.latex import build_csv_output, build_latex_output
 from exozippy.outputs.modes import (
     DEFAULT_MAX_INVALID_FRAC,
     ModeInfo,
     ModeReport,
     check_invalid_frac,
     identify_modes,
+    markov_indicator_iact,
     mode_suffix,
+    transition_stats,
+    weight_ess,
 )
 
 N_CHAIN, N_DRAW = 8, 1500
 N = N_CHAIN * N_DRAW
+
+
+class _StubSystem:
+    """Component-free system, for exercising the table builders alone."""
+
+    name = "toy"
+
+    def get_all_components(self):
+        return []
 
 
 def _make_idata(posterior, lp):
@@ -622,7 +634,9 @@ def test_displaced_high_lp_minority_is_a_mode_not_invalid():
       second mode, with no invalid draws at all.
     """
     rng = np.random.default_rng(7)
-    a = rng.normal(0.0, 0.001, N)  # razor-tight bulk: huge robust z for any offset
+    a = rng.normal(
+        0.0, 0.001, N
+    )  # razor-tight bulk: huge robust z for any offset
     lp = rng.normal(1000.0, 3.0, N)
     minority = slice(0, N_DRAW)  # chain 0 entirely in the displaced basin
     a[minority] = rng.normal(5.0, 0.001, N_DRAW)  # z ~ 5000 sigma_bulk
@@ -658,3 +672,258 @@ def test_displaced_low_lp_cluster_stays_invalid():
     assert rep.n_invalid == 300
     assert rep.invalid_reason_counts == {"raw-z": 300}
     assert rep.n_modes == 1
+
+
+# ----------------------------------------------------------------------
+# Mode-transition bookkeeping and the occupancy weights' error bar
+#
+# Occupancy weighting is unbiased when the sampler mixes between modes, but
+# its PRECISION is set by the number of independent mode transitions, not by
+# the number of draws: a 50000-draw run that switched five times knows the
+# weight to roughly 40%.  Nothing reported that, so "0.7" and "0.7 +/- 0.3"
+# were indistinguishable in every output format.
+# ----------------------------------------------------------------------
+
+
+def _two_state_chain(n, p01, p10, rng):
+    """Two-state Markov chain; the indicator's IACT is 2/(p01+p10) - 1."""
+    s = np.zeros(n, dtype=int)
+    s[0] = rng.random() < p01 / (p01 + p10)
+    for i in range(1, n):
+        s[i] = (rng.random() >= p10) if s[i - 1] else (rng.random() < p01)
+    return s.astype(int)
+
+
+def test_transition_stats_counts_per_chain_and_round_trips():
+    """
+    Given label sequences with hand-countable mode changes -- one chain that
+      never leaves mode 0, one that crosses once, one that goes 0 -> 1 -> 0,
+    When transition_stats runs,
+    Then the total, the per-chain counts and the round trips (k -> j -> k)
+      are each exactly what the sequences show, and unassigned (-1) draws are
+      skipped rather than counted as a visit to a third state.
+    """
+    labels = np.array(
+        [
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 1, 1, 1],
+            [0, 0, 1, 1, 0, 0],
+            [0, -1, -1, 0, 0, 0],
+        ]
+    )
+
+    total, per_chain, round_trips = transition_stats(labels)
+
+    assert per_chain.tolist() == [0, 1, 2, 0]
+    assert total == 3
+    assert round_trips == 1  # only chain 2 returns to where it started
+
+
+def test_weight_ess_recovers_a_known_transition_rate():
+    """
+    Given a two-state chain whose mode-label transition probabilities are
+      known, so the indicator's IACT is exactly 2/(p01+p10) - 1,
+    When weight_ess measures it as a time series,
+    Then the recovered IACT matches the analytic Markov value, and N_eff and
+      sigma_w follow -- N_eff is thousands of draws below the raw draw count.
+    """
+    rng = np.random.default_rng(5)
+    p01, p10 = 0.005, 0.015
+    labels = np.array(
+        [_two_state_chain(20000, p01, p10, rng) for _ in range(4)]
+    )
+    analytic_tau = 2.0 / (p01 + p10) - 1.0  # = 99
+
+    n_eff, tau = weight_ess(labels, 1)
+
+    assert tau == pytest.approx(analytic_tau, rel=0.25)
+    assert n_eff == pytest.approx(labels.size / analytic_tau, rel=0.3)
+    w = float((labels == 1).mean())
+    sigma_w = np.sqrt(w * (1 - w) / n_eff)
+    # the naive "sqrt(w(1-w)/N)" over all 80000 draws would be ~10x tighter
+    assert sigma_w > 5 * np.sqrt(w * (1 - w) / labels.size)
+
+
+def test_time_series_and_markov_iact_agree():
+    """
+    Given synthetic two-state chains spanning fast and slow mixing,
+    When the time-series IACT estimate and the closed-form two-state Markov
+      value 2/(p01+p10) - 1 are compared,
+    Then they agree -- an independent cross-check that the time-series
+      estimator is measuring what it claims to.
+    """
+    rng = np.random.default_rng(9)
+    for p01, p10 in [(0.3, 0.3), (0.02, 0.02), (0.005, 0.015)]:
+        labels = np.array(
+            [_two_state_chain(20000, p01, p10, rng) for _ in range(4)]
+        )
+
+        _n_eff, tau = weight_ess(labels, 1)
+        tau_markov = markov_indicator_iact(labels, 1)
+
+        assert tau_markov == pytest.approx(2.0 / (p01 + p10) - 1.0, rel=0.3)
+        assert tau == pytest.approx(tau_markov, rel=0.3)
+
+
+def test_thinning_does_not_manufacture_independence():
+    """
+    Given one two-state chain set, and the SAME series thinned by 5, 10 and
+      50 -- thinning makes consecutive stored draws further apart, so the
+      thinned series genuinely looks less autocorrelated,
+    When weight_ess measures each,
+    Then N_eff (and therefore sigma_w) is unchanged: the IACT falls by the
+      thinning factor exactly as the draw count does, so no thinning factor
+      can be mistaken for extra information.
+    """
+    rng = np.random.default_rng(13)
+    labels = np.array(
+        [_two_state_chain(20000, 0.005, 0.005, rng) for _ in range(4)]
+    )
+    n_eff_full, tau_full = weight_ess(labels, 1)
+
+    for thin in (5, 10, 50):
+        n_eff, tau = weight_ess(labels[:, ::thin], 1)
+
+        assert tau == pytest.approx(tau_full / thin, rel=0.5)
+        assert n_eff == pytest.approx(n_eff_full, rel=0.25)
+
+
+def test_chains_that_never_switch_get_no_spuriously_tight_weight():
+    """
+    Given chains that each sit in one mode for their entire length -- the
+      case evidence weighting exists for -- so there is no information at all
+      about the relative masses beyond "each chain landed somewhere",
+    When identify_modes runs,
+    Then the report says zero transitions and every chain stuck, N_eff is of
+      order the number of chains rather than the number of draws, and the
+      weight's 1-sigma is comparable to the weight itself.
+    """
+    rng = np.random.default_rng(3)
+    chain_mode = np.repeat([0] * 4 + [1] * 4, N_DRAW)
+    a = rng.normal(0, 1, N) + 10 * chain_mode
+    idata = _make_idata({"a_raw": a}, rng.normal(0, 1, N))
+
+    rep = identify_modes(idata)
+
+    assert rep.n_modes == 2
+    assert rep.n_transitions == 0
+    assert rep.n_round_trips == 0
+    assert rep.transitions_per_chain.tolist() == [0] * N_CHAIN
+    assert rep.n_chains_no_switch == N_CHAIN
+    assert rep.modes[0].weight_ess < 4 * N_CHAIN
+    assert rep.modes[0].weight_err > 0.2
+    assert not rep.weights_reliable
+    text = rep.to_text()
+    assert "chains that never changed mode: 8/8" in text
+    assert "mode-weight precision" in " ".join(rep.notes)
+
+
+def test_mixing_transitions_give_a_tight_weight():
+    """
+    Given two modes that every chain visits repeatedly (draw-by-draw mixing),
+    When identify_modes runs,
+    Then the transition count is large, the weights are validated, and the
+      weight uncertainty is small -- the advisory low-N_eff note does not
+      fire on a run that genuinely mixed.
+    """
+    rng = np.random.default_rng(21)
+    labels = (rng.random(N) < 0.3).astype(int)
+    a = rng.normal(0, 1, N) + 10 * labels
+    idata = _make_idata({"a_raw": a}, rng.normal(0, 1, N))
+
+    rep = identify_modes(idata)
+
+    assert rep.n_modes == 2
+    assert rep.n_transitions > 1000
+    assert rep.n_round_trips > 500
+    assert rep.n_chains_no_switch == 0
+    assert rep.weights_reliable
+    assert rep.modes[0].weight_err < 0.02
+    assert not any("mode-weight precision" in n for n in rep.notes)
+
+
+def test_transition_diagnostics_reach_latex_and_csv(tmp_path):
+    """
+    Given a report whose chains never switched mode,
+    When the LaTeX table comments and the CSV header block are built,
+    Then both carry the weight uncertainty and the transition/no-switch
+      counts, so the numbers a reader needs to judge the weights travel with
+      them into every output format.
+    """
+    rng = np.random.default_rng(3)
+    chain_mode = np.repeat([0] * 6 + [1] * 2, N_DRAW)
+    a = rng.normal(0, 1, N) + 10 * chain_mode
+    rep = identify_modes(_make_idata({"a_raw": a}, rng.normal(0, 1, N)))
+
+    var_file = tmp_path / "defs.tex"
+    tmpl_file = tmp_path / "table.tex"
+    csv_file = tmp_path / "results.csv"
+    build_latex_output(
+        _StubSystem(),
+        var_filename=str(var_file),
+        template_filename=str(tmpl_file),
+        mode_report=rep,
+    )
+    build_csv_output(_StubSystem(), str(csv_file), mode_report=rep)
+
+    tmpl = tmpl_file.read_text()
+    assert r"\ezmodeweighterrone" in var_file.read_text()
+    assert r"\ezmodeweighterrone" in tmpl
+    assert "Mode changes in the stored draws: 0" in tmpl
+    assert "2 chains never changed mode" not in tmpl  # it is 8 of 8
+    assert "8 of 8 chains never changed mode" in tmpl
+    csv_text = csv_file.read_text()
+    assert "weight_err" in csv_text.splitlines()[0]
+    assert "Mode changes in the stored draws: 0" in csv_text
+
+
+def test_thin_factor_read_from_the_trace_and_reported():
+    """
+    Given a trace stamped by run.py with its storage thinning,
+    When identify_modes runs,
+    Then the report carries the factor and says out loud that the transition
+      count is a lower bound; an unstamped trace says the thinning is unknown
+      rather than quietly asserting it was 1.
+    """
+    rng = np.random.default_rng(31)
+    labels = (rng.random(N) < 0.3).astype(int)
+    a = rng.normal(0, 1, N) + 10 * labels
+
+    unstamped = _make_idata({"a_raw": a}, rng.normal(0, 1, N))
+    rep_unstamped = identify_modes(unstamped)
+
+    stamped = _make_idata({"a_raw": a}, rng.normal(0, 1, N))
+    stamped.posterior.attrs["nthin"] = 10
+    rep_stamped = identify_modes(stamped)
+
+    assert rep_unstamped.thin_factor == 1
+    assert not rep_unstamped.thin_known
+    assert "does not record its storage thinning" in rep_unstamped.to_text()
+    assert rep_stamped.thin_factor == 10
+    assert rep_stamped.thin_known
+    assert "LOWER BOUND" in rep_stamped.to_text()
+
+
+def test_ladder_round_trips_quoted_separately_from_mode_changes():
+    """
+    Given a PTDE trace stamped with the ladder's own temperature round trips,
+    When the mode report renders,
+    Then it quotes them as sampler context and says explicitly that they are
+      temperature round trips and NOT mode changes -- "swap" is ambiguous
+      between the two and conflating them would misstate the weights.
+    """
+    rng = np.random.default_rng(41)
+    labels = (rng.random(N) < 0.3).astype(int)
+    a = rng.normal(0, 1, N) + 10 * labels
+    idata = _make_idata({"a_raw": a}, rng.normal(0, 1, N))
+    idata.posterior.attrs["ptde_ladder_round_trips"] = 77
+    idata.posterior.attrs["ptde_swap_rounds"] = 5000
+
+    rep = identify_modes(idata)
+    text = rep.to_text()
+
+    assert rep.ladder_round_trips == 77
+    assert rep.ladder_swap_rounds == 5000
+    assert "temperature round trips" in text
+    assert "NOT mode changes" in text
+    assert "77" in text


### PR DESCRIPTION
Review item **1.13**: evidence-based mode weights were dead on arrival for realistic fits, with an anti-conservative error bar when they did run. Plus a new diagnostic: how much the *occupancy* weights can be trusted.

## The headline, on a real fit

**KMT-2019-BLG-1806**, 70 chains x 650 draws, 2 modes:

| | |
|---|---|
| mode changes | 52 |
| round trips | 35 |
| chains that NEVER switched | **53 of 70** |
| `N_eff` for the weight | **74.9** (from 45500 draws; IACT 607) |
| minority mode weight | `0.0545` -> **`0.0545 +/- 0.0262`** |

A naive binomial on all 45500 draws would have said `+/- 0.0011` -- **24x too tight**. What looked like a precisely-measured 5.45% is a ~2 sigma statement. DC2018_128 is unimodal and correctly reports `1.0 +/- 0.0`, IACT 1.0.

## (a) The diagnostic overflowed and blamed the proposal

Reproduced with `N(0,1.3)` vs `N(0,1)` plus an additive `logC`: `logC = 100` -> `re2 = 1.59e-5`; `700` -> `nan`; `1e3, 1e4, 1e6` -> `inf`, mode refused as "proposal poorly supports the target". **`lnZ` itself was fine throughout** -- only the guard was broken, which makes the refusal maximally misleading.

Fixed by recentering, as the review specified. **Equivalence proven, not assumed**: only `var/mean^2` ratios and the IACT (from the *normalized* autocorrelation) enter `re2`, so `f1` is literally unchanged after dividing through by `exp(l2)` and `f2' = r*f2` is a constant rescale invisible to a scale-free ratio. Numerically, over **72 non-degenerate cases** spanning `logC` -5..500 and proposal mismatch 1.05x-3x: **max relative difference 7.9e-16** (3 ULP). Degenerate target==proposal cases are excluded and stated as such -- there `re2` is exactly 0 and both forms return ~1e-32 of round-off, so a relative comparison of two noise floors is meaningless.

## (b) Absolute convergence tolerance at 1e6 scale

Real, but **not universal** -- the review implies it always fails; sweeping 200 seeds per scale gives 0/200 spurious failures at `|lnZ|` = 1e4 and 1e5, then **48/200 at 1e6, 40/200 at 1e7, 52/200 at 1e8**. It is not 100% because the iterate sometimes lands on an exact float fixed point; the failures are two-float limit cycles one ULP apart (ULP at 1e6 = 1.16e-10 > tol 1e-10).

Now relative to `|lr|`: `abs(lr_new - lr) < tol * max(1, abs(lr_new))`, justified in both directions -- loose enough that 1e-10 relative is ~4.5e5 ULPs, well above the `sqrt(N)` summation noise of the two `_logmeanexp` calls (~1.4e-8 at 1e6), giving 0/200 spurious failures; tight enough that the admitted step is 1e-4 nat even at `|lnZ|` = 1e6, four orders below the 0.5-nat refusal threshold, while a genuinely unconverged iteration moves O(0.01-1) nat/step. A barely-overlapping proposal still reports `converged=False` at both `logC = 0` and `logC = 1e6`.

## (c) IACT measured on a destroyed series

AR(1) with known IACT, laid out as the code actually lays out a mode's draws:

| true tau | ordered 1 chain | concatenated | after `rng.choice` | **new** | error bar |
|---|---|---|---|---|---|
| 19 | 15.0 | 16.3 | 1.11 | 3.40 | **1.7x larger** |
| 99 | 113 | 146 | 1.03 | 19.25 | **4.4x larger** |
| 399 | 253 | 556 | 1.00 | 68.81 | **8.2x larger** |

The review's "concatenates chains" is real but **second-order** -- concatenation biases (16.3/146/556 vs 15.0/113/253); the unsorted `rng.choice` is what *destroys* the measurement. Both fixed: subsampling is now a per-chain stride and the IACT is measured per chain and combined. No separate thinning correction is needed -- the estimator averages exactly the strided series, so its own IACT is the right inflation factor (checked: `tau_thin/N_thin` = 7.3e-3 vs `tau_full/N_full` = 7.3e-3).

**I did not implement the review's implied recipe literally.** Taking "combine per chain" as a max of within/between estimates is inflated 2-4x one time in ten by the chi-square noise of a `(C-1)`-dof quantity -- which would spuriously refuse modes that were fine, the same disease in the other direction. The estimator moved to a new `outputs/autocorr.py` using the Vehtari et al. (2021) multi-chain construction (ragged-chain generalized, Geyer pair truncation), whose `B/n_bar` normalization gets both regimes right: AR(1) recovery over 20 repeats is 0.92-1.25x truth, and chains stuck in different modes land at `N_eff ~ n_chains`. Reasoning is in the module docstring.

## New: transition counts and occupancy precision

`identify_modes` now records per-chain transition counts, round trips (on the run-length-compressed visit sequence), chains that never switched, and `N_eff = N/IACT` of the mode-indicator series -> `sigma_w = sqrt(w(1-w)/N_eff)`.

- **Markov cross-check agrees**: time-series IACT vs the analytic `2/(p01+p10) - 1` on synthetic two-state chains -- 47.3 vs 49.0, 96.5 vs 99.0, 960 vs 999, 2.3 vs 2.3.
- **Thinning cannot manufacture independence**: the same series thinned 1/5/10/50x gives `N_eff` = 313/312/310/326. `run.py` now stamps `posterior.attrs["nthin"]`; the report calls the transition count a **lower bound** under thinning, or says thinning is *unknown* for older traces rather than assuming 1.
- **PTDE disambiguated**: the samplers stamp their existing `round_trips` counter and the report quotes it as context, labelled explicitly as *temperature* round trips of a replica and "NOT mode changes". The quantity used for weights is mode changes in the stored T=1 draws -- which correctly includes a T=1 replica changing mode via a hot swap.
- **Advisory, not gating**: below `N_eff = 30` a plain-language note states the number and what it implies, and says the ordering is informative while the values are uncertain. Nothing is suppressed or substituted.

## Loose ends

`weight_err` is now surfaced in text (`weight = 0.5500 +/- 0.0228`), LaTeX (`\\ezmodeweighterr<n>` macros and a `$w \\pm dw$` row, wrapped in `\\ensuremath`) and CSV (new column plus provenance/mixing header comments; `ledger.append_ledger_csv` updated to keep rows aligned). Occupancy and evidence weights print side by side with a cross-check note when they disagree by >3 sigma.

Stale `idata.posterior["mode"].attrs` fixed on **both** paths (provenance changes on refusal too), now carrying `weight_errs`, `occupancy_weights` and the transition counts. Nothing downstream read `attrs["weights"]` (`system.py:570` reads only `n_modes`), so this changes no behavior -- only what a reader of the saved trace is told.

## Tests

`test_mode_evidence.py` +11, `test_mode_report.py` +9. No existing assertion weakened, and none encoded the buggy behavior -- the old tests simply never went past `|logC| < 2`, which is why the whole regime was untested. One test deliberately re-implements the pre-fix expression to prove it is non-finite where the new one works.

Green: `test_mode_evidence`/`test_mode_report`/`test_mode_report_cli`/`test_mode_ledger`/`test_multimode_outputs` (73), `test_ptde*`/`test_hot_chains`/`test_multiseed_ptde`/`test_trace_plots` (71), `test_runner`/`test_run_endpoints`/`test_mulens_review_fixes`/`test_whitening` (74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)