### PR TITLE
config: rank guard on the standalone solver, seeds at RANK_DERIVED_DATA, loud typo'd instance names (review 2.1.1-2.1.3)

### DIFF
--- a/examples/kelt4/kelt4.params.yaml
+++ b/examples/kelt4/kelt4.params.yaml
@@ -24,12 +24,16 @@ orbit.0.cosi:
   initval: 0.11996
 planet.0.radius:
   initval: 1.706
-rvinstrument.EXPERT.jitter_variance:
-  lower: -100
-  upper: 100
-rvinstrument.FIES.jitter_variance:
-  lower: -100
-  upper: 100
+# EXPERT and FIES are commented out of the rvinstrument block in
+# kelt4_rvonly.yaml, so these entries name instances the config does not
+# define.  They were silently ignored; naming an undefined instance is now a
+# STRICT NAMING ERROR, so they are commented out here to match the config.
+#rvinstrument.EXPERT.jitter_variance:
+#  lower: -100
+#  upper: 100
+#rvinstrument.FIES.jitter_variance:
+#  lower: -100
+#  upper: 100
 #inst.TRES.jitter_variance:
 #  lower: -100
 #  upper: 100

--- a/examples/kelt4/kelt4_sed.params.yaml
+++ b/examples/kelt4/kelt4_sed.params.yaml
@@ -102,12 +102,16 @@ orbit.0.cosi:
   initval: 0.11996
 planet.0.radius:
   initval: 1.706
-rvinstrument.EXPERT.jitter_variance:
-  lower: -100
-  upper: 100
-rvinstrument.FIES.jitter_variance:
-  lower: -100
-  upper: 100
+# EXPERT and FIES are commented out of the rvinstrument block in kelt4.yaml,
+# so these entries name instances the config does not define.  They were
+# silently ignored; naming an undefined instance is now a STRICT NAMING
+# ERROR, so they are commented out here to match the config.
+#rvinstrument.EXPERT.jitter_variance:
+#  lower: -100
+#  upper: 100
+#rvinstrument.FIES.jitter_variance:
+#  lower: -100
+#  upper: 100
 #inst.TRES.jitter_variance:
 #  lower: -100
 #  upper: 100

--- a/src/exozippy/components/mulensing/mmexofast_support.py
+++ b/src/exozippy/components/mulensing/mmexofast_support.py
@@ -131,8 +131,10 @@ def push_seed_hints(data, config_manager, want_rho, is_binary, source="?"):
     Epochs are shifted back into the data's own time system by subtracting
     the JSON's ``jd_offset`` (0.0 when absent, and for pre-jd_offset files).
 
-    Rank sits between RANK_DERIVED_DATA and RANK_USER (config.add_seed_hints
-    default) so an explicit user initval list still wins.
+    Rank is RANK_DERIVED_DATA (config.add_seed_hints): MMEXOFAST is a very
+    fancy derivation FROM THE DATA, not a user statement, so it sits in the
+    same tier as any other data-driven hint and EVERY user entry -- an initval
+    list, and equally a plain scalar initval -- outranks it.
 
     Returns the number of seed solutions pushed (0 when the file has none).
     """

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -1921,6 +1921,18 @@ class ConfigManager:
         map.  A solver that raises (missing dependencies) is retried next
         iteration; results carry RANK_DERIVED_MIXED so user values and
         data-derived hints always win, and re-fire as inputs refine.
+
+        "Always win" has to be enforced here, not just asserted: unlike the
+        equation path (``_attempt_solve``), which picks the LOWEST-ranked
+        symbol of a violated relation, a standalone solver writes its target
+        unconditionally.  ``_meaningful_change`` compares values, not ranks,
+        so before the guard below an explicit ``orbit.b.m_total`` in
+        params.yaml (RANK_USER) was overwritten every iteration by the body
+        mass sum and its provenance DOWNGRADED to RANK_DERIVED_MIXED --
+        exactly the inversion the ranking system exists to prevent.  A path
+        already held at a rank the solver cannot beat is therefore skipped;
+        one held at RANK_DERIVED_MIXED or below (including the solver's own
+        previous answer) still re-fires as its inputs refine.
         """
         for lookup_key in self.standalone_solvers:
             solver_func = self.custom_solvers[lookup_key]
@@ -1935,6 +1947,13 @@ class ConfigManager:
                 ):
                     continue
                 if pinned_vars and path in pinned_vars:
+                    continue
+                if provenance.get(path, 0) > RANK_DERIVED_MIXED:
+                    logger.debug(
+                        f"Standalone solver for {path} skipped: already held "
+                        f"at rank {provenance.get(path)} > "
+                        f"{RANK_DERIVED_MIXED}."
+                    )
                     continue
                 try:
                     val = float(

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -241,6 +241,26 @@ def canonical_param_key(key, system_config):
     return key
 
 
+def _declared_instance_names(system_config):
+    """Every ``name:`` declared by any list-instanced component in the config.
+
+    This is the universe of legal instance names in a 3-part parameter key.
+    It is deliberately NOT per component: a component's per-element names are
+    a manifest option that may borrow another component's instance names --
+    the lens's per-source vectors are addressed by the SOURCE STAR's name
+    (``lens.SourceA.t_0``), for instance.  Used by
+    ``standardize_param_names`` to reject typo'd instance names.
+    """
+    names = set()
+    for entries in (system_config or {}).values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict) and isinstance(entry.get("name"), str):
+                names.add(entry["name"])
+    return names
+
+
 # Provenance Ranks
 RANK_USER = 100  # Explicitly in params.yaml
 RANK_DERIVED_USER = 80  # Solved using ONLY Rank 100s
