### PR TITLE
planet: fix the multi-planet crash and the no-op negative-mass barrier (review 2.4.1, 2.4.2)

### DIFF
--- a/src/exozippy/components/planet/planet.py
+++ b/src/exozippy/components/planet/planet.py
@@ -379,9 +379,19 @@ class Planet(Component):
         # inside an unselected jnp.where branch of pytensor's softplus): any
         # system with m_total > 1.42 Msun silently froze every numpyro chain
         # at its starting point.  See potentials.py.
+        #
+        # The barrier is applied to the UNCLIPPED sum, not to self.m_total:
+        # calc_m_total clips at 1e-9, so feeding the clipped node here made
+        # the whole m_total < 0 region a constant log(sigmoid(~0)) = -0.693
+        # with exactly zero gradient -- a flat plateau with no restoring
+        # force, which is precisely the pathology the log_q notes warn about
+        # and is reachable in 'linear' mass mode (planet.mass's lower bound
+        # is -1000 Mjup, more than a solar mass below zero).
+        star = system.active_components["star"]
+        m_total_unclipped = star.mass.value[self.star_map] + self.mass.value
         pm.Potential(
             f"{self.prefix}.m_pos_constraint",
-            soft_lower_bound(self.m_total.value, 0.0, scale=0.88),
+            soft_lower_bound(m_total_unclipped, 0.0, scale=0.88),
         )
 
         self._add_chen_potential()

--- a/src/exozippy/components/planet/planet.py
+++ b/src/exozippy/components/planet/planet.py
@@ -5,7 +5,7 @@ import pymc as pm
 import pytensor.tensor as pt
 
 from exozippy.components.component import Component
-from exozippy.constants import MSUN_TO_MEARTH, RSUN_TO_REARTH
+from exozippy.constants import KEPLER_CONST, MSUN_TO_MEARTH, RSUN_TO_REARTH
 from exozippy.potentials import soft_lower_bound, soft_upper_bound
 
 from . import physics
@@ -410,36 +410,99 @@ class Planet(Component):
             ),
         )
 
-        if self.n_elements < 2:
-            return
+        if self.n_elements >= 2:
+            self._add_crossing_potential(system, orbits)
 
-        logger.warning("Planet collision penalty is untested.")
+    def _initial_semimajor_axes(self, system, orbits):
+        """Per-planet starting semi-major axis, solRad.
 
-        # 1. Sort planets by semi-major axis (using the PyMC variables)
-        # Note: Since these are tensors, we usually assume the user
-        # provided them in order, or we use their 'initval' to sort.
-        sorted_planets = sorted(self.planets, key=lambda p: p.a.initval)
+        ``planet.arsun`` is a derived Parameter and carries no ``initval``
+        of its own, so the start is recomputed here from the same relation
+        (``physics.calc_arsun``) using the start values the relaxation
+        engine did resolve.  Returns NaN wherever an input is missing; the
+        caller falls back to the config order there.
+        """
 
-        for i in range(len(sorted_planets) - 1):
-            inner = sorted_planets[i]
-            outer = sorted_planets[i + 1]
+        def vec(x, n):
+            try:
+                out = np.asarray(np.atleast_1d(x), dtype=float) * np.ones(n)
+            except (TypeError, ValueError):
+                return np.full(n, np.nan)
+            return out
 
