### PR TITLE
config: sort component discovery so start values cannot depend on the filesystem

### DIFF
--- a/scripts/diag_mulens.py
+++ b/scripts/diag_mulens.py
@@ -1,0 +1,179 @@
+"""Compare the DC2018_128 mulens start values and logp across two machines.
+
+Diagnostic for the class of bug fixed in #92: the relaxation engine inverts an
+underdetermined system to build microlensing start values (see #93), so two
+machines could resolve the same config into two different physical models.  The
+raw point is FIXED (the test's ``GOOD_RAW``), so any divergence in the physical
+block localizes the cause.
+
+Run on both machines from anywhere and diff the two outputs:
+
+    poetry run python scripts/diag_mulens.py > diag_$(hostname).txt
+
+Prints, in order: environment and versions, every resolved initval and
+init_scale, every parameter's physical value at ``GOOD_RAW``, and the mulens
+residual summary (chi2, per-time-bin z, worst points).
+"""
+
+import importlib.metadata as md
+import importlib.util
+import os
+import platform
+import shutil
+import socket
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytensor
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_DIR = REPO_ROOT / "examples" / "DC2018_128"
+TEST_FILE = REPO_ROOT / "tests" / "test_runaway_logp_regression.py"
+
+from exozippy.system import System  # noqa: E402
+
+
+def _load_pinned_point():
+    """Import GOOD_RAW / GOOD_EXPECTED_LP from the test that pins them.
+
+    Loaded by path rather than by adding tests/ to sys.path, so this script
+    works from any cwd and does not shadow anything named like a test module.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_runaway_logp_regression", TEST_FILE
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.GOOD_RAW, module.GOOD_EXPECTED_LP
+
+
+def _fmt(a, prec=8):
+    a = np.atleast_1d(np.asarray(a, dtype=float)).ravel()
+    return np.array2string(a[:4], precision=prec, floatmode="maxprec")
+
+
+def main():
+    good_raw, expected_lp = _load_pinned_point()
+
+    print("=" * 78)
+    print("ENVIRONMENT")
+    print("=" * 78)
+    print(f"  host          {socket.gethostname()}")
+    print(f"  python        {sys.version.split()[0]}")
+    print(f"  platform      {platform.platform()}")
+    print(f"  glibc         {platform.libc_ver()}")
+    for pkg in (
+        "numpy", "scipy", "pytensor", "pymc", "vbmicrolensing", "astropy",
+        "sympy", "exoplanet-core", "celerite2", "numba",
+    ):
+        try:
+            print(f"  {pkg:<13} {md.version(pkg)}")
+        except Exception:
+            print(f"  {pkg:<13} MISSING")
+    print(f"  blas__ldflags {pytensor.config.blas__ldflags!r}")
+    print(f"  pytensor cxx  {pytensor.config.cxx!r}")
+    print(f"  GOOD_EXPECTED_LP (pinned in the test) = {expected_lp}")
+
+    work = Path(tempfile.mkdtemp()) / "DC2018_128"
+    shutil.copytree(
+        EXAMPLE_DIR,
+        work,
+        ignore=shutil.ignore_patterns("fitresults", ".#*", "#*#"),
+    )
+    orig = os.getcwd()
+    os.chdir(work)
+    try:
+        with open("DC2018_128.yaml") as f:
+            config = yaml.safe_load(f)
+        with open("DC2018_128.params.yaml") as f:
+            user_params = yaml.safe_load(f)
+        # The pinned draws were recorded under linear planet mass; a lens body
+        # now defaults to log_q, and the raw values do not carry across.
+        for entry in config.get("planet", []):
+            entry.setdefault("mass_parameterization", "linear")
+
+        system = System(config, user_params)
+        system.prepare()
+        model = system.build_model()
+        point = {k: np.asarray(v, dtype=float) for k, v in good_raw.items()}
+
+        total = float(np.asarray(model.compile_logp()(point)))
+        print(f"  TOTAL logp at GOOD_RAW = {total:.4f}")
+
+        params = system.get_all_parameters()
+
+        print()
+        print("=" * 78)
+        print("RESOLVED initval / init_scale / bounds  (stage 3 output)")
+        print("=" * 78)
+        for p in params:
+            iv = "SYMBOLIC" if hasattr(p.initval, "owner") else _fmt(p.initval)
+            sc = "None" if p.init_scale is None else _fmt(p.init_scale, 6)
+            lo = "None" if p.lower is None else _fmt(p.lower, 6)
+            up = "None" if p.upper is None else _fmt(p.upper, 6)
+            print(f"  {p.label:<38s} iv={iv} sc={sc} lo={lo} up={up}")
+
+        print()
+        print("=" * 78)
+        print("PHYSICAL value of every parameter at GOOD_RAW")
+        print("=" * 78)
+        labels, nodes = [], []
+        for p in params:
+            v = getattr(p, "value", None)
+            if isinstance(v, pytensor.graph.basic.Variable):
+                labels.append(p.label)
+                nodes.append(v)
+        exprs = model.replace_rvs_by_values(nodes)
+        fn = pytensor.function(model.value_vars, exprs, on_unused_input="ignore")
+        vals = fn(*[point[vv.name] for vv in model.value_vars])
+        for lab, val in zip(labels, vals):
+            print(f"  {lab:<38s} {_fmt(val)}")
+
+        print()
+        print("=" * 78)
+        print("MULENS RESIDUALS at GOOD_RAW")
+        print("=" * 78)
+        obs = [v for v in model.observed_RVs if "mulens" in v.name][0]
+        ins = obs.owner.inputs
+        mu, sigma = ins[-2], ins[-1]
+        data = np.asarray(obs.tag.observations.eval(), dtype=float).ravel()
+        e = model.replace_rvs_by_values([mu, sigma])
+        f2 = pytensor.function(model.value_vars, e, on_unused_input="ignore")
+        mu_v, sig_v = [
+            np.asarray(a, dtype=float).ravel()
+            for a in f2(*[point[vv.name] for vv in model.value_vars])
+        ]
+        inst = next(
+            c for c in system.get_all_components()
+            if c.prefix == "mulensinstrument"
+        )
+        t = np.asarray(inst.time, dtype=float).ravel()
+        r = data - mu_v
+        z = r / sig_v
+        print(f"  N={data.size}  chi2={np.sum(z**2):.2f}  "
+              f"chi2/N={np.sum(z**2) / data.size:.3f}")
+        print(f"  data  min={data.min():.6f} max={data.max():.6f} "
+              f"mean={data.mean():.6f}")
+        print(f"  model min={mu_v.min():.6f} max={mu_v.max():.6f} "
+              f"mean={mu_v.mean():.6f}")
+        print(f"  sigma min={sig_v.min():.6f} med={np.median(sig_v):.6f} "
+              f"max={sig_v.max():.6f}")
+        print(f"  resid mean={r.mean():+.6f} std={r.std():.6f}  "
+              f"z mean={z.mean():+.4f} std={z.std():.4f}")
+        print("  per-bin (sorted by time, 8 equal bins):")
+        for b in np.array_split(np.argsort(t), 8):
+            print(f"    t=[{t[b].min():.2f},{t[b].max():.2f}] n={b.size:4d} "
+                  f"mean_z={z[b].mean():+9.3f} max|z|={np.abs(z[b]).max():9.2f}")
+        print("  worst 8 points:")
+        for i in np.argsort(-np.abs(z))[:8]:
+            print(f"    t={t[i]:.5f} data={data[i]:+.6f} model={mu_v[i]:+.6f} "
+                  f"sig={sig_v[i]:.6f} z={z[i]:+.2f}")
+    finally:
+        os.chdir(orig)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diag_rotation.py
+++ b/scripts/diag_rotation.py
@@ -1,0 +1,183 @@
+"""Is the DC2018_128 light curve blind to the DIRECTION of mu_rel?
+
+Companion to diag_mulens.py, for the underdetermined-seeding issue (#93).
+
+The relaxation engine seeds microlensing start values by inverting an
+underdetermined system: the MMEXOFAST seed carries no pi_E, so splitting the
+known ``mu_rel_mag`` into ``(mu_ra_rel, mu_dec_rel)`` is one equation in two
+unknowns.  The engine picks a point on that circle.  The natural objection is
+that a genuinely degenerate family should give the SAME light curve, which
+would make any choice safe.
+
+This script tests that.  It builds the model twice with the lens proper motion
+rotated 90 degrees -- holding ``|mu_rel|`` fixed, so both builds sit in the same
+family -- and evaluates both at the SEED (raw = 0), so no pinned raw offsets
+confound the comparison.
+
+    poetry run python scripts/diag_rotation.py
+
+Measured on DC2018_128: ``|mu_rel|`` identical to seven digits, but chi2 differs
+by ~77 over 870 points, because (a) ``mu_rel_geo = mu_rel_helio -`` an Earth
+velocity term is a vector subtraction and so is not rotationally symmetric,
+moving ``t_E``; and (b) ``pi_E`` is parallel to ``mu_rel``, so the rotation
+rotates the parallax vector, which annual parallax makes observable.
+
+Caveat when reading the absolute chi2: MMEXOFAST fits with pi_E = 0, so its
+seeded t_E/u_0/t_0 describe a no-parallax model, while this model applies a
+derived pi_E of order 0.2.  The seed is therefore not expected to reproduce
+MMEXOFAST's chi2, and chi2/N > 1 here is not evidence of a bug on its own.
+"""
+
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytensor
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_DIR = REPO_ROOT / "examples" / "DC2018_128"
+TEST_FILE = REPO_ROOT / "tests" / "test_runaway_logp_regression.py"
+
+from exozippy.system import System  # noqa: E402
+
+# The defaults.yaml proper motion, and the offset the engine derives on top of
+# it.  mu_rel = lens_pm - source_pm, so pinning all four components explicitly
+# is the only way to guarantee the two builds differ by a pure rotation: pinning
+# just one lets the engine re-derive the other and |mu_rel| drifts (measured:
+# 11.411 vs 11.616, a 1.8% contamination of the comparison).
+DEFAULT = -3.0
+OFFSET = -11.4113305      # == the engine's -14.4113305 hint minus DEFAULT
+
+
+def _pin(mu_ra, mu_dec):
+    """Pin both stars' proper motions so mu_rel is exactly (mu_ra, mu_dec)."""
+    return {
+        "star.0.pm_ra": {"initval": DEFAULT + mu_ra},
+        "star.0.pm_dec": {"initval": DEFAULT + mu_dec},
+        "star.1.pm_ra": {"initval": DEFAULT},
+        "star.1.pm_dec": {"initval": DEFAULT},
+    }
+
+REPORT = (
+    "lens.mu_ra_rel", "lens.mu_dec_rel", "lens.mu_rel_mag",
+    "lens.mu_rel_geo_mag", "lens.t_E", "lens.theta_E",
+    "lens.pi_E_N", "lens.pi_E_E",
+)
+
+
+def _good_raw():
+    spec = importlib.util.spec_from_file_location(
+        "_runaway_logp_regression", TEST_FILE
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.GOOD_RAW
+
+
+def build_and_measure(label, overrides, good_raw):
+    work = Path(tempfile.mkdtemp()) / "DC2018_128"
+    shutil.copytree(
+        EXAMPLE_DIR, work,
+        ignore=shutil.ignore_patterns("fitresults", ".#*", "#*#"),
+    )
+    cwd = os.getcwd()
+    os.chdir(work)
+    try:
+        with open("DC2018_128.yaml") as f:
+            config = yaml.safe_load(f)
+        with open("DC2018_128.params.yaml") as f:
+            user_params = yaml.safe_load(f)
+        for entry in config.get("planet", []):
+            entry.setdefault("mass_parameterization", "linear")
+        user_params.update(overrides)
+
+        system = System(config, user_params)
+        system.prepare()
+        model = system.build_model()
+
+        # Evaluate at the SEED: raw = 0 everywhere.
+        point = {
+            k: np.zeros_like(np.asarray(v, dtype=float))
+            for k, v in good_raw.items()
+        }
+        total = float(np.asarray(model.compile_logp()(point)))
+
+        params = {p.label: p for p in system.get_all_parameters()}
+        labels, nodes = [], []
+        for name in REPORT:
+            node = getattr(params.get(name), "value", None)
+            if isinstance(node, pytensor.graph.basic.Variable):
+                labels.append(name)
+                nodes.append(node)
+        fn = pytensor.function(
+            model.value_vars,
+            model.replace_rvs_by_values(nodes),
+            on_unused_input="ignore",
+        )
+        raw_args = [point[vv.name] for vv in model.value_vars]
+        vals = {
+            k: float(np.asarray(v, dtype=float).ravel()[0])
+            for k, v in zip(labels, fn(*raw_args))
+        }
+
+        obs = [v for v in model.observed_RVs if "mulens" in v.name][0]
+        ins = obs.owner.inputs
+        f2 = pytensor.function(
+            model.value_vars,
+            model.replace_rvs_by_values([ins[-2], ins[-1]]),
+            on_unused_input="ignore",
+        )
+        mu_v, sig_v = [
+            np.asarray(a, dtype=float).ravel() for a in f2(*raw_args)
+        ]
+        data = np.asarray(obs.tag.observations.eval(), dtype=float).ravel()
+        chi2 = float(np.sum(((data - mu_v) / sig_v) ** 2))
+
+        print(f"\n--- {label} ---")
+        for k in labels:
+            print(f"    {k:<24s} {vals[k]:+.6f}")
+        mag = float(np.hypot(vals["lens.mu_ra_rel"], vals["lens.mu_dec_rel"]))
+        print(f"    |mu_rel| from components  {mag:.6f}")
+        print(f"    chi2 = {chi2:.2f}   chi2/N = {chi2 / data.size:.3f}")
+        print(f"    total logp = {total:.4f}")
+        return mag, chi2
+
+
+    finally:
+        os.chdir(cwd)
+
+
+def main():
+    good_raw = _good_raw()
+    a_mag, a_chi2 = build_and_measure(
+        "A: mu_rel entirely in RA", _pin(OFFSET, 0.0), good_raw
+    )
+    b_mag, b_chi2 = build_and_measure(
+        "B: mu_rel entirely in Dec (rotated 90 deg)",
+        _pin(0.0, OFFSET),
+        good_raw,
+    )
+
+    print("\n=== VERDICT ===")
+    print(f"  |mu_rel|:  A={a_mag:.6f}   B={b_mag:.6f}")
+    if abs(a_mag - b_mag) > 1e-6 * max(a_mag, b_mag):
+        print("  -> ABORT: the two builds are not the same family, so the chi2")
+        print("     comparison below would be contaminated.  Fix the pinning.")
+        return
+    print("     (equal, so both builds sit in the same family)")
+    print(f"  chi2    :  A={a_chi2:.2f}   B={b_chi2:.2f}   "
+          f"delta={abs(a_chi2 - b_chi2):.2f}")
+    if abs(a_chi2 - b_chi2) > 1.0:
+        print("  -> the light curve DISTINGUISHES members of the family;")
+        print("     an arbitrary choice is not safe.")
+    else:
+        print("  -> the light curve is blind to the direction.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -412,7 +412,20 @@ class ConfigManager:
 
         components_dir = Path(__file__).parent / "components"
 
-        for py_file in components_dir.rglob("symbolic_physics.py"):
+        # Sorted: rglob yields entries in filesystem directory order, which is
+        # stable on one machine but differs between machines (ext4's hashed
+        # btree vs xfs/NFS), so it survives PYTHONHASHSEED randomization and
+        # looks perfectly reproducible until you compare two boxes.  This order
+        # sets all_relations order, which sets the order the relaxation engine
+        # visits equations, which decides WHICH member of a symmetric pair it
+        # solves for -- e.g. mu_rel_mag**2 = mu_ra_rel**2 + mu_dec_rel**2 and
+        # pi_rel = KAPPA*m*(pi_E_N**2 + pi_E_E**2) are both symmetric under
+        # swapping the pair, so nothing in the equation itself breaks the tie.
+        # Unsorted, an Ubuntu 26.04 box transposed (pm_ra, pm_dec),
+        # (mu_ra_rel, mu_dec_rel) and (pi_E_N, pi_E_E) relative to a RHEL8 box:
+        # t_E came out 11.54 d instead of 18.29 d and DC2018_128's logp at the
+        # pinned GOOD_RAW went -945.57 -> -113614.65.
+        for py_file in sorted(components_dir.rglob("symbolic_physics.py")):
             module_name = (
                 f"exozippy.components.{py_file.parent.name}.symbolic_physics"
             )
@@ -482,7 +495,12 @@ class ConfigManager:
                             if rel_inst not in self.all_relations:
                                 self.all_relations.append(rel_inst)
 
-        for defaults_file in components_dir.rglob("defaults.yaml"):
+        # Sorted for the same reason as the symbolic_physics walk above.  No
+        # root-level key is currently defined by two components (a test pins
+        # that), so today this is future-proofing rather than a live fix --
+        # _deep_merge is last-writer-wins, so the first such collision would
+        # otherwise resolve by walk order.
+        for defaults_file in sorted(components_dir.rglob("defaults.yaml")):
             with open(defaults_file, "r") as f:
                 comp_defaults = yaml.safe_load(f) or {}
                 self._deep_merge(self.base_defaults, comp_defaults)
@@ -2604,7 +2622,10 @@ class ConfigManager:
     def _attempt_rank_upgrade(
         self, eq, resolved, provenance, resolved_scales, scale_provenance
     ):
-        symbols_in_eq = [str(s) for s in eq.free_symbols]
+        # Sorted for the same reason as _execute_solve's walk: free_symbols is a
+        # set of Symbols whose hashes include the PYTHONHASHSEED-randomized name
+        # string, so bare iteration order varies per process.
+        symbols_in_eq = sorted(str(s) for s in eq.free_symbols)
 
         def get_rank(s):
             return provenance.get(s, RANK_DEFAULT)
@@ -2615,8 +2636,10 @@ class ConfigManager:
             return False
 
         # 2. Identify the target:
-        # Pick the symbol with the lowest provenance.
-        target = min(symbols_in_eq, key=get_rank)
+        # Pick the symbol with the lowest provenance, breaking rank ties
+        # alphabetically -- a bare min() returns the first minimum it meets, so
+        # on tied ranks the winner would follow iteration order.
+        target = min(symbols_in_eq, key=lambda s: (get_rank(s), s))
 
         # 3. Check dependencies: Are all inputs known?
         inputs = [s for s in symbols_in_eq if s != target]

--- a/tests/test_config_discovery_order.py
+++ b/tests/test_config_discovery_order.py
@@ -1,0 +1,189 @@
+"""Component discovery must not depend on filesystem directory order.
+
+``ConfigManager`` finds every ``symbolic_physics.py`` and ``defaults.yaml`` with
+``Path.rglob``, which yields entries in filesystem directory order.  That order
+is stable on one machine but differs between machines (ext4's hashed btree vs
+xfs/NFS), so it survives PYTHONHASHSEED randomization and looks perfectly
+reproducible until two boxes are compared.
+
+It is load-bearing: the walk order sets ``all_relations`` order, which sets the
+order the relaxation engine visits equations, which decides which member of a
+*symmetric* relation pair it solves for.  ``mulensing`` has two such pairs --
+``mu_rel_mag**2 = mu_ra_rel**2 + mu_dec_rel**2`` and
+``pi_rel = KAPPA*m*(pi_E_N**2 + pi_E_E**2)`` -- and nothing in either equation
+breaks the tie.  Unsorted, an Ubuntu 26.04 box transposed ``(pm_ra, pm_dec)``,
+``(mu_ra_rel, mu_dec_rel)`` and ``(pi_E_N, pi_E_E)`` relative to a RHEL8 box:
+``t_E`` came out 11.54 d instead of 18.29 d and DC2018_128's logp at the pinned
+``GOOD_RAW`` moved -945.57 -> -113614.65, i.e. two different physical models
+from one config.
+
+These tests simulate a differently-ordered filesystem by reversing ``rglob``.
+"""
+
+import copy
+import pathlib
+
+import yaml
+
+from exozippy.config import ConfigManager
+
+EXAMPLE_DIR = pathlib.Path(__file__).parent / ".." / "examples" / "DC2018_128"
+COMPONENTS_DIR = (
+    pathlib.Path(__file__).parent / ".." / "src" / "exozippy" / "components"
+)
+
+
+def _dc2018_128_inputs():
+    with open(EXAMPLE_DIR / "DC2018_128.yaml") as f:
+        config = yaml.safe_load(f)
+    with open(EXAMPLE_DIR / "DC2018_128.params.yaml") as f:
+        user_params = yaml.safe_load(f)
+    return config, user_params
+
+
+def _reverse_rglob(monkeypatch):
+    """Make every Path.rglob yield its results in the opposite order."""
+    real_rglob = pathlib.Path.rglob
+
+    def reversed_rglob(self, pattern, *args, **kwargs):
+        return iter(list(real_rglob(self, pattern, *args, **kwargs))[::-1])
+
+    monkeypatch.setattr(pathlib.Path, "rglob", reversed_rglob)
+
+
+def test_relation_order_is_independent_of_filesystem_walk_order(monkeypatch):
+    """
+    Given a filesystem that yields component files in the opposite order,
+    When ConfigManager assembles its relation list,
+    Then the list is identical to the normally-discovered one.
+    """
+    # Arrange
+    config, user_params = _dc2018_128_inputs()
+    reference = [
+        str(rel)
+        for rel in ConfigManager(
+            copy.deepcopy(user_params), copy.deepcopy(config)
+        ).all_relations
+    ]
+    assert reference, "expected DC2018_128 to instantiate some relations"
+
+    # Act
+    _reverse_rglob(monkeypatch)
+    shuffled = [
+        str(rel)
+        for rel in ConfigManager(
+            copy.deepcopy(user_params), copy.deepcopy(config)
+        ).all_relations
+    ]
+
+    # Assert
+    assert shuffled == reference
+
+
+def test_defaults_merge_is_independent_of_filesystem_walk_order(monkeypatch):
+    """
+    Given a filesystem that yields defaults.yaml files in the opposite order,
+    When ConfigManager merges them into base_defaults,
+    Then the merged result is unchanged.
+    """
+    # Arrange
+    config, user_params = _dc2018_128_inputs()
+    reference = ConfigManager(
+        copy.deepcopy(user_params), copy.deepcopy(config)
+    ).base_defaults
+
+    # Act
+    _reverse_rglob(monkeypatch)
+    shuffled = ConfigManager(
+        copy.deepcopy(user_params), copy.deepcopy(config)
+    ).base_defaults
+
+    # Assert
+    assert shuffled == reference
+
+
+def test_no_root_level_default_key_has_two_owners():
+    """
+    Given every component defaults.yaml,
+    When their root-level keys are collected,
+    Then no key is defined by more than one file.
+
+    _deep_merge is last-writer-wins, so a key with two owners would resolve by
+    walk order.  Sorting makes that deterministic, but a collision is still
+    almost certainly a mistake -- components/defaults.yaml is the intended home
+    for genuinely shared root-level defaults.
+    """
+    # Arrange / Act
+    owners = {}
+    for path in sorted(COMPONENTS_DIR.rglob("defaults.yaml")):
+        with open(path) as f:
+            block = yaml.safe_load(f) or {}
+        for key in block:
+            owners.setdefault(key, []).append(path.parent.name)
+
+    # Assert
+    clashes = {k: v for k, v in owners.items() if len(v) > 1}
+    assert not clashes, f"root-level default keys with multiple owners: {clashes}"
+
+
+def test_rank_upgrade_tie_break_is_alphabetical():
+    """
+    Given two symbols in one relation that tie on provenance rank,
+    When _attempt_rank_upgrade picks its target,
+    Then it takes the alphabetically first, not the first iterated.
+
+    A bare min() returns the first minimum it encounters, so on a tie the
+    winner would follow set-iteration order (PYTHONHASHSEED-randomized).
+    """
+    # Arrange
+    import sympy as sp
+
+    from exozippy.config import RANK_DEFAULT
+
+    config, user_params = _dc2018_128_inputs()
+    cm = ConfigManager(copy.deepcopy(user_params), copy.deepcopy(config))
+
+    a_name, b_name = "lens.0.pi_E_E", "lens.0.pi_E_N"
+    a, b = sp.Symbol(a_name), sp.Symbol(b_name)
+    cm.master_symbol_map.setdefault(a_name, a)
+    cm.master_symbol_map.setdefault(b_name, b)
+    provenance = {a_name: RANK_DEFAULT, b_name: RANK_DEFAULT}
+
+    class _StubEq:
+        """free_symbols in deliberately non-alphabetical order.
+
+        A real Eq hands back a set, whose order is randomized per process --
+        which would make this test pass or fail by luck.  Pinning the order
+        makes the unsorted implementation fail every time.
+        """
+
+        free_symbols = (b, a)
+
+    # The method bails at its dependency check (nothing is resolved), but only
+    # after choosing a target, so spy on the selection.
+    real_min = min
+    seen = []
+
+    def spy_min(iterable, **kwargs):
+        items = list(iterable)
+        result = real_min(items, **kwargs)
+        seen.append((items, result))
+        return result
+
+    import builtins
+
+    orig = builtins.min
+    builtins.min = spy_min
+    try:
+        # Act
+        cm._attempt_rank_upgrade(_StubEq(), {}, provenance, {}, {})
+    finally:
+        builtins.min = orig
+
+    # Assert
+    assert seen, "expected _attempt_rank_upgrade to select a target"
+    candidates, target = seen[0]
+    assert candidates == sorted(candidates), (
+        f"symbols were not sorted before selection: {candidates}"
+    )
+    assert target == min(a_name, b_name)


### PR DESCRIPTION
## The bug

`ConfigManager` discovered every `symbolic_physics.py` and `defaults.yaml` with `Path.rglob`, which yields entries in **filesystem directory order**:

| | radish (RHEL8) | WSL2 / Ubuntu 26.04 (ext4) |
|---|---|---|
| `symbolic_physics.py` | transit, mulensing, planet, orbit, sed | **sed, planet, transit, mulensing, orbit** |

That order sets `all_relations` order, which sets the order the relaxation engine visits equations, which decides **which member of a symmetric relation pair it solves for**. `mulensing` has two such pairs, and nothing in either equation breaks the tie:

```python
sp.Eq(mu_rel_mag**2, mu_ra_rel**2 + mu_dec_rel**2)                 # symbolic_physics.py:158
sp.Eq(pi_rel, KAPPA * lens_mass_total * (pi_E_N**2 + pi_E_E**2))   # symbolic_physics.py:171
```

So the two machines **transposed three pairs** of start values:

| initval | radish | WSL |
|---|---|---|
| `star.pm_ra` | **-14.4113305** | -3.0 |
| `star.pm_dec` | -3.0 | **-14.4113305** |
| `lens.mu_ra_rel` | **-11.4113305** | `4.7e-125` |
| `lens.mu_dec_rel` | 0.0 | **-11.4113305** |
| `lens.pi_E_N` | 0.0 | **-0.22019125** |
| `lens.pi_E_E` | **-0.22019125** | 0.0 |

**The core defect: the start values a fit begins from depended on the filesystem.** That is indefensible regardless of how large the resulting difference is.

## How big is the difference, honestly

Two numbers, and they are very different -- worth separating, because the first one on its own overstates the severity.

**At the seed: Delta chi2 ~ 77.** The two arrangements are a pure 90 degree rotation with `|mu_rel|` identical to seven digits (11.411331), so they are members of one family. `scripts/diag_rotation.py` evaluates both at `raw = 0`:

| | mu_rel in RA | rotated 90 deg |
|---|---|---|
| \|mu_rel\| helio | 11.411331 | 11.411331 |
| \|mu_rel\| **geo** | 11.309388 | 11.489481 |
| `t_E` | 18.334 d | 18.047 d |
| `pi_E` (N, E) | (-0.0015, -0.2202) | (-0.2202, +0.0020) |
| chi2 (870 pts) | 1239.21 | 1316.05 |

The family is **not** degenerate -- so an arbitrary pick is not safe -- for two reasons: `mu_rel_geo = mu_rel_helio -` an Earth velocity term is a *vector* subtraction and so is not rotationally symmetric, which moves `t_E`; and `pi_E` is parallel to `mu_rel`, so the rotation rotates the parallax vector, which annual parallax makes observable.

**At the pinned test point: Delta chi2 ~ 225,000** (logp -945.57 vs -113614.65, failing `test_runaway_logp_regression` on one machine while CI stayed green). This is the *regression test amplifying* the above: `GOOD_RAW` offsets recorded under one arrangement get applied to transposed initvals, so the physical vectors stop being a pure rotation and `|mu_rel|` becomes 18.27 vs 28.88.

So: a real seeding difference of Delta chi2 ~ 77, amplified by a pinned-raw-point test into a 225,000 gap. Earlier drafts of this description said "two different physical models from one config"; that overstates it and has been corrected here.

## Why it hid

Filesystem order is stable *per machine*, so it survives `PYTHONHASHSEED` randomization -- the wrong logp reproduced to four decimals across 5 seeds and 2 commits. It is only visible when two boxes are compared, which CI never does. The codebase had already been bitten by the hash-seed variant of this class of bug (see the comment at `_execute_solve`'s walk about "the July-2026 init_scale flakiness"); this is the filesystem-order variant.

## Changes

1. `sorted()` on both `rglob` walks.
2. `_attempt_rank_upgrade`: sort its `free_symbols` walk and give `min()` an alphabetical tie-break, matching the hardening `_execute_solve` already had. A bare `min()` returns the first minimum it meets, so tied ranks followed set-iteration order. This one *is* genuinely `PYTHONHASHSEED`-dependent. It is **not** implicated in the failure above (it is never called for those equations) and is fixed here as its own hazard.
3. `scripts/diag_mulens.py` -- the cross-machine start-value diff that caught this.
4. `scripts/diag_rotation.py` -- the degeneracy test behind the Delta chi2 ~ 77 figure.

## Tests

`tests/test_config_discovery_order.py` simulates a differently-ordered filesystem by reversing `rglob`. Verified by reverting the fix -- **2 of the 4 fail deterministically without it**:

- `test_relation_order_is_independent_of_filesystem_walk_order` (the bug) -- FAILS without fix
- `test_rank_upgrade_tie_break_is_alphabetical` (fix 2) -- FAILS without fix
- `test_defaults_merge_is_independent_of_filesystem_walk_order` -- passes either way; a guard
- `test_no_root_level_default_key_has_two_owners` -- a pin, not a regression test

That last one is why the `defaults.yaml` sort is honest future-proofing rather than a live fix: no root-level key currently has two owners, so `_deep_merge`'s last-writer-wins ordering is not yet observable. The comment in the diff says so.

The tie-break test uses a stub whose `free_symbols` order is pinned non-alphabetically. With a real `sp.Eq` (a set) it would have failed only ~half the time without the fix.

## Verification

- `test_runaway_logp_regression` passes; WSL now reproduces radish exactly: logp **-945.5716** (pinned -945.5716), chi2 **8662.26** (radish 8662.26), and all three pairs identical.
- Full suite on WSL: **1260 passed, 3 failed**. All 3 pass in isolation; they are memory-pressure timeouts from WSL2's default 50%-of-host RAM, unrelated to this change.

## What this does NOT fix

The choice is now **consistent, not correct**. The MMEXOFAST seed carries no `pi_E`, so the engine is still inverting an underdetermined system and still puts the whole magnitude in one component with (numerically) zero in the other. Tracked in #93, where the agreed direction is to seed the direction from the galactic model's expected proper motion. Note also that MMEXOFAST fits with `pi_E = 0`, so its seeded `t_E`/`u_0`/`t_0` describe a no-parallax model -- the seed is not expected to reproduce its chi2, and chi2/N > 1 there is not by itself a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)