@@ -1047,9 +1067,68 @@ class ConfigManager:
                 standardized[key] = copy.deepcopy(val)
                 continue
 
-            # Numeric index or unknown name: canonical_param_key returns the
-            # key unchanged and it is stored as-is.  deepcopy so broadcast
-            # instances never share one dict (see the aliasing fix in #76).
+            # An UNKNOWN INSTANCE NAME is as fatal as an unknown component
+            # prefix, and for the same reason.  canonical_param_key returns
+            # such a key unchanged (deliberately -- it is also the lookup
+            # helper behind ConfigManager.canonical_key, which must stay
+            # total), so it used to be stored verbatim, registered as an inert
+            # leaf symbol by finalize_user_params, and never reach any
+            # parameter: `star.Aa.teff` silently dropped the user's value,
+            # bounds, mu and sigma.  A typo'd PRIOR that changes the posterior
+            # without a word is the worst version of this, so refuse to run.
+            #
+            # The accepted name set is every `name:` DECLARED ANYWHERE in the
+            # config, not just this component's own list, and that width is
+            # load-bearing -- a component's per-element names need not be its
+            # config entries' names:
+            #   * `lens.SourceA.t_0` (examples/ob161003) addresses element j
+            #     of the lens's per-source vectors by the SOURCE STAR's name;
+            #     the lens block itself has one entry, named "Lens".  The
+            #     per-parameter `names` list is a manifest option and is not
+            #     known until stage 2, long after this runs.
+            #   * `mann.B.ks_offset` names a mann block that has no `name:`
+            #     yet: this ConfigManager is built BEFORE the component loop
+            #     in System.__init__, and mann/torres derive their name from
+            #     their `star:` key inside their own __init__.
+            # Both are covered because the borrowed name is always some other
+            # component's instance name.  A genuine typo is a string that
+            # appears nowhere, which is what we reject.  Numeric index forms
+            # (`star.0.teff`) are pass-through by design.
+            if (
+                not comp_name.isdigit()
+                and canonical_param_key(key, config) == key
+                and comp_name not in _declared_instance_names(config)
+            ):
+                own = [
+                    e["name"]
+                    for e in comp_list
+                    if isinstance(e, dict) and e.get("name") is not None
+                ]
+                own_msg = (
+                    f"'{comp_type}' instances are: "
+                    f"{', '.join(repr(n) for n in own)}."
+                    if own
+                    else f"No '{comp_type}' entry declares a 'name:', so its "
+                    f"instances are addressable by index only."
+                )
+                raise ValueError(
+                    f"\n!!! STRICT NAMING ERROR !!!\n"
+                    f"Parameter '{key}' names the instance '{comp_name}', "
+                    f"which is not declared by any component in your system "
+                    f"configuration.\n"
+                    f"{own_msg} "
+                    f"Indices 0-{len(comp_list) - 1} also work "
+                    f"(e.g. '{comp_type}.0.{param_name}'), as does the "
+                    f"instance-less broadcast form "
+                    f"'{comp_type}.{param_name}'.\n"
+                    f"Fix the spelling, or delete the entry: it is otherwise "
+                    f"ignored outright, silently discarding its value, bounds "
+                    f"and prior."
+                )
+
+            # Numeric index or resolved name: canonical_param_key returns the
+            # index form.  deepcopy so broadcast instances never share one
+            # dict (see the aliasing fix in #76).
             standardized[canonical_param_key(key, config)] = copy.deepcopy(val)
 
         # Pass 2: expand 2-part keys for list components.

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -363,13 +363,12 @@ class ConfigManager:
         # finalize_user_params runs the relaxation engine once per seed; it
         # stays None for the ordinary single-start case (K == 1).  seed_hint_sets
         # is a per-seed observable channel that components (e.g. the MMEXOFAST
-        # loader) push into; it feeds the relaxation engine at a rank between
-        # RANK_DERIVED_DATA and RANK_USER so an explicit user initval list wins.
+        # loader) push into; it feeds the relaxation engine at RANK_DERIVED_DATA
+        # -- MMEXOFAST is a (very fancy) derivation FROM THE DATA, not a user
+        # statement, so it sits in the same tier as any other data-driven hint
+        # and every user entry outranks it.
         self.seed_resolved = None
         self.seed_hint_sets = []
-        self.seed_hint_rank = (
-            RANK_DERIVED_USER  # 80: below RANK_USER, above data
-        )
         self.scale_hints = {}  # path -> init_scale in internal units
         self.propagated_scales = {}  # path -> init_scale (internal) from Jacobian forward pass
         self.dependencies = {}
@@ -604,16 +603,17 @@ class ConfigManager:
         self.hints[translated_path] = internal_value
         self.hint_ranks[translated_path] = rank
 
-    def add_seed_hints(self, seed_dicts, rank=None):
+    def add_seed_hints(self, seed_dicts):
         """Register K per-seed observable sets for multi-seed sampling (P4).
 
         `seed_dicts` is a list of length K; each entry maps a parameter path
         (human-readable or index form) to a value in that parameter's user
         unit.  These feed the relaxation engine as one complete start point per
-        seed (see finalize_user_params).  Rank sits between RANK_DERIVED_DATA
-        and RANK_USER by default so an explicit user initval list still wins;
-        the MMEXOFAST loader is the primary caller.  Paths absent from a given
-        seed fall back to the base (defaults/hints/user) solution for that seed.
+        seed (see finalize_user_params), at RANK_DERIVED_DATA -- the same tier
+        as ``add_hint``'s default, because the MMEXOFAST loader (the primary
+        caller) is a derivation from the data, not a user statement.  Every
+        user entry therefore outranks a seed.  Paths absent from a given seed
+        fall back to the base (defaults/hints/user) solution for that seed.
         """
         processed = []
         for d in seed_dicts:
@@ -623,8 +623,6 @@ class ConfigManager:
                 pd[tpath] = ival
             processed.append(pd)
         self.seed_hint_sets = processed
-        if rank is not None:
-            self.seed_hint_rank = rank
 
     def seed_start_value(self, path, seed=0):
         """Seed-hint start value for ``path`` in USER units, or None.
@@ -1176,15 +1174,18 @@ class ConfigManager:
         base_flat = {str(k): v for k, v in flat_params.items()}
 
         # --- MULTI-SEED SOLVE (P4) ---
-        # Build K per-seed RANK_USER override sets (user initval lists win over
-        # MMEXOFAST-style seed hints; both fall back to the shared base_flat for
-        # any path they do not touch), then run the relaxation engine once per
+        # Build the K per-seed override sets in their two provenance channels
+        # (user initval lists at RANK_USER, component/MMEXOFAST seed hints at
+        # RANK_DERIVED_DATA; both fall back to the shared base_flat for any
+        # path they do not touch), then run the relaxation engine once per
         # seed inside this single prepare() call so every seed shares one symbol
         # environment (guards against the known cross-build nondeterminism).
         # Bounds/scales are taken from seed 0 only -- seeds move the START, never
         # the bounds -- so self.propagated_scales is restored to seed 0's after
         # the loop.
-        K, seed_overrides = self._build_seed_overrides(name_to_index)
+        K, user_overrides, seed_hint_overrides = self._build_seed_overrides(
+            name_to_index
+        )
 
         # Solve seed 0 LAST so the final self.propagated_scales and any
         # init_scale synced back into self.user_params by _execute_solve both
@@ -1193,8 +1194,10 @@ class ConfigManager:
         seed_resolved = [None] * K
         for k in list(range(1, K)) + [0]:
             flat_k = dict(base_flat)
-            flat_k.update(seed_overrides[k])
-            seed_resolved[k] = self.resolve_and_validate_parameters(flat_k)
+            flat_k.update(user_overrides[k])
+            seed_resolved[k] = self.resolve_and_validate_parameters(
+                flat_k, seed_hints=seed_hint_overrides[k]
+            )
 
         # seed 0 remains the canonical single start injected back into
         # user_params below; the full K-set is stored for get_raw_starts.
@@ -1296,19 +1299,29 @@ class ConfigManager:
                 )
 
     def _build_seed_overrides(self, name_to_index):
-        """Assemble the per-seed RANK_USER override sets for multi-seed sampling.
+        """Assemble the per-seed override sets for multi-seed sampling.
 
-        Two sources feed the seeds, in priority order:
+        Two sources feed the seeds, and they are kept in SEPARATE channels
+        because they carry different provenance:
           1. User initval lists in params.yaml (`initval: [v0, v1, ...]`) --
-             highest priority (an explicit user list always wins).
+             RANK_USER, merged into the engine's user_provided_params.
           2. Component seed hints (config_manager.seed_hint_sets), e.g. the
-             MMEXOFAST loader -- lower priority.
+             MMEXOFAST loader -- RANK_DERIVED_DATA, passed to the engine as
+             `seed_hints` and layered in with the other data-driven hints.
 
-        Returns (K, overrides) where K is the seed count and overrides is a
-        length-K list of {internal_path_str: internal_value} dicts.  Every list
-        must have length K or 1 (length-1 broadcasts to all seeds).  When no
-        list initvals and no seed hints exist, K == 1 and overrides == [{}],
-        exactly reproducing the legacy single-solve behavior.
+        Merging them into one RANK_USER dict (as this did until the 2.1.2
+        review fix) had two consequences: a seed silently clobbered a user's
+        *scalar* initval for the same path -- the scalar lives in base_flat,
+        which the merged override dict overwrote -- and a seed that disagreed
+        with a genuine user entry made every symbol of the connecting relation
+        RANK_USER, tripping the "over-constrained" contradiction clause.
+
+        Returns (K, user_overrides, seed_hint_overrides) where K is the seed
+        count and each override list has length K of {internal_path_str:
+        internal_value} dicts.  Every initval list must have length K or 1
+        (length-1 broadcasts to all seeds).  When no list initvals and no seed
+        hints exist, K == 1 and both lists are [{}], exactly reproducing the
+        legacy single-solve behavior.
         """
         # 1. User initval lists -> {sym_path: [internal values]}
         user_lists = {}
@@ -1349,18 +1362,25 @@ class ConfigManager:
                 f"component seed hints. Provide matching counts (or length 1)."
             )
 
-        # 3. Merge per seed (mm first, user lists override).
-        overrides = []
+        # 3. Split per seed.  No merge: the two channels enter the engine at
+        #    different ranks, and a path in both is resolved by rank, not by
+        #    dict order (a user list is RANK_USER and wins).
+        user_overrides = []
+        seed_hint_overrides = []
         for k in range(K):
-            d = {}
             if mm_sets:
                 src = mm_sets[k] if len(mm_sets) > 1 else mm_sets[0]
-                d.update(src)
-            for p, vals in user_lists.items():
-                d[p] = vals[k] if len(vals) > 1 else vals[0]
-            overrides.append(d)
+                seed_hint_overrides.append(dict(src))
+            else:
+                seed_hint_overrides.append({})
+            user_overrides.append(
+                {
+                    p: (vals[k] if len(vals) > 1 else vals[0])
+                    for p, vals in user_lists.items()
+                }
+            )
 
-        return K, overrides
+        return K, user_overrides, seed_hint_overrides
 
     def _to_symbol_path(self, path, name_to_index):
         """Translate a user_params key to the internal-index path string used by
@@ -1686,8 +1706,15 @@ class ConfigManager:
         return {p for p in paths if ranks.get(p, 0) > RANK_DEFAULT}
 
     def resolve_and_validate_parameters(
-        self, user_provided_params, tolerance=1e-3
+        self, user_provided_params, tolerance=1e-3, seed_hints=None
     ):
+        """Run the relaxation engine.
+
+        ``user_provided_params`` is {internal_path: internal_value} at
+        RANK_USER.  ``seed_hints`` is the optional per-seed hint set for this
+        seed (see ``_build_seed_overrides``), layered in at RANK_DERIVED_DATA
+        alongside ``self.hints``.
+        """
         resolved = {str(k): float(v) for k, v in user_provided_params.items()}
         provenance = {str(k): RANK_USER for k in user_provided_params.keys()}
         resolved_scales = {}
@@ -1743,6 +1770,23 @@ class ConfigManager:
                 provenance[path_str] = self.hint_ranks.get(
                     path_str, RANK_DERIVED_DATA
                 )
+
+        # 1.5b LAYER IN THIS SEED'S HINT SET (RANK_DERIVED_DATA)
+        # Same tier as the component hints above: an MMEXOFAST solution is a
+        # derivation from the data, not a user statement.  The guard is `<=`
+        # rather than `<` so a seed WINS a tie with an ordinary component
+        # hint -- a per-seed fit of the actual light curve is strictly more
+        # informative than the generic guess a component pushes for every
+        # seed alike.  (Today no real path is in both channels: the seeds
+        # carry lens.0.{t_0,u_0,t_E,rho,log_s,alpha,q}, and the only
+        # component hint that touches one of those, lens.0.alpha, is rank
+        # 20.  The rule is stated so a future overlap has a defined answer.)
+        # Anything above RANK_DERIVED_DATA -- every user entry, in particular
+        # a scalar initval, which lives in user_provided_params -- wins.
+        for path_str, val in (seed_hints or {}).items():
+            if provenance.get(path_str, 0) <= RANK_DERIVED_DATA:
+                resolved[path_str] = val
+                provenance[path_str] = RANK_DERIVED_DATA
 
         # 1.6 LAYER IN SCALE HINTS (correct indexed paths)
         # The initialization loop above calls resolve() without an index, so a hint

--- a/tests/test_config_provenance.py
+++ b/tests/test_config_provenance.py
@@ -236,3 +236,138 @@ def test_seed_hints_do_not_change_the_mmexofast_auto_trigger():
 
     assert before == set(paths)
     assert after == before
+
+
+# ---------------------------------------------------------------------------
+# 2.1.3  a typo'd instance name must be loud
+# ---------------------------------------------------------------------------
+
+
+def test_typoed_instance_name_raises_and_names_the_valid_instances():
+    """
+    Given a params key whose INSTANCE name is a typo ('star.Aa.teff' for
+    'star.A.teff'),
+    When the ConfigManager standardizes the names,
+    Then it raises a STRICT NAMING ERROR listing the valid instance names --
+    rather than keeping the key as an inert leaf and silently discarding the
+    user's value, prior and sigma.
+    """
+    config = {"star": [{"name": "A"}, {"name": "B"}]}
+    params = {
+        "star.Aa.teff": {"initval": 4000.0, "mu": 4000.0, "sigma": 100.0}
+    }
+
+    with pytest.raises(ValueError, match="STRICT NAMING ERROR") as exc:
+        ConfigManager(params, system_config=config)
+
+    msg = str(exc.value)
+    assert "star.Aa.teff" in msg
+    assert "'A'" in msg and "'B'" in msg
+
+
+def test_numeric_index_and_named_instances_still_pass():
+    """
+    Given the legitimate 3-part spellings -- a numeric index and a real
+    instance name --
+    When the names are standardized,
+    Then both resolve to index form and neither raises.
+    """
+    config = {"star": [{"name": "A"}, {"name": "B"}]}
+    cm = ConfigManager(
+        {
+            "star.0.teff": {"initval": 5000.0},
+            "star.B.teff": {"initval": 4000.0},
+        },
+        system_config=config,
+    )
+
+    assert set(cm.user_params) == {"star.0.teff", "star.1.teff"}
+
+
+def test_flat_dict_component_three_part_key_does_not_raise():
+    """
+    Given a 3-part key naming a flat-dict (non-list) component,
+    When the names are standardized,
+    Then the key is kept as-is: there are no instances to check it against.
+    """
+    config = {"sed": {"file": "x.sed"}}
+    cm = ConfigManager(
+        {"sed.whatever.errscale": {"initval": 1.0}}, system_config=config
+    )
+
+    assert "sed.whatever.errscale" in cm.user_params
+
+
+def test_name_borrowed_from_another_component_is_accepted():
+    """
+    Given a mann block that has not derived its `name:` yet -- ConfigManager
+    is built BEFORE the component loop in System.__init__, and Mann.__init__
+    is what copies `star: "A"` into `name: "A"` --
+    When 'mann.A.ks_offset' is standardized,
+    Then it is kept rather than rejected: 'A' is declared somewhere in the
+    config (as a star), and the legal-name universe is every declared name,
+    not just the addressed component's own list.
+    """
+    config = {
+        "star": [{"name": "A"}],
+        "mann": [{"star": "A", "constrain": ["mass"], "ks": 8.782}],
+    }
+    cm = ConfigManager(
+        {"mann.A.ks_offset": {"initval": 0.1}}, system_config=config
+    )
+
+    assert "mann.A.ks_offset" in cm.user_params
+
+
+def test_lens_per_source_element_name_is_accepted():
+    """
+    Given the NSNL spelling examples/ob161003 ships -- 'lens.SourceA.t_0'
+    addresses element j of the lens's PER-SOURCE vectors by the source star's
+    name, while the lens block itself has a single entry named 'Lens' --
+    When the names are standardized,
+    Then the key survives.  A per-parameter `names` list is a manifest option
+    resolved at stage 2, so a check restricted to the lens block's own entry
+    names would reject a shipped, working example.
+    """
+    config = {
+        "star": [
+            {"name": "Lens"},
+            {"name": "LensB"},
+            {"name": "SourceA"},
+            {"name": "SourceB"},
+        ],
+        "lens": [
+            {
+                "name": "Lens",
+                "lenses": ["star.0", "star.1"],
+                "sources": ["star.2", "star.3"],
+            }
+        ],
+    }
+    cm = ConfigManager(
+        {"lens.SourceA.t_0": {"initval": 2457551.04}}, system_config=config
+    )
+
+    assert "lens.SourceA.t_0" in cm.user_params
+
+
+def test_name_declared_nowhere_raises_even_for_a_borrowing_component():
+    """
+    Given the same lens topology but a source name that appears nowhere in
+    the config,
+    When the names are standardized,
+    Then it raises: the accepted set is wide (any declared name) but not
+    unbounded, so a real typo is still caught.
+    """
+    config = {
+        "star": [{"name": "Lens"}, {"name": "SourceA"}],
+        "lens": [
+            {"name": "Lens", "lenses": ["star.0"], "sources": ["star.1"]}
+        ],
+    }
+
+    with pytest.raises(ValueError, match="STRICT NAMING ERROR"):
+        ConfigManager(
+            {"lens.SourceZ.t_0": {"initval": 2457551.04}},
+            system_config=config,
+        )

--- a/tests/test_config_provenance.py
+++ b/tests/test_config_provenance.py
@@ -1,0 +1,109 @@
+# tests/test_config_provenance.py
+"""Provenance-ranking regressions from section 2.1 of the 2026-08-08 review.
+
+The ConfigManager's whole job is to reconcile conflicting constraints under a
+declared hierarchy -- user > data-derived > default (see config.py's class
+docstring).  Each test here pins one place where that hierarchy was violated
+or where a user's entry vanished without a diagnostic:
+
+  2.1.1  the standalone orbit.m_total solver overwrote an explicit user value
+         every iteration, DOWNGRADING its provenance to RANK_DERIVED_MIXED.
+  2.1.2  MMEXOFAST seed hints entered at RANK_USER, so a seed clobbered a
+         user's scalar initval and a seed disagreeing with a genuine user
+         entry tripped the "over-constrained" contradiction clause.
+  2.1.3  a 3-part key with a typo'd INSTANCE name was kept as an inert leaf
+         symbol -- value, bounds and prior silently discarded.
+"""
+
+import pytest
+
+from exozippy.config import (
+    RANK_DERIVED_MIXED,
+    RANK_USER,
+    ConfigManager,
+)
+
+MJUP_PER_MSUN = 1047.348644  # solMass -> jupiterMass
+
+_PSPL_CONFIG = {
+    "star": [
+        {"name": "Lens", "mist": False},
+        {"name": "Source", "mist": False},
+    ],
+    "lens": [{"name": "Lens", "lenses": ["star.0"], "sources": ["star.1"]}],
+}
+
+_BINARY_CONFIG = {
+    "star": [
+        {"name": "Lens", "mist": False},
+        {"name": "Source", "mist": False},
+    ],
+    "planet": [{"name": "Comp"}],
+    "lens": [
+        {
+            "name": "Lens",
+            "lenses": ["star.0", "planet.0"],
+            "sources": ["star.1"],
+        }
+    ],
+}
+
+
+def _orbit_config():
+    return {
+        "star": [{"name": "A", "mist": False}],
+        "planet": [{"name": "b"}],
+        "orbit": [{"name": "b", "primary": ["A"], "companion": ["b"]}],
+    }
+
+
+def _orbit_params():
+    return {
+        "star.A.mass": {"initval": 1.0},
+        "planet.b.mass": {"initval": 0.001 * MJUP_PER_MSUN},
+        "orbit.b.logP": {"initval": 1.0},
+        "orbit.b.tc": {"initval": 2456000.0},
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2.1.1  standalone solvers must respect provenance
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_solver_does_not_overwrite_a_user_value():
+    """
+    Given an explicit user orbit.b.m_total that disagrees with the sum of the
+    orbit's member-body masses,
+    When the relaxation engine runs (the standalone m_total solver fires once
+    per iteration),
+    Then the user's value survives at RANK_USER -- the solver is skipped, not
+    allowed to overwrite it and downgrade its provenance to
+    RANK_DERIVED_MIXED.
+    """
+    params = _orbit_params()
+    params["orbit.b.m_total"] = {"initval": 5.0}  # body sum is 1.001
+
+    cm = ConfigManager(params, system_config=_orbit_config())
+    cm.finalize_user_params()
+
+    assert cm._last_resolved["orbit.0.m_total"] == pytest.approx(5.0)
+    assert cm._last_provenance["orbit.0.m_total"] == RANK_USER
+    assert "orbit.0.m_total" not in cm._last_solved_by
+
+
+def test_standalone_solver_still_fires_without_a_user_value():
+    """
+    Given the same orbit with no user m_total,
+    When the engine runs,
+    Then the standalone solver still supplies the member-mass sum at
+    RANK_DERIVED_MIXED -- the guard blocks only ranks it cannot beat.
+    """
+    cm = ConfigManager(_orbit_params(), system_config=_orbit_config())
+    cm.finalize_user_params()
+
+    assert cm._last_resolved["orbit.0.m_total"] == pytest.approx(
+        1.001, rel=1e-3
+    )
+    assert cm._last_provenance["orbit.0.m_total"] == RANK_DERIVED_MIXED
+    assert "standalone solver" in cm._last_solved_by["orbit.0.m_total"]

--- a/tests/test_config_provenance.py
+++ b/tests/test_config_provenance.py
@@ -15,9 +15,11 @@ or where a user's entry vanished without a diagnostic:
          symbol -- value, bounds and prior silently discarded.
 """
 
