### PR TITLE
config: stop warning that honored keys will be ignored, and pin the vocabularies against drift (review 2.2.1, 2.2.2)

### DIFF
--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -67,6 +67,15 @@ logger = logging.getLogger(__name__)
 # debugging imports
 # import ipdb
 
+# Every key `_run_fit` reads off the `sampler:` block. Anything else is
+# warned about and ignored, so this set must stay a superset of the keys the
+# code actually consumes: a key missing here produces a warning saying it will
+# be IGNORED about a key that is in fact HONORED, which is worse than no
+# warning at all (that is how 'jitter' -- the very key the sample_jax_nuts
+# comment tells users to opt back in with -- got flagged as unknown).
+# tests/test_known_keys.py cross-checks this set against the `sampler_cfg`
+# accesses in this module's own source, in both directions, so it cannot
+# silently drift again. Add the key here in the same edit that consumes it.
 KNOWN_SAMPLER_KEYS = {
     "init",
     "tune",
@@ -86,6 +95,7 @@ KNOWN_SAMPLER_KEYS = {
     "max_rhat",
     "maxtime",
     "chain_method",
+    "jitter",
     "eval_timeout",
     "rung_thin_factor",
     "rung_thin_start",
@@ -94,6 +104,22 @@ KNOWN_SAMPLER_KEYS = {
     "seed_polish",
     "store_hot_chains",
 }
+
+
+def warn_unknown_sampler_keys(sampler_cfg):
+    """Warn about `sampler:` keys this module does not consume.
+
+    Returns the sorted list of unrecognized keys (empty when all are known),
+    so the check is exercisable without running a fit.
+    """
+    unknown = sorted(set(sampler_cfg) - KNOWN_SAMPLER_KEYS)
+    if unknown:
+        logger.warning(
+            f"Unrecognized key(s) in the sampler block will be ignored: "
+            f"{unknown}. "
+            f"Did you mean 'method'? Valid sampler keys: {sorted(KNOWN_SAMPLER_KEYS)}"
+        )
+    return unknown
 
 
 def run_fit(config, user_params=None):
@@ -214,13 +240,7 @@ def _run_fit(config, gui, user_params=None):
         pytensor.config.profile = True
 
     # Warn about unrecognized keys in the sampler block so they are never silently ignored.
-    _unknown_sampler_keys = sorted(set(sampler_cfg) - KNOWN_SAMPLER_KEYS)
-    if _unknown_sampler_keys:
-        logger.warning(
-            f"Unrecognized key(s) in the sampler block will be ignored: "
-            f"{_unknown_sampler_keys}. "
-            f"Did you mean 'method'? Valid sampler keys: {sorted(KNOWN_SAMPLER_KEYS)}"
-        )
+    warn_unknown_sampler_keys(sampler_cfg)
 
     # 3. Build the stellar system into a PyMC Graph
     system = System(config, user_params=user_params)

--- a/src/exozippy/system.py
+++ b/src/exozippy/system.py
@@ -21,9 +21,45 @@ from exozippy.graph import determine_pymc_build_order
 
 """
 The System Class builds an entire system to model from its components.
-Critically, it contains no component-specific logic, so it 
+Critically, it contains no component-specific logic, so it
 can generally construct any model containing arbitrary components.
 """
+
+# Top-level config keys that are NOT component blocks. Every other top-level
+# key is looked up in the component registry and, failing that, warned about
+# as "will be ignored" -- so a key that some part of the codebase honors but
+# that is missing here produces a warning which is actively false, training
+# users to disbelieve the warning system. Each entry names its consumer:
+#
+#   run            -- documentation/bookkeeping block; deliberately inert.
+#                     evaluator._NON_STRUCTURAL_CONFIG_KEYS excludes it from
+#                     the structural hash, which is its only mention in code.
+#   name           -- System.name (below), read back by e.g.
+#                     astrometryinstrument's sky-plot title.
+#   parameter_file -- System.__init__, mkparam.mkprior, gui.document.
+#   prefix         -- run.py, cli_modes.py, mkparam.py, gui/status.py,
+#                     gui/runner.py, mulensinstrument's mmexofast cache path.
+#   logger_level   -- run.py, cli.py, cli_modes.py.
+#   sampler        -- run.py (see run.KNOWN_SAMPLER_KEYS for its own block).
+#   modes          -- run.py: {ledger, max_invalid_frac, force, weights}.
+#   mkprior        -- mkparam.mkprior: {n_seeds}.
+#   gui            -- gui.status.gui_enabled: {snapshot}.
+#
+# tests/test_known_keys.py cross-checks this set against the top-level-config
+# accesses in the source, in both directions, so it cannot silently drift.
+RESERVED_CONFIG_KEYS = frozenset(
+    {
+        "run",
+        "parameter_file",
+        "prefix",
+        "sampler",
+        "name",
+        "logger_level",
+        "modes",
+        "mkprior",
+        "gui",
+    }
+)
 
 
 class System(Component):
@@ -59,14 +95,7 @@ class System(Component):
         self.active_components = {}
 
         # 1. AGNOSTIC INSTANTIATION
-        reserved_keys = {
-            "run",
-            "parameter_file",
-            "prefix",
-            "sampler",
-            "name",
-            "logger_level",
-        }
+        reserved_keys = RESERVED_CONFIG_KEYS
         for key in self.config.keys():
             if key in self.registry:
                 CompClass = self.registry[key]

--- a/tests/test_known_keys.py
+++ b/tests/test_known_keys.py
@@ -1,0 +1,346 @@
+# tests/test_known_keys.py
+"""Anti-drift cover for the two hand-maintained "known key" vocabularies.
+
+EXOZIPPy warns about unrecognized keys in exactly two places:
+
+  * ``System.__init__`` -- top-level YAML keys that are neither a registered
+    component nor in ``system.RESERVED_CONFIG_KEYS``;
+  * ``run.warn_unknown_sampler_keys`` -- keys inside the ``sampler:`` block
+    that are not in ``run.KNOWN_SAMPLER_KEYS``.
+
+Both warnings say the key "will be ignored". When the declared set falls
+behind the set the code actually consumes, that statement becomes false --
+worse than silence, because it teaches users to disbelieve the warnings.
+That is exactly what happened to ``modes``/``mkprior``/``gui`` (honored by
+run.py, mkparam.py and gui/status.py) and to ``jitter`` (the key
+``sample_jax_nuts``'s own comment tells users to opt back in with).
+
+The cross-checks below are deliberately NOT a second copy of the same
+strings: a test that re-listed the keys would have been edited in lockstep
+with the bug and caught nothing. Instead they parse the shipped source with
+``ast`` and collect the string keys the code really reads off the config
+dicts, then compare in BOTH directions -- consumed-but-undeclared (false
+"ignored" warnings) and declared-but-unconsumed (dead vocabulary).
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+from exozippy.components.factory import discover_components
+from exozippy.run import KNOWN_SAMPLER_KEYS, warn_unknown_sampler_keys
+from exozippy.system import RESERVED_CONFIG_KEYS, System
+
+SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "exozippy"
+EXAMPLES = pathlib.Path(__file__).resolve().parents[1] / "examples"
+
+# Expressions that denote THE top-level system-config dict. A component's own
+# ``self.config`` is its YAML block (a list), not the system config, so bare
+# ``config`` is only trusted outside components/ (a component-local ``config``
+# is a per-instance block -- see planet/symbolic_physics.py) and ``self.config``
+# only inside system.py, where System owns it.
+_TOP_LEVEL_RECEIVERS = {
+    "system.config",
+    "system_config",
+    "self.system_config",
+    "cm.system_config",
+    "self.config_manager.system_config",
+}
+
+# Reserved keys that are deliberately accepted and then ignored, so no
+# ``config["<key>"]`` read exists for the scanner to find. Keep this list
+# tiny and justified -- an entry here is an exemption from the reverse check.
+_INERT_RESERVED_KEYS = {
+    # A free-form documentation block (``run: {name: ...}`` in every example
+    # config). Nothing reads it; evaluator._NON_STRUCTURAL_CONFIG_KEYS only
+    # excludes it from the structural hash.
+    "run",
+}
+
+
+def _expr_src(node):
+    """Source text of an AST expression, e.g. 'self.config_manager.system_config'."""
+    try:
+        return ast.unparse(node)
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+def _literal_keys_accessed(tree, receivers):
+    """Every string literal used as a dict key on one of ``receivers``.
+
+    Matches both ``recv["key"]`` and ``recv.get("key", ...)``. Non-literal
+    keys (``config.get(comp_type)``) are invisible to this scan by design:
+    they cannot be checked statically, and every key in the two vocabularies
+    under test is spelled literally at its point of use.
+    """
+    found = {}
+    for node in ast.walk(tree):
+        recv = key = None
+        if isinstance(node, ast.Subscript) and isinstance(
+            node.slice, ast.Constant
+        ):
+            if isinstance(node.slice.value, str):
+                recv, key = _expr_src(node.value), node.slice.value
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            recv, key = _expr_src(node.func.value), node.args[0].value
+        if recv in receivers:
+            found.setdefault(key, set()).add(node.lineno)
+    return found
+
+
+def _scan_top_level_config_keys():
+    """{key: {"module:line", ...}} for every literal read of the system config."""
+    found = {}
+    for path in sorted(SRC.rglob("*.py")):
+        rel = path.relative_to(SRC)
+        receivers = set(_TOP_LEVEL_RECEIVERS)
+        if rel.parts[0] != "components":
+            receivers.add("config")
+        if rel.as_posix() == "system.py":
+            receivers.add("self.config")
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for key, lines in _literal_keys_accessed(tree, receivers).items():
+            for line in lines:
+                found.setdefault(key, set()).add(f"{rel.as_posix()}:{line}")
+    return found
+
+
+def _scan_sampler_cfg_keys():
+    """{key: {"run.py:line", ...}} for every literal read of the sampler block."""
+    tree = ast.parse((SRC / "run.py").read_text(encoding="utf-8"))
+    return {
+        key: {f"run.py:{line}" for line in lines}
+        for key, lines in _literal_keys_accessed(tree, {"sampler_cfg"}).items()
+    }
+
+
+def _example_config_files():
+    """Every examples/ YAML that is a system config (not a params/aux file)."""
+    yaml = pytest.importorskip("yaml")
+    out = []
+    for path in sorted(EXAMPLES.rglob("*.yaml")):
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        keys = {k for k in data if isinstance(k, str)}
+        # 'parameter_file' is the decisive marker: every runnable system
+        # config names one, and no params file or component input file does.
+        if "parameter_file" in keys:
+            out.append((path, keys))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The two reported bugs (these fail on pre-fix src/).
+# ---------------------------------------------------------------------------
+
+
+def test_honored_global_blocks_are_not_warned_about(caplog):
+    """
+    Given a config using the global blocks run.py/mkparam.py/gui honor
+      (`modes:`, `mkprior:`, `gui:`),
+    When a System is constructed from it,
+    Then no "will be ignored" warning is emitted for them.
+
+    Regression (review 2.2.1): reserved_keys listed only run/parameter_file/
+    prefix/sampler/name/logger_level, so every DC2018 run warned that 'modes'
+    would be ignored -- about a key run.py reads twice.
+    """
+    # ARRANGE
+    config = {
+        "star": [{"name": "A"}],
+        "modes": {"weights": "evidence", "ledger": False},
+        "mkprior": {"n_seeds": 4},
+        "gui": {"snapshot": True},
+    }
+
+    # ACT
+    with caplog.at_level("WARNING", logger="exozippy.system"):
+        System(config, user_params={})
+
+    # ASSERT
+    ignored = [
+        r.getMessage() for r in caplog.records if "ignored" in r.getMessage()
+    ]
+    assert ignored == [], f"honored keys reported as ignored: {ignored}"
+
+
+def test_jitter_is_a_recognized_sampler_key(caplog):
+    """
+    Given a sampler block that opts back into jittered JAX starts,
+    When the unknown-sampler-key check runs,
+    Then nothing is reported as unrecognized.
+
+    Regression (review 2.2.2): 'jitter' is consumed by the numpyro/blackjax
+    branch (sample_jax_nuts(jitter=...)), and its own comment tells users to
+    "Opt back in with 'jitter: true'" -- but it was missing from
+    KNOWN_SAMPLER_KEYS, so following that instruction fired a warning saying
+    the key was unknown and would be ignored.
+    """
+    # ARRANGE
+    sampler_cfg = {"method": "numpyro", "jitter": True}
+
+    # ACT
+    with caplog.at_level("WARNING", logger="exozippy.run"):
+        unknown = warn_unknown_sampler_keys(sampler_cfg)
+
+    # ASSERT
+    assert unknown == []
+    assert not [r for r in caplog.records if "sampler block" in r.getMessage()]
+
+
+def test_a_genuine_typo_is_still_reported(caplog):
+    """
+    Given a sampler block with a misspelled key,
+    When the unknown-sampler-key check runs,
+    Then it is still reported -- widening the vocabulary must not mute it.
+    """
+    # ARRANGE / ACT
+    with caplog.at_level("WARNING", logger="exozippy.run"):
+        unknown = warn_unknown_sampler_keys({"jittr": True, "draws": 10})
+
+    # ASSERT
+    assert unknown == ["jittr"]
+    assert any("will be ignored" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Anti-drift: the declared vocabularies vs the consumed ones.
+# ---------------------------------------------------------------------------
+
+
+def test_every_consumed_sampler_key_is_declared():
+    """
+    Given every `sampler_cfg["..."]` / `.get("...")` read in run.py's source,
+    When compared against KNOWN_SAMPLER_KEYS,
+    Then no consumed key is missing from it.
+
+    Not a restatement of the set: the expected side is parsed out of run.py
+    itself, so adding a `sampler_cfg.get("new_knob")` without declaring it
+    fails here. This is how 'jitter' would have been caught.
+    """
+    # ARRANGE
+    consumed = _scan_sampler_cfg_keys()
+    # Sanity: the scanner must actually be finding reads, or the test is vacuous.
+    assert len(consumed) > 10
+
+    # ACT
+    undeclared = {
+        k: sorted(v)
+        for k, v in consumed.items()
+        if k not in KNOWN_SAMPLER_KEYS
+    }
+
+    # ASSERT
+    assert undeclared == {}, (
+        "sampler keys consumed by run.py but missing from KNOWN_SAMPLER_KEYS "
+        f"(users get a false 'will be ignored' warning): {undeclared}"
+    )
+
+
+def test_no_dead_sampler_vocabulary():
+    """
+    Given KNOWN_SAMPLER_KEYS,
+    When compared against the keys run.py actually reads,
+    Then every declared key is consumed somewhere.
+
+    The mirror direction: a declared-but-unread key silently accepts a knob
+    that does nothing, which is the failure mode the review's sibling items
+    (IMF: Kroupa, a typo'd ld_law) all shared.
+    """
+    # ARRANGE
+    consumed = set(_scan_sampler_cfg_keys())
+
+    # ACT
+    dead = sorted(KNOWN_SAMPLER_KEYS - consumed)
+
+    # ASSERT
+    assert dead == [], f"declared sampler keys nothing reads: {dead}"
+
+
+def test_every_consumed_top_level_key_is_a_component_or_reserved():
+    """
+    Given every literal read of the system-config dict across src/exozippy,
+    When each key is checked against the component registry plus
+      RESERVED_CONFIG_KEYS,
+    Then all of them are recognized.
+
+    Again parsed from the source rather than re-listed, so a new global block
+    ("gui:", "modes:", ...) that is honored but not reserved fails here
+    instead of shipping a warning that lies about it.
+    """
+    # ARRANGE
+    registry = set(discover_components())
+    consumed = _scan_top_level_config_keys()
+    assert len(consumed) > 5  # scanner sanity
+
+    # ACT
+    unrecognized = {
+        k: sorted(v)
+        for k, v in consumed.items()
+        if k not in registry and k not in RESERVED_CONFIG_KEYS
+    }
+
+    # ASSERT
+    assert unrecognized == {}, (
+        "top-level config keys the code honors but System warns are ignored: "
+        f"{unrecognized}"
+    )
+
+
+def test_no_dead_reserved_config_vocabulary():
+    """
+    Given RESERVED_CONFIG_KEYS,
+    When compared against the keys the source actually reads,
+    Then every reserved key is either consumed or explicitly listed as inert.
+    """
+    # ARRANGE
+    consumed = set(_scan_top_level_config_keys())
+
+    # ACT
+    dead = sorted(RESERVED_CONFIG_KEYS - consumed - _INERT_RESERVED_KEYS)
+
+    # ASSERT
+    assert dead == [], (
+        "reserved top-level keys nothing reads; either wire them up, drop "
+        f"them, or document them in _INERT_RESERVED_KEYS: {dead}"
+    )
+
+
+def test_no_example_config_triggers_the_ignored_warning():
+    """
+    Given every runnable system config under examples/,
+    When its top-level keys are classified the way System.__init__ does,
+    Then none of them would be warned about as ignored.
+
+    A user-facing cross-check that does not depend on the AST scan: the
+    shipped examples are the vocabulary we promise works.
+    """
+    # ARRANGE
+    registry = set(discover_components())
+    configs = _example_config_files()
+    assert len(configs) > 5  # the examples tree must not have moved
+
+    # ACT
+    offenders = {}
+    for path, keys in configs:
+        bad = sorted(keys - registry - RESERVED_CONFIG_KEYS)
+        if bad:
+            offenders[path.name] = bad
+
+    # ASSERT
+    assert offenders == {}, (
+        f"example configs using unreserved keys: {offenders}"
+    )


### PR DESCRIPTION
Two false "will be ignored" warnings, plus an anti-drift test so the lists cannot rot again.

Both are the same defect: a hand-maintained list of known keys drifted from the set the code actually consumes. The symptom is worse than a missing warning -- the tool says a key is IGNORED when it is HONORED, which teaches users to disbelieve the warning system. 2.2.2 is the sharp case: the `sample_jax_nuts` comment tells users to opt back in with `jitter: true`, and doing exactly that fires an unknown-key warning.

## Reproduced

**2.2.1** -- a config with `modes`/`mkprior`/`gui` emitted three `does not match any registered component and will be ignored` warnings. All three are honored: `modes` twice in `run.py` (seed-ledger switch, and mode-report `max_invalid_frac`/`force`/`weights`), `mkprior` in `mkparam.py` (`n_seeds`), `gui` in `gui/status.py` (`snapshot`).

**2.2.2** -- `"jitter" in KNOWN_SAMPLER_KEYS` was `False`.

## Full audit, both directions

**`KNOWN_SAMPLER_KEYS`** (26 consumed keys in `run.py`):
- consumed but not declared: **`jitter`** only -- fixed;
- declared but not consumed: **none**. All 25 pre-existing entries have a live read.

**`reserved_keys`** (now `RESERVED_CONFIG_KEYS`):
- consumed but not declared: **`modes`, `mkprior`, `gui`** -- exactly the three named, nothing else -- fixed;
- declared but not consumed: **`run`**, a documentation block present in all 20 example configs. Nothing reads it; its only code mention is `evaluator._NON_STRUCTURAL_CONFIG_KEYS`, which excludes it from the structural hash. Deliberately inert, kept, documented.

Worth a look separately: `name:` is read at **top level** by `System.__init__`, not from inside `run:`, so the examples' `run: {name: ...}` is decorative and `System.name` is always `"system"`. Pre-existing; not changed here.

## The anti-drift test is not a restatement

`tests/test_known_keys.py` (8 tests) declares no key. It `ast`-parses the shipped source and collects every string literal used as a dict key on the relevant receiver -- `sampler_cfg` in `run.py`, and the top-level config across `src/exozippy` -- then compares **in both directions**. Adding a `sampler_cfg.get("new_knob")` or a new honored global block fails the test in the same edit that introduces it, which is exactly what a restated list cannot do.

A scanner-sanity assertion (`len(consumed) > 10`) stops it degenerating into a vacuous pass if the scan ever stops matching, and an independent check asserts no `examples/**.yaml` uses a key the warning would flag. Non-literal reads are invisible by design and documented; every key in both vocabularies is spelled literally at its point of use.

Pre-fix verification: with the plumbing in place but the four vocabulary entries removed, **4 of 8 fail**. Post-fix 8/8. `test_a_genuine_typo_is_still_reported` pins that widening the vocabulary did not mute real typos.

One small refactor supports this: the sampler warning moved into `run.warn_unknown_sampler_keys(sampler_cfg)` so the real code path can run without a fit.

## Three more lists in the same family -- found, not fixed

1. **`gui/app.py:_config_top_keys`** -- literal fallback missing `name`/`modes`/`mkprior`/`gui`. Harmless today (it feeds an *intersection* test and any real config also carries component blocks), and it cannot import `RESERVED_CONFIG_KEYS` without defeating the fallback's purpose.
2. **`introspect._global_schema()`** -- declares only `prefix`, `logger_level`, `sampler`. Nothing validates against it, so no false warning, but `modes`/`mkprior`/`gui`/`run`/`name` are undocumented to the GUI. The natural home if you want one source of truth.
3. **`diagnostics.check_unused_yaml`'s `valid_subkeys`** -- described in-code as "the exact and ONLY keys ConfigManager.resolve absorbs", and **it has drifted the same way**: `resolve()` also absorbs `latex` and `description`, so `star.A.teff: {latex: "..."}` is reported as an ignored sub-key while being honored. A genuine third instance of this defect, in the params-file vocabulary. Worth a follow-up.

## On the broader nested-key gap

The scanner shape generalizes to one half of it. `Component.config_schema()` already declares each component's own config keys and is already consumed by the GUI -- a declared vocabulary with no warning attached. A `System.prepare()`-time check that every key in a component's YAML block appears in its `config_schema()` would catch `sed: "NextGen"` on a star block, kept honest by an AST cross-check identical to this one. The user-param-path half (`planet.b.tc`, where `tc` lives on orbit) is different in kind and belongs with `check_unused_yaml`, which already walks user params against built `Parameter` labels and mainly needs promoting from a report line to a warning.

## Tests

`test_known_keys.py` 8 passed. Regression sweep across everything touching these lists or `run.py`/`system.py` -- `test_introspect`, `test_mulens_review_fixes`, `test_config_healing`, `test_run_endpoints`, `test_evaluator`, `test_trace_staleness` -- 127 passed, no assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)