-            # Get the symbolic apastron (furthest point) of the inner planet
-            # Q = a * (1 + e)
-            inner_apastron = inner.orbit.a.value * (
-                1.0 + inner.orbit.ecc.value
+        n = self.n_elements
+        period = vec(orbits.period.initval, orbits.n_elements)[self.orbit_map]
+        m_planet = vec(self.mass.initval, n)
+        star = system.active_components["star"]
+        m_star = vec(star.mass.initval, star.n_elements)[self.star_map]
+
+        m_total = np.maximum(m_star + m_planet, 1e-9)
+        with np.errstate(invalid="ignore"):
+            return (
+                KEPLER_CONST * m_total ** (1.0 / 3.0) * period ** (2.0 / 3.0)
             )
 
-            # Get the symbolic periastron (closest point) of the outer planet
-            # q = a * (1 - e)
-            outer_periastron = outer.orbit.a_val * (
-                1.0 - outer.orbit.ecc.value
-            )
+    def _add_crossing_potential(self, system, orbits):
+        """Soft non-crossing barrier between neighboring planets' orbits.
 
-            # Potential: If they cross, log-probability goes to -inf
+        Two planets whose orbits intersect are dynamically unstable on
+        timescales far shorter than the age of any system we fit, so the
+        posterior is bounded by keeping the outer planet's periastron,
+        a_out (1 - e_out), outside the inner planet's apastron,
+        a_in (1 + e_in).  This is the constraint the original (never
+        executed) block described; three things about it are new:
+
+        - It reads the component's own vectors.  The old code walked a
+          ``self.planets`` list of per-planet objects with ``.orbit.a`` /
+          ``.orbit.a_val`` attributes, none of which have existed since the
+          vectorized refactor -- so ANY system with two or more planets
+          raised AttributeError here.  A planet's semi-major axis is
+          ``planet.arsun`` (solRad, derived from m_total and the orbit's
+          period) and its eccentricity is its orbit's, via ``orbit_map``.
+        - The wall is a soft bound, not ``pt.switch(..., 0, -inf)``.  A -inf
+          gives NUTS no gradient to follow out of the forbidden region (and
+          NaNs the JAX backward pass), so this uses the same clipped
+          log-sigmoid barrier as every other soft constraint here.  The
+          transition width is 1% of the inner planet's starting semi-major
+          axis, i.e. the barrier is scaled to the orbit it guards.
+        - Planets are ordered ONCE, by their starting semi-major axes.  The
+          ordering is a topology choice, not a sampled quantity: re-deriving
+          it per draw would make the potential discontinuous wherever two
+          orbits swap places.
+
+        Limitation, deliberately not modeled: only adjacent pairs are
+        constrained, and only pairs on distinct orbits.  For nested
+        hierarchical orbits (a planet orbiting a body group) this compares
+        semi-major axes about different centers, which is the right
+        first-order condition but not a stability criterion.
+        """
+        # Semi-major axis (solRad) and eccentricity, per planet.
+        a = self.arsun.value
+        ecc = orbits.ecc.value[self.orbit_map]
+
+        a_init = self._initial_semimajor_axes(system, orbits)
+        # A missing start sorts last but must not become the barrier scale.
+        order = np.argsort(np.where(np.isfinite(a_init), a_init, np.inf))
+
+        for k in range(len(order) - 1):
+            i, j = int(order[k]), int(order[k + 1])
+            if self.orbit_map[i] == self.orbit_map[j]:
+                # One orbit cannot cross itself; two planets sharing an
+                # orbit index are co-orbital by construction.
+                continue
+
+            inner_apastron = a[i] * (1.0 + ecc[i])
+            outer_periastron = a[j] * (1.0 - ecc[j])
+
+            scale = a_init[i] if np.isfinite(a_init[i]) else 0.0
+            scale = float(max(abs(scale), 1e-6))
+
             pm.Potential(
-                f"crossing_penalty_{inner.name}_{outer.name}",
-                pt.switch(outer_periastron > inner_apastron, 0.0, -np.inf),
+                f"{self.prefix}.crossing_bound_"
+                f"{self.names[i]}_{self.names[j]}",
+                soft_lower_bound(
+                    outer_periastron - inner_apastron, 0.0, scale=scale
+                ),
             )
 
     def _add_chen_potential(self):

--- a/tests/test_multiplanet.py
+++ b/tests/test_multiplanet.py
@@ -1,0 +1,284 @@
+"""Multi-planet systems and the planet-planet non-crossing barrier.
+
+Nothing in examples/ or tests/ built a system with more than one planet, so
+``Planet.build_likelihood``'s ``n_elements >= 2`` branch was dark code and had
+rotted into an AttributeError (it walked a ``self.planets`` list of per-planet
+objects that has not existed since the vectorized refactor, and reached for
+``inner.orbit.a.value`` / ``outer.orbit.a_val``, neither of which exists).
+Layer 1 here is the coverage that keeps that path lit.
+
+Layer 2 pins the barrier itself.  It used to be
+``pt.switch(ok, 0.0, -np.inf)``: the right value and no gradient at all for
+NUTS to follow out of the forbidden region, so the assertions below are on
+the GRADIENT, not only on the value.
+
+The companion regression for the m_pos_constraint plateau (review item
+2.4.2) lives in tests/test_planet_mass_barrier.py -- it needs only one
+planet, so keeping it out of this file lets each item fail on its own.
+"""
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+from pytensor.graph.replace import graph_replace
+
+from exozippy.system import System
+
+# ---------------------------------------------------------------------------
+# Fixtures: one two-planet RV system, built once
+# ---------------------------------------------------------------------------
+_P_INNER = 20.0  # planet 'c'
+_P_OUTER = 111.0  # planet 'b'
+
+
+def _write_rv(path, seed, n=40):
+    rng = np.random.default_rng(seed)
+    t = np.sort(rng.uniform(2455000.0, 2455400.0, n))
+    rv = (
+        30.0 * np.sin(2 * np.pi * t / _P_OUTER)
+        + 10.0 * np.sin(2 * np.pi * t / _P_INNER)
+        + rng.normal(0, 3.0, n)
+    )
+    np.savetxt(path, np.column_stack([t, rv, np.full(n, 3.0)]))
+    return path
+
+
+def _build(planets, orbits, params=None, files=None):
+    config = {
+        "star": [{"name": "A", "mist": False}],
+        "planet": planets,
+        "orbit": orbits,
+        "rvinstrument": [{"name": "HIRES", "file": files[0]}],
+    }
+    user_params = {
+        "star.A.mass": {"initval": 1.0, "sigma": 0.05},
+        "star.A.radius": {"initval": 1.0, "sigma": 0.05},
+    }
+    user_params.update(params or {})
+    system = System(config, user_params)
+    system.prepare()
+    return system, system.build_model()
+
+
+@pytest.fixture(scope="module")
+def rv_file(tmp_path_factory):
+    d = tmp_path_factory.mktemp("multiplanet_rv")
+    return str(_write_rv(d / "two_planets.rv", 7))
+
+
+@pytest.fixture(scope="module")
+def two_planet_system(rv_file):
+    """A star with two planets on two orbits, measured by one RV data set.
+
+    RV data put both planets on the mass-constrained side, so the mass is
+    sampled in 'linear' mode -- the mode in which the m_pos_constraint
+    plateau of item 2.4.2 is reachable.
+    """
+    return _build(
+        planets=[{"name": "b"}, {"name": "c", "orbit_ndx": 1}],
+        orbits=[
+            {"name": "b", "primary": ["A"], "companion": ["b"]},
+            {"name": "c", "primary": ["A"], "companion": ["c"]},
+        ],
+        params={
+            "orbit.b.logP": {"initval": np.log10(_P_OUTER)},
+            "orbit.b.tc": {"initval": 2455010.0},
+            "orbit.c.logP": {"initval": np.log10(_P_INNER)},
+            "orbit.c.tc": {"initval": 2455005.0},
+        },
+        files=[rv_file],
+    )
+
+
+@pytest.fixture(scope="module")
+def one_planet_system(rv_file):
+    return _build(
+        planets=[{"name": "b"}],
+        orbits=[{"name": "b", "primary": ["A"], "companion": ["b"]}],
+        params={
+            "orbit.b.logP": {"initval": np.log10(_P_OUTER)},
+            "orbit.b.tc": {"initval": 2455010.0},
+        },
+        files=[rv_file],
+    )
+
+
+def _potential(model, needle):
+    hits = [p for p in model.potentials if needle in p.name]
+    assert len(hits) == 1, (
+        f"{needle}: found {[p.name for p in model.potentials]}"
+    )
+    return hits[0]
+
+
+# ---------------------------------------------------------------------------
+# 1. A >= 2 planet system builds at all (the coverage gap)
+# ---------------------------------------------------------------------------
+def test_two_planet_system_builds(two_planet_system):
+    """
+    Given a star with two planets on two orbits,
+    When the model is built,
+    Then it builds -- build_likelihood's multi-planet branch used to raise
+    AttributeError('Planet' object has no attribute 'planets') here.
+    """
+    system, model = two_planet_system
+
+    assert system.planet.n_elements == 2
+    assert system.planet.names == ["b", "c"]
+    # Vector parameters really do carry both planets.
+    assert len(np.atleast_1d(system.planet.mass.initval)) == 2
+    assert "planet.mass_raw" in {v.name for v in model.free_RVs}
+
+
+def test_two_planet_start_is_finite(two_planet_system):
+    """
+    Given the two-planet model,
+    When logp and its gradient are evaluated at the start point,
+    Then both are finite -- the old -inf crossing switch could kill the
+    start outright, and a NaN gradient freezes every JAX chain.
+    """
+    _, model = two_planet_system
+
+    point = model.initial_point()
+    assert np.isfinite(model.compile_logp()(point))
+    assert all(np.all(np.isfinite(g)) for g in model.compile_dlogp()(point))
+
+
+def test_two_planet_mass_mode_is_linear(two_planet_system):
+    """RV data measure both orbits, so the signed linear mass is sampled --
+    which is what makes the m_pos_constraint region below reachable."""
+    system, _ = two_planet_system
+    assert system.planet.mass_parameterization == "linear"
+
+
+# ---------------------------------------------------------------------------
+# 2. The planet-planet non-crossing barrier
+# ---------------------------------------------------------------------------
+def test_crossing_bound_is_added_once_ordered_inner_to_outer(
+    two_planet_system,
+):
+    """
+    Given two planets whose starting semi-major axes differ,
+    When the model is built,
+    Then exactly one non-crossing barrier is added, named inner-then-outer
+    (planet 'c' is the shorter period, so it is the inner one).
+    """
+    system, model = two_planet_system
+
+    names = [p.name for p in model.potentials if "crossing_bound" in p.name]
+    assert names == ["planet.crossing_bound_c_b"]
+
+    a_init = system.planet._initial_semimajor_axes(system, system.orbit)
+    assert a_init[1] < a_init[0]  # c inside b
+    assert np.all(np.isfinite(a_init))
+
+
+def test_single_planet_system_has_no_crossing_bound(one_planet_system):
+    """One planet cannot cross anything; the barrier must not appear."""
+    _, model = one_planet_system
+    assert not [p for p in model.potentials if "crossing_bound" in p.name]
+
+
+def _crossing_fn(system, model):
+    """Compile the crossing barrier and its gradient as a function of the
+    per-planet semi-major axes and the per-orbit eccentricities."""
+    pot = _potential(model, "crossing_bound")
+    a = pt.dvector("a")
+    ecc = pt.dvector("ecc")
+    node = graph_replace(
+        pot,
+        {system.planet.arsun.value: a, system.orbit.ecc.value: ecc},
+    )
+    return pytensor.function(
+        [a, ecc], [node, pt.grad(node.sum(), a)], on_unused_input="ignore"
+    )
+
+
+@pytest.mark.parametrize("ratio", [1.5, 3.0])
+def test_crossing_bound_is_inert_for_separated_orbits(
+    two_planet_system, ratio
+):
+    """
+    Given circular orbits with the outer one well outside the inner one,
+    When the barrier is evaluated,
+    Then it is negligible -- the constraint costs nothing where it should.
+    """
+    system, model = two_planet_system
+    f = _crossing_fn(system, model)
+
+    a_init = system.planet._initial_semimajor_axes(system, system.orbit)
+    a = a_init.copy()
+    a[0] = a[1] * ratio  # outer 'b' pushed outside inner 'c'
+
+    value, _ = f(a, np.zeros(system.orbit.n_elements))
+    assert value == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.parametrize("ratio", [0.95, 0.5, 0.1])
+def test_crossing_bound_pushes_the_orbits_apart(two_planet_system, ratio):
+    """
+    Given an outer planet whose periastron has fallen inside the inner
+    planet's apastron,
+    When the barrier and its gradient are evaluated,
+    Then the penalty is finite (not -inf) and its gradient is a restoring
+    force: it pushes the outer semi-major axis out and the inner one in.
+
+    This is the assertion the old pt.switch(..., 0.0, -np.inf) fails: -inf
+    has the right sign and no gradient at all for NUTS to follow.
+    """
+    system, model = two_planet_system
+    f = _crossing_fn(system, model)
+
+    a_init = system.planet._initial_semimajor_axes(system, system.orbit)
+    a = a_init.copy()
+    a[0] = a[1] * ratio
+
+    value, grad = f(a, np.zeros(system.orbit.n_elements))
+
+    assert np.isfinite(value)
+    assert value < -1.0
+    assert np.all(np.isfinite(grad))
+    assert grad[0] > 0.0  # push the outer planet ('b') outward
+    assert grad[1] < 0.0  # pull the inner planet ('c') inward
+
+
+def test_crossing_bound_deepens_monotonically(two_planet_system):
+    """Deeper inside the forbidden region costs more, so the sampler always
+    has a direction to walk -- a plateau (or a -inf) would not."""
+    system, model = two_planet_system
+    f = _crossing_fn(system, model)
+
+    a_init = system.planet._initial_semimajor_axes(system, system.orbit)
+    zeros = np.zeros(system.orbit.n_elements)
+
+    values = []
+    for ratio in (0.9, 0.7, 0.5):
+        a = a_init.copy()
+        a[0] = a[1] * ratio
+        values.append(float(f(a, zeros)[0]))
+
+    assert values[0] > values[1] > values[2]
+
+
+def test_crossing_bound_responds_to_eccentricity(two_planet_system):
+    """
+    Given two nested circular orbits that do not cross,
+    When the inner planet's eccentricity is raised until its apastron
+    reaches the outer planet's periastron,
+    Then the barrier turns on -- the constraint is on the apses, not on the
+    semi-major axes alone.
+    """
+    system, model = two_planet_system
+    f = _crossing_fn(system, model)
+
+    a_init = system.planet._initial_semimajor_axes(system, system.orbit)
+    a = a_init.copy()
+    a[0] = a[1] * 1.5
+
+    circular = float(f(a, np.zeros(system.orbit.n_elements))[0])
+    # orbit index 1 is planet 'c' (the inner one): e = 0.8 puts its apastron
+    # at 1.8 a_c, well outside the outer planet's 1.5 a_c periastron.
+    eccentric = np.zeros(system.orbit.n_elements)
+    eccentric[system.planet.orbit_map[1]] = 0.8
+    assert float(f(a, eccentric)[0]) < circular - 1.0

--- a/tests/test_planet_mass_barrier.py
+++ b/tests/test_planet_mass_barrier.py
@@ -1,0 +1,162 @@
+"""planet.m_pos_constraint: the barrier keeping the total mass positive.
+
+The barrier used to be applied to ``planet.m_total``, whose physics function
+``calc_m_total`` clips the sum at 1e-9 solar masses.  A clipped input makes
+the soft bound see a *constant* on the whole ``star.mass + planet.mass < 0``
+region -- ``log(sigmoid(~0)) = -0.693`` -- so the penalty had the right sign,
+a plausible magnitude, and a gradient of exactly zero.  That is a flat
+plateau with no restoring force: precisely the pathology the log_q notes in
+CLAUDE.md warn about, and it is reachable, because a planet whose mass RV or
+astrometric data constrain samples the *signed* linear mass, whose lower
+bound is -1000 Mjup (about -0.95 Msun).
+
+So these tests assert on the GRADIENT.  A value-only test passes on the
+broken code, which is how this survived.
+"""
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+from pytensor.graph.replace import graph_replace
+
+from exozippy.system import System
+
+_PERIOD = 17.0
+
+
+@pytest.fixture(scope="module")
+def rv_system(tmp_path_factory):
+    """One star, one planet, one RV data set.
+
+    RV data put the planet on the mass-constrained side, so the mass is
+    sampled in 'linear' mode -- the mode in which the region below zero is
+    reachable at all.
+    """
+    rng = np.random.default_rng(11)
+    t = np.sort(rng.uniform(2455000.0, 2455400.0, 40))
+    rv = 30.0 * np.sin(2 * np.pi * t / _PERIOD) + rng.normal(0, 3.0, 40)
+    path = tmp_path_factory.mktemp("mass_barrier") / "a.rv"
+    np.savetxt(path, np.column_stack([t, rv, np.full(40, 3.0)]))
+
+    config = {
+        "star": [{"name": "A", "mist": False}],
+        "planet": [{"name": "b"}],
+        "orbit": [{"name": "b", "primary": ["A"], "companion": ["b"]}],
+        "rvinstrument": [{"name": "HIRES", "file": str(path)}],
+    }
+    params = {
+        "star.A.mass": {"initval": 1.0, "sigma": 0.05},
+        "star.A.radius": {"initval": 1.0, "sigma": 0.05},
+        "orbit.b.logP": {"initval": np.log10(_PERIOD)},
+        "orbit.b.tc": {"initval": 2455010.0},
+    }
+    system = System(config, params)
+    system.prepare()
+    return system, system.build_model()
+
+
+@pytest.fixture(scope="module")
+def barrier(rv_system):
+    """Compile m_pos_constraint and d/d(planet mass), as a function of the
+    planet and star mass vectors in internal units (solar masses).
+
+    The potential is cut out of the built model, so this measures what
+    Planet.build_likelihood actually put there -- including, on the broken
+    code, calc_m_total's pt.maximum clip.
+    """
+    system, model = rv_system
+
+    hits = [p for p in model.potentials if "m_pos_constraint" in p.name]
+    assert len(hits) == 1, [p.name for p in model.potentials]
+
+    m_p = pt.dvector("m_p")
+    m_s = pt.dvector("m_s")
+    node = graph_replace(
+        hits[0],
+        {system.planet.mass.value: m_p, system.star.mass.value: m_s},
+    )
+    return pytensor.function(
+        [m_p, m_s], [node, pt.grad(node.sum(), m_p)], on_unused_input="ignore"
+    )
+
+
+def _at(barrier, m_total, m_star=1.0):
+    value, grad = barrier(np.array([m_total - m_star]), np.array([m_star]))
+    return float(np.atleast_1d(value)[0]), float(np.atleast_1d(grad)[0])
+
+
+def test_mass_mode_is_linear(rv_system):
+    """RV data measure the orbit, so the signed linear mass is sampled --
+    which is what makes the region below zero reachable."""
+    system, _ = rv_system
+    assert system.planet.mass_parameterization == "linear"
+    assert np.min(np.atleast_1d(system.planet.mass.lower)) < -0.9
+
+
+# The transition width is softness * scale = 0.01 * 0.88 = 0.0088 solMass,
+# so "safely positive" starts a few hundredths of a solar mass above zero.
+@pytest.mark.parametrize("m_total", [1.0, 0.5, 0.05])
+def test_barrier_is_inert_for_a_positive_total_mass(barrier, m_total):
+    """
+    Given a physical total mass,
+    When the barrier is evaluated,
+    Then it costs nothing -- the fix must not perturb any real fit.
+    """
+    value, _ = _at(barrier, m_total)
+    assert value == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.parametrize("m_total", [-1e-3, -0.02, -0.5, -1.0])
+def test_barrier_has_a_restoring_gradient_below_zero(barrier, m_total):
+    """
+    Given a total mass driven below zero by a negative planet mass,
+    When the barrier and its gradient are evaluated,
+    Then the gradient is strictly positive: it pushes the planet mass back
+    up, out of the forbidden region.
+
+    On the clipped input the gradient is exactly 0.0 here (pt.maximum sends
+    no derivative down the unselected branch), so the sampler feels nothing
+    at all no matter how far negative it wanders.
+    """
+    value, grad = _at(barrier, m_total)
+
+    assert np.isfinite(value) and np.isfinite(grad)
+    assert grad > 0.0
+
+
+@pytest.mark.parametrize("m_total", [-0.02, -0.5, -1.0])
+def test_barrier_gradient_is_the_designed_steepness(barrier, m_total):
+    """Well inside the forbidden region the log-sigmoid is linear, with
+    slope 4.4 / (scale * softness) = 4.4 / (0.88 * 0.01) = 500 nats per
+    solar mass -- the historical steepness the docstring in
+    Planet.build_likelihood quotes.  (Not 0, which is what the clipped
+    input gave; and not scaled by anything, which is the other way this
+    could go wrong.)"""
+    _, grad = _at(barrier, m_total)
+    assert grad == pytest.approx(500.0, rel=1e-3)
+
+
+def test_barrier_deepens_monotonically(barrier):
+    """
+    Given a sequence of total masses going further below zero,
+    When the barrier is evaluated at each,
+    Then the penalty keeps growing.  On the clipped input every one of these
+    returns the same -0.693: a plateau, which is what removes the restoring
+    force.
+    """
+    values = [_at(barrier, mt)[0] for mt in (-0.01, -0.1, -0.5, -1.0)]
+
+    assert all(np.isfinite(values))
+    assert values[0] > values[1] > values[2] > values[3]
+    # Not the log(sigmoid(0)) plateau the clipped input produced.
+    assert not np.allclose(values, -np.log(2.0))
+
+
+def test_barrier_is_not_the_clipped_plateau(barrier):
+    """The direct statement of the bug: feeding the clipped m_total made
+    every point below zero identical.  Two very different total masses must
+    not give the same penalty."""
+    shallow, _ = _at(barrier, -0.01)
+    deep, _ = _at(barrier, -1.0)
+    assert deep < shallow - 100.0


### PR DESCRIPTION
Two bugs in `planet.py`, both in code paths nothing exercised.

## 2.4.1 -- any >=2-planet system crashed

Reproduced by building a 2-planet RV system in memory:

```
File ".../components/planet/planet.py", line 411, in build_likelihood
    sorted_planets = sorted(self.planets, key=lambda p: p.a.initval)
AttributeError: 'Planet' object has no attribute 'planets'
```

**The intent was recovered, not guessed.** `git log -S crossing_penalty` traces the block to `components/stellarsystem.py` in 9221dad, where it was `build_dependent_parameters` on a container holding a `self.planets` list of per-planet objects (`p.orbit.a_val`, `p.orbit.e_val`). It is a planet-planet **non-crossing** constraint: outer periastron `a_out(1-e_out)` must stay outside inner apastron `a_in(1+e_in)`. The refactor into the vectorized `Planet` component copied the body verbatim and lost the list; `inner.orbit.a.value` and `outer.orbit.a_val` are leftovers of that copy (the latter is the original spelling, the former a half-finished rename).

Changes:
- reads the component's own vectors -- `self.arsun.value` and `orbits.ecc.value[self.orbit_map]`;
- `pt.switch(ok, 0.0, -np.inf)` -> `potentials.soft_lower_bound(...)`, per the house rule that a `-inf` wall has no gradient for NUTS to follow;
- `arsun` is derived and carries **no `initval`** (verified -- it is literally `None`), so a new `_initial_semimajor_axes()` recomputes the start from `calc_arsun`'s own relation using resolved `star.mass`/`planet.mass`/`orbit.period` initvals. Sorted once at build time: re-deriving per draw would make the potential discontinuous where two orbits swap;
- pairs sharing an `orbit_ndx` are skipped, and the `"Planet collision penalty is untested."` warning is gone.

**The real fix is the coverage.** New `tests/test_multiplanet.py` (12 tests, **all 12 error on pre-fix code**): the system builds; logp and dlogp finite at the start; exactly one `planet.crossing_bound_c_b` potential named inner->outer; ~0 for separated orbits; deepens monotonically inside the forbidden region; responds to the inner planet's **eccentricity** (it is the apses, not the axes); and gradient `grad[outer] > 0, grad[inner] < 0` -- a restoring force where `-inf` had none.

No example config could honestly gain a second planet (hd80606, hat3, wasp18, gj1214, kelt17 are single-planet; kelt4 is a hierarchical stellar triple with one planet), so this is a test fixture.

## 2.4.2 -- `m_pos_constraint` was a flat plateau

Asserted on the **gradient**, since a plateau has the right value and the wrong derivative -- which is exactly how it survived. Cutting the potential out of a built model and `graph_replace`ing the masses with free inputs, pre-fix with a 1 Msun star:

| m_total | value | d/d(planet mass) |
|---|---|---|
| -0.01 | -0.6931469 | 0.0 |
| -1.0 | -0.6931469 | **0.0** |

Identical value, zero gradient -- `log(sigmoid(1e-9 * 500))`, because `calc_m_total` already clips at 1e-9. Post-fix:

| m_total | value | d/d(planet mass) |
|---|---|---|
| +1e-3 | ~0 | ~0 |
| -0.02 | -10.0 | +499.977 |
| -1.0 | -510.0 | +500.0 |

Positive gradient (pushes the mass back up) equal to the designed `4.4/(0.88*0.01) = 500` nats/solMass. Nothing changes above zero, so no existing fit moves.

The fix bounds the **unclipped** sum: `soft_lower_bound(star.mass.value[star_map] + self.mass.value, 0.0, scale=0.88)`.

This is reachable in `linear` mass mode, which per CLAUDE.md is the default when a planet is mass-constrained by RV or astrometry and is not a lens body -- so it is not hypothetical. New `tests/test_planet_mass_barrier.py` (13 tests, **9 fail pre-fix**) uses a single-planet system so it fails independently of 2.4.1, and first asserts the mode really is `linear` and the bound really is below -0.9 Msun, i.e. that the region is reachable at all.

## Tests

`test_multiplanet`+`test_planet_mass_barrier`+`test_planet_log_q`+`test_chen` -> 81 passed. Regression spot-checks green: `test_rv_model`+`test_hierarchical_orbit` (13), `test_graph`/`test_physics`/`test_overrides`/`test_parameter_logic` (62), `test_examples_prepare`+`test_integration_kelt4` (25), `test_runaway_logp_regression`+`test_scale_propagation` (5).

## Flagged, deliberately not done

- The crossing barrier constrains only **adjacent** pairs on distinct orbits (documented in the docstring). For nested hierarchical orbits it compares semi-major axes about different centers -- the right first-order condition, but not a stability criterion. Making it a real mutual-Hill-radius criterion would be inventing physics the original never claimed.
- **No opt-out key.** On by default for every multi-planet system, matching the original intent. If that proves unwanted for e.g. a resonant pair, `crossing_bound: false` is the natural addition; not added speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)