+import numpy as np
 import pytest
 
 from exozippy.config import (
+    RANK_DERIVED_DATA,
     RANK_DERIVED_MIXED,
     RANK_USER,
     ConfigManager,
@@ -107,3 +109,130 @@ def test_standalone_solver_still_fires_without_a_user_value():
     )
     assert cm._last_provenance["orbit.0.m_total"] == RANK_DERIVED_MIXED
     assert "standalone solver" in cm._last_solved_by["orbit.0.m_total"]
+
+
+# ---------------------------------------------------------------------------
+# 2.1.2  seed hints are data-derived, not user statements
+# ---------------------------------------------------------------------------
+
+
+def test_seed_hint_does_not_override_a_user_scalar_initval():
+    """
+    Given a user scalar initval for lens.Lens.t_0 and an MMEXOFAST seed hint
+    naming a very different t_0,
+    When the engine solves,
+    Then the USER's value is the start and keeps RANK_USER: a seed is a
+    (fancy) derivation from the data and every user entry outranks it.
+    """
+    cm = ConfigManager(
+        {"lens.Lens.t_0": {"initval": 2455000.0}},
+        system_config=_PSPL_CONFIG,
+    )
+    cm.add_seed_hints([{"lens.0.t_0": 2459999.0}])
+    cm.finalize_user_params()
+
+    assert cm._last_resolved["lens.0.t_0"] == pytest.approx(2455000.0)
+    assert cm._last_provenance["lens.0.t_0"] == RANK_USER
+
+
+def test_seed_hint_beats_a_default_and_lands_at_derived_data_rank():
+    """
+    Given no user entry for lens.Lens.t_0,
+    When a seed hint supplies one,
+    Then it is used, at RANK_DERIVED_DATA -- above defaults.yaml, below any
+    user entry.
+    """
+    cm = ConfigManager({}, system_config=_PSPL_CONFIG)
+    cm.add_seed_hints([{"lens.0.t_0": 2459999.0}])
+    cm.finalize_user_params()
+
+    assert cm._last_resolved["lens.0.t_0"] == pytest.approx(2459999.0)
+    assert cm._last_provenance["lens.0.t_0"] == RANK_DERIVED_DATA
+
+
+def test_seed_hint_conflicting_with_a_user_entry_is_not_over_constrained():
+    """
+    Given a user lens.Lens.s and an MMEXOFAST seed for lens.0.log_s that
+    disagrees (they are two coordinates for one fact, tied by s = 10**log_s),
+    When the engine runs,
+    Then no "over-constrained" contradiction is raised: the seed is not a
+    user statement, so the relation is resolved in the user's favor -- s
+    keeps its value and log_s is back-solved from it.
+    """
+    cm = ConfigManager(
+        {"lens.Lens.s": {"initval": 1.5}}, system_config=_BINARY_CONFIG
+    )
+    cm.add_seed_hints([{"lens.0.log_s": float(np.log10(2.5))}])
+    cm.finalize_user_params()
+
+    assert not [
+        d for d in cm.diagnostics if "Over-constrained" in d["message"]
+    ]
+    assert cm._last_resolved["lens.0.s"] == pytest.approx(1.5)
+    assert cm._last_resolved["lens.0.log_s"] == pytest.approx(
+        np.log10(1.5), rel=1e-3
+    )
+
+
+def test_user_initval_list_still_outranks_a_seed_hint_per_seed():
+    """
+    Given both a per-seed user initval LIST and a seed hint set for the same
+    path,
+    When the K seeds are solved,
+    Then each seed starts at the user's element for that seed -- splitting the
+    two sources into separate rank channels must not lose the list's priority.
+    """
+    cm = ConfigManager(
+        {"lens.Lens.t_0": {"initval": [2455000.0, 2455010.0]}},
+        system_config=_PSPL_CONFIG,
+    )
+    cm.add_seed_hints([{"lens.0.t_0": 2459999.0}, {"lens.0.t_0": 2459998.0}])
+    cm.finalize_user_params()
+
+    assert cm.seed_resolved is not None and len(cm.seed_resolved) == 2
+    assert cm.seed_resolved[0]["lens.0.t_0"] == pytest.approx(2455000.0)
+    assert cm.seed_resolved[1]["lens.0.t_0"] == pytest.approx(2455010.0)
+
+
+def test_seed_hints_still_vary_the_start_across_seeds():
+    """
+    Given seed hints only (the ordinary MMEXOFAST case: no user entry),
+    When the K seeds are solved,
+    Then each seed lands on its own hint value -- the demotion to
+    RANK_DERIVED_DATA must not collapse the seeds onto one start.
+    """
+    cm = ConfigManager({}, system_config=_PSPL_CONFIG)
+    cm.add_seed_hints([{"lens.0.t_0": 2459999.0}, {"lens.0.t_0": 2459888.0}])
+    cm.finalize_user_params()
+
+    assert cm.seed_resolved is not None and len(cm.seed_resolved) == 2
+    assert cm.seed_resolved[0]["lens.0.t_0"] == pytest.approx(2459999.0)
+    assert cm.seed_resolved[1]["lens.0.t_0"] == pytest.approx(2459888.0)
+
+
+def test_seed_hints_do_not_change_the_mmexofast_auto_trigger():
+    """
+    Given a params file whose entries make the microlensing observables
+    derivable,
+    When probe_derivable is asked (the MMEXOFAST auto-trigger's question),
+    Then the answer is unchanged by the presence of seed hints: the probe
+    reads user_params only, and its test is provenance > RANK_DEFAULT, which
+    RANK_DERIVED_DATA (60) satisfies anyway.  Getting this wrong re-runs the
+    fitter on every restart.
+    """
+    params = {
+        "lens.Lens.t_0": {"initval": 2460000.0},
+        "lens.Lens.u_0": {"initval": 0.5},
+        "lens.Lens.t_E": {"initval": 25.0},
+    }
+    paths = ["lens.0.t_0", "lens.0.u_0", "lens.0.t_E"]
+
+    cm = ConfigManager(dict(params), system_config=_PSPL_CONFIG)
+    before = cm.probe_derivable(paths)
+
+    cm2 = ConfigManager(dict(params), system_config=_PSPL_CONFIG)
+    cm2.add_seed_hints([{"lens.0.t_0": 2459999.0}])
+    after = cm2.probe_derivable(paths)
+
+    assert before == set(paths)
+    assert after == before

--- a/tests/test_mmexofast_support.py
+++ b/tests/test_mmexofast_support.py
@@ -28,7 +28,7 @@ class _RecordingConfigManager:
     def add_scale_hint(self, path, scale):
         self.scale_hints[path] = scale
 
-    def add_seed_hints(self, seed_dicts, rank=None):
+    def add_seed_hints(self, seed_dicts):
         self.seed_hint_sets = seed_dicts
 
 

--- a/tests/test_multiseed_mmexofast.py
+++ b/tests/test_multiseed_mmexofast.py
@@ -31,7 +31,6 @@ class _RecordingConfigManager:
         self.system_config = system_config or {}
         self.user_params = user_params or {}
         self.seed_hint_sets = []
-        self.seed_hint_rank = None
         self.scale_hints = {}
 
     def add_hint(self, *args, **kwargs):
@@ -40,10 +39,8 @@ class _RecordingConfigManager:
     def add_scale_hint(self, path, scale):
         self.scale_hints[path] = scale
 
-    def add_seed_hints(self, seed_dicts, rank=None):
+    def add_seed_hints(self, seed_dicts):
         self.seed_hint_sets = seed_dicts
-        if rank is not None:
-            self.seed_hint_rank = rank
 
 
 def _make_binary_lens(mmexofast_path, finite_source=True):


### PR DESCRIPTION
All three items from section 2.1 (config / linking).

## 2.1.1 -- standalone solver overwrote user values

Reproduced: `orbit.b.m_total: {initval: 5.0}` against a body-mass sum of 1.001 resolved to `1.001`, provenance downgraded **100 -> 40**, with `_last_solved_by` crediting the standalone solver.

`_run_standalone_solvers` wrote its target unconditionally. Unlike the equation path (`_attempt_solve`, which rewrites the *lowest*-ranked symbol), nothing compared provenance -- `_meaningful_change` compares values, not ranks. Now skips a path already held above `RANK_DERIVED_MIXED`, so the docstring's claim ("user values and data-derived hints always win") is enforced rather than asserted. Paths at <= 40, including the solver's own previous answer, still re-fire as inputs refine.

**Siblings checked**: `orbit.m_total` is the only standalone solver; the other two custom solvers run inside `_execute_solve`, which is already rank-guarded.

## 2.1.2 -- MMEXOFAST seed hints now enter at RANK_DERIVED_DATA

Per the user's decision: MMEXOFAST is a very fancy derivation from data, not a user statement, so it gets rank 60 rather than a privileged tier.

Both consequences reproduced first: a seed `lens.0.t_0` overwrote a user scalar `lens.Lens.t_0`; a user `lens.Lens.s: 1.5` plus a seeded `lens.0.log_s` printed `Over-constrained relation 'lens.0.s = 10**lens.0.log_s'`.

Cause: `_build_seed_overrides` merged seeds and user initval lists into one dict passed as `user_provided_params`, which stamps everything `RANK_USER`. They are now separate channels -- the engine takes a new `seed_hints=` argument and layers it at `RANK_DERIVED_DATA` beside `self.hints`. Both symptoms gone: the user scalar survives at rank 100, and `log_s` is back-solved from the user's `s` with no diagnostic.

**On the rank tie** (seeds now sit at the same rank as ordinary component hints): the seed layer runs after the component-hint layer with a `<=` guard, so a seed wins a tie -- deliberate, since a per-seed fit of the actual light curve beats a generic guess pushed for every seed alike. In practice **no real path is in both channels today**: seeds carry `lens.0.{t_0,u_0,t_E,rho,log_s,alpha,q}`, the only component hint touching any of those is `lens.0.alpha` at rank **20**, and the `errfacs` -> `err_scale` hints are on a disjoint path. No new rank needed.

**Auto-trigger verified**, since getting this wrong would re-run MMEXOFAST on every restart: `probe_derivable` builds its snapshot from `user_params` only (seeds are pushed at stage 2, after the stage-1a trigger) and tests provenance `> RANK_DEFAULT`, which 60 satisfies. Pinned by a test asserting identical before/after trigger sets.

**Dead scaffolding removed**: `self.seed_hint_rank` and `add_seed_hints`'s `rank=` parameter (set in two places, read nowhere). **`RANK_DERIVED_USER` was KEPT** -- contrary to my expectation it is not dead: the engine uses it as the cap in `min(RANK_DERIVED_USER, min_input_rank)` at two sites, and for link-Jacobian scale provenance.

## 2.1.3 -- a typo'd instance name silently dropped the user's prior

Reproduced: `star.Aa.teff` with value+mu+sigma was stored verbatim and `resolve("star","teff",element=0)` returned the defaults.yaml `5778.0` with `sigma: None` -- the prior vanished with zero diagnostics. Only unknown *component* prefixes raised.

`standardize_param_names` now raises `STRICT NAMING ERROR` in the existing style, naming the component's instances plus the index and broadcast alternatives. `canonical_param_key` is untouched -- it is also the lookup helper behind `ConfigManager.canonical_key` (used by `run._user_initval`) and must stay total.

**Scoping discovery, caught by `test_examples_prepare.py`** (added earlier today -- it failed 3 examples against a first, stricter version): the legal-name universe is **every `name:` declared anywhere in the config**, not the addressed component's own list. Two shipped spellings need that width:
- `lens.SourceA.t_0` (`examples/ob161003`) addresses element *j* of the lens's per-source vectors by the *source star's* name, while the lens block has one entry named `Lens`. Per-element `names` are a manifest option resolved at stage 2, unavailable at ConfigManager construction.
- `mann.B.ks_offset` -- ConfigManager is built before the component loop, and `Mann.__init__` is what derives `name:` from `star:`.

Numeric index forms and flat-dict components remain pass-through.

## One behavior change that needs a look

`examples/kelt4/kelt4.params.yaml` and `kelt4_sed.params.yaml` carried `rvinstrument.EXPERT/FIES.jitter_variance` bounds while both configs have EXPERT and FIES **commented out** of their `rvinstrument:` block. Those entries were dead -- exactly the silent drop being fixed -- so they are now commented out to match, alongside the `#inst.TRES.jitter_variance` block the author had already commented the same way. `kelt4_rv+transit+sed.yaml` does define both instruments, so its params file is unchanged.

## Tests

New `tests/test_config_provenance.py`, 14 tests. **Pre-fix: 6 fail, 8 pass** -- the 8 passers are must-not-break guards (solver still fires without a user value, seeds still vary across seeds, user initval lists still win per seed, and the numeric/named/flat-dict/borrowed-name spellings all still resolve). No existing assertion weakened; the only edits to existing tests were dropping the now-nonexistent `rank=None` from two `add_seed_hints` stubs.

| Suite | Result |
|---|---|
| `test_config_provenance` | 14 passed |
| `test_mmexofast_support`, `test_multiseed_mmexofast`, `test_mkprior_multiseed` | 30 passed |
| `test_config_healing/units/multiseed_config/multiseed_system/hierarchical_orbit/bad_user_input/inspect_start` | 54 passed |
| `test_examples_prepare` | 20 passed |
| `test_linked_params/nsnl/log_s/mann/torres/overrides/mkparam` | 97 passed |
| `test_astrometry/gui_document/gui_tune/introspect/evaluator/solve_api/integration_kelt4` | 83 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)