### PR TITLE
getdata: make -u actually reblend, and stop silently downloading nothing (review 2.5.4, 2.5.7)

### DIFF
--- a/src/exozippy/utilities/getdata.py
+++ b/src/exozippy/utilities/getdata.py
@@ -19,6 +19,8 @@ import glob
 import os
 import sys
 
+import numpy as np
+
 
 def build_parser():
     """Return the argparse parser for the getdata utility."""
@@ -81,40 +83,166 @@ def build_parser():
     return parser
 
 
+def tic_contamination_ratio(target_id, verbose=False):
+    """Return the TIC-8.2 contamination ratio Rcont for ``target_id``.
+
+    Rcont = (flux from contaminating neighbors) / (flux from the target),
+    measured in the TIC's own fixed aperture. Returns 0.0 when the TIC has
+    no contamination entry for the star. Only used as a fallback when the
+    light curve itself does not carry CROWDSAP (see crowding_fraction).
+    """
+    # this feature probably won't be used often. don't make it a
+    # dependency if not used
+    from astroquery.vizier import Vizier
+
+    v = Vizier(
+        columns=["TIC", "Ncont", "Rcont", "_r"], catalog="IV/39/tic82"
+    ).query_object(target_id)[0]
+    ndx = np.argmin(v["_r"])
+    v = v[ndx]
+
+    if str(v["Rcont"]) == "--":
+        if verbose:
+            print("No contamination listed in the TIC for " + str(target_id))
+        return 0.0
+
+    if verbose:
+        print(
+            "TIC lists "
+            + str(v["Ncont"])
+            + " contaminating stars (Rcont = "
+            + str(v["Rcont"])
+            + ")"
+        )
+    return float(v["Rcont"])
+
+
+def crowding_fraction(lc, contratio=0.0):
+    """Return (crowdsap, source) for a light curve about to be re-blended.
+
+    CROWDSAP is the fraction of the flux in the photometric aperture that
+    belongs to the target. The SPOC/PDC pipeline used exactly this number to
+    subtract the contaminating flux, so taking it from the light curve's own
+    header is the exact inverse of the correction we are undoing (it is
+    per-sector and measured for the aperture actually used, unlike the TIC's
+    single all-sky number).
+
+    When the header does not carry it -- older products, QLP and other
+    non-SPOC pipelines, or a light curve that has already been un-corrected
+    -- fall back on the TIC contamination ratio, which is the same quantity
+    in a different form: Rcont = F_contam / F_target, so
+
+        crowdsap = F_target / (F_target + F_contam) = 1 / (1 + Rcont)
+
+    FLFRCSAP (the fraction of the target's flux that lands inside the
+    aperture) is deliberately unused: the pipeline divides the flux by it,
+    and a multiplicative constant cancels exactly under normalization.
+
+    Returns (1.0, "none") when there is nothing to undo.
+    """
+    meta = getattr(lc, "meta", None) or {}
+    raw = None
+    for key in ("CROWDSAP", "crowdsap"):
+        if key in meta:
+            raw = meta[key]
+            break
+
+    if raw is not None:
+        try:
+            crowdsap = float(raw)
+        except (TypeError, ValueError):
+            crowdsap = np.nan
+        if np.isfinite(crowdsap) and 0.0 < crowdsap <= 1.0:
+            return crowdsap, "CROWDSAP"
+        print(
+            "WARNING: ignoring unusable CROWDSAP = "
+            + str(raw)
+            + " in the light curve header"
+        )
+
+    if contratio > 0.0:
+        print(
+            "WARNING: no usable CROWDSAP in the light curve header; falling "
+            "back on the TIC contamination ratio (Rcont = "
+            + str(contratio)
+            + "), which was measured in the TIC aperture, not this "
+            "pipeline's"
+        )
+        return 1.0 / (1.0 + contratio), "Rcont"
+
+    print(
+        "WARNING: no CROWDSAP in the light curve header and no TIC "
+        "contamination ratio -- leaving the light curve as delivered "
+        "(no deblending undone)"
+    )
+    return 1.0, "none"
+
+
+def reblend_lightcurve(lc, crowdsap):
+    """Put back the contaminating flux the pipeline subtracted.
+
+    SPOC/PDC removes crowding *additively*, then divides by the aperture
+    throughput (Kepler Data Processing Handbook, KSCI-19081):
+
+        F_pdc = (F_sap - (1 - CROWDSAP) * median(F_sap)) / FLFRCSAP
+
+    Taking the median of both sides gives
+
+        median(F_sap) = FLFRCSAP * median(F_pdc) / CROWDSAP
+
+    and substituting back inverts the correction exactly:
+
+        F_sap = FLFRCSAP * (F_pdc + (1 - CROWDSAP)/CROWDSAP * median(F_pdc))
+
+    The FLFRCSAP factor is a constant, so it cancels under normalize(); the
+    additive term does not. In normalized units the whole operation is
+
+        f_blended = CROWDSAP * f + (1 - CROWDSAP)
+
+    so a transit of undiluted depth d comes back at depth CROWDSAP * d, and
+    the errors scale by CROWDSAP with it (the transit S/N is unchanged).
+    That dilution is the whole point of the -u flag: the fit then models it
+    with its own dilution parameter.
+
+    The old code multiplied the flux by the constant (1 + Rcont) instead,
+    which normalize() divided straight back out -- a no-op that left users
+    with undiluted depths while their file said otherwise.
+    """
+    if not np.isfinite(crowdsap) or crowdsap <= 0.0 or crowdsap > 1.0:
+        raise ValueError("crowdsap must be in (0, 1]; got " + repr(crowdsap))
+    if crowdsap == 1.0:
+        # no contaminating flux in the aperture: nothing to put back
+        return lc
+
+    median = np.nanmedian(np.asarray(lc.flux.value, dtype=float))
+    if not np.isfinite(median) or median <= 0.0:
+        raise ValueError(
+            "cannot undo deblending: the median flux is "
+            + repr(median)
+            + ", so the contaminating flux level is undefined"
+        )
+
+    excess = (1.0 - crowdsap) / crowdsap * median
+    unit = getattr(lc.flux, "unit", None)
+    if unit is not None:
+        excess = excess * unit
+    return lc + excess
+
+
 def run(args):
     """Download and write light curves for the parsed argparse namespace."""
     import lightkurve as lk
-    import numpy as np
 
-    # undo the deblending applied to TESS/Kepler lightcurves
+    # undo the deblending applied to TESS/Kepler lightcurves.
+    # contratio is None for a lightcurve that must be left as delivered;
+    # otherwise it is the TIC contamination ratio, used only as a fallback
+    # when the lightcurve header has no CROWDSAP.
     if args.undeblend:
-        # this feature probably won't be used often. don't make it a dependency if not used
-        from astroquery.vizier import Vizier
-
-        v = Vizier(
-            columns=["TIC", "Ncont", "Rcont", "_r"], catalog="IV/39/tic82"
-        ).query_object(args.id)[0]
-        ndx = np.argmin(v["_r"])
-        v = v[ndx]
-
-        if str(v["Rcont"]) == "--":
-            if args.verbose:
-                print("No deblending to undo")
-            og_contratio = 0.0
-        else:
-            if args.verbose:
-                print(
-                    "Undoing deblending for "
-                    + str(v["Ncont"])
-                    + " stars ("
-                    + str(v["Rcont"])
-                    + ")"
-                )
-            og_contratio = float(v["Rcont"])
+        og_contratio = tic_contamination_ratio(args.id, verbose=args.verbose)
         file_ext = ".undeblended.dat"
     else:
         file_ext = ".dat"
-        contratio = 0.0
+        contratio = None
 
     t0 = datetime.datetime(2000, 1, 1)
     jd0 = 2451544.5
@@ -160,10 +288,17 @@ def run(args):
         pass
     else:
         if len(unique_ids) > 1 and "TIC" in args.id:
-            match = np.where(search_results.target_name == args.id[3:])
-            if len(match) > 0:
-                search_results = search_results[match]
-                unique_ids = list(set(search_results.target_name))
+            match = np.where(search_results.target_name == args.id[3:])[0]
+            if len(match) == 0:
+                raise ValueError(
+                    "No light curves match the requested TIC ID "
+                    + args.id
+                    + ". The search returned these target names: "
+                    + ", ".join(sorted(str(u) for u in unique_ids))
+                    + ". Specify the target by one of those TIC IDs."
+                )
+            search_results = search_results[match]
+            unique_ids = list(set(search_results.target_name))
 
         if len(unique_ids) > 1:
             print("Multiple IDs match " + args.id)
@@ -266,7 +401,7 @@ def run(args):
             filter = "Kepler"
             telescope = "Kepler"
             if args.undeblend:
-                contratio = 0.0
+                contratio = None
                 file_ext = ".dat"
                 print(
                     "WARNING: undeblending not supported for Kepler -- ignoring -u option"
@@ -283,7 +418,7 @@ def run(args):
             filter = "Kepler"
             telescope = "Kepler"
             if args.undeblend:
-                contratio = 0.0
+                contratio = None
                 file_ext = ".dat"
                 print(
                     "WARNING: undeblending not supported for Kepler -- ignoring -u option"
@@ -333,7 +468,21 @@ def run(args):
 
         lc = search_result.download()
         lc = lc.remove_nans()
-        lc *= 1.0 + contratio
+        if contratio is not None:
+            # must happen before normalize(): the correction is additive,
+            # and normalize() would divide any multiplicative one back out
+            crowdsap, source = crowding_fraction(lc, contratio)
+            lc = reblend_lightcurve(lc, crowdsap)
+            if crowdsap < 1.0:
+                print(
+                    "Undoing deblending of "
+                    + sector
+                    + " with crowdsap = "
+                    + "%.6f" % crowdsap
+                    + " (from "
+                    + source
+                    + "); transit depths are diluted by that factor"
+                )
         lc = lc.normalize()
 
         time = np.array(lc.time.value) + bjd_offset

--- a/tests/test_getdata.py
+++ b/tests/test_getdata.py
@@ -1,0 +1,327 @@
+"""Tests for the getdata download utility.
+
+No network access: lightkurve's search is monkeypatched with a fake search
+result whose "downloads" are synthetic light curves built in memory, and the
+TIC contamination lookup is monkeypatched with a constant.
+"""
+
+import lightkurve as lk
+import numpy as np
+import pytest
+from astropy.table import Row, Table
+
+from exozippy.utilities import getdata
+
+TRUE_DEPTH = 0.01  # undiluted (deblended) transit depth
+BJD_OFFSET = 2457000.0
+
+
+def make_lightcurve(depth=TRUE_DEPTH, meta=None, n=400):
+    """Return a synthetic PDCSAP-like TESS light curve with one box transit."""
+    time = np.linspace(1500.0, 1510.0, n)
+    flux = np.full(n, 1000.0)
+    flux[(time > 1504.9) & (time < 1505.1)] *= 1.0 - depth
+    err = np.full(n, 1.0)
+    return lk.LightCurve(time=time, flux=flux, flux_err=err, meta=meta or {})
+
+
+class FakeSearchResult:
+    """The slice of lightkurve's SearchResult API that getdata.run() uses.
+
+    Backed by an astropy Table so that indexing (including the tuple that
+    np.where returns) behaves exactly as it does in lightkurve.
+    """
+
+    def __init__(self, table, lightcurves):
+        self.table = table
+        self.lightcurves = lightcurves
+
+    def __len__(self):
+        return len(self.table)
+
+    def __getitem__(self, key):
+        selection = self.table[key]
+        if isinstance(selection, Row):
+            selection = Table(selection)
+        return FakeSearchResult(selection, self.lightcurves)
+
+    def __iter__(self):
+        for i in range(len(self.table)):
+            yield self[i]
+
+    @property
+    def target_name(self):
+        return self.table["target_name"].data
+
+    @property
+    def mission(self):
+        return self.table["mission"].data
+
+    @property
+    def author(self):
+        return self.table["author"].data
+
+    @property
+    def exptime(self):
+        return self.table["exptime"].quantity
+
+    def download(self, *args, **kwargs):
+        return self.lightcurves[int(self.table["lcindex"][0])]
+
+
+def make_search_result(target_names, lightcurves):
+    """One SPOC 120 s TESS sector per entry of target_names."""
+    n = len(target_names)
+    table = Table(
+        {
+            "target_name": np.array([str(t) for t in target_names]),
+            "mission": np.array(
+                ["TESS Sector %02d" % (i + 1) for i in range(n)]
+            ),
+            "author": np.array(["SPOC"] * n),
+            "exptime": np.full(n, 120.0),
+            "lcindex": np.arange(n),
+        }
+    )
+    table["exptime"].unit = "s"
+    return FakeSearchResult(table, lightcurves)
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Install fakes for the two network calls; return a config dict."""
+    state = {
+        "target_names": ["375506058"],
+        "lightcurves": [make_lightcurve()],
+        "contratio": 0.0,
+    }
+
+    def fake_search(target_id, **kwargs):
+        return make_search_result(state["target_names"], state["lightcurves"])
+
+    monkeypatch.setattr(lk, "search_lightcurve", fake_search)
+    monkeypatch.setattr(
+        getdata,
+        "tic_contamination_ratio",
+        lambda target_id, verbose=False: state["contratio"],
+    )
+    return state
+
+
+def written_depth(path, pattern):
+    """Return 1 - min(flux) from the single file matching pattern."""
+    import glob
+
+    files = sorted(glob.glob(str(path / pattern)))
+    assert len(files) == 1, "expected one file matching %s, got %r" % (
+        pattern,
+        files,
+    )
+    data = np.loadtxt(files[0])
+    return 1.0 - data[:, 1].min()
+
+
+# ---------------------------------------------------------------- 2.5.4
+
+
+def test_undeblend_dilutes_the_depth_by_crowdsap(patched, tmp_path):
+    """
+    Given a light curve whose header says CROWDSAP = 0.8,
+    When getdata runs with -u,
+    Then the written transit depth is 0.8 x the undiluted depth.
+    """
+    # Arrange
+    crowdsap = 0.8
+    patched["lightcurves"] = [make_lightcurve(meta={"CROWDSAP": crowdsap})]
+    args = getdata.build_parser().parse_args(
+        ["TIC375506058", "-u", "-n", "-1", "-p", str(tmp_path)]
+    )
+
+    # Act
+    getdata.run(args)
+
+    # Assert
+    depth = written_depth(tmp_path, "*.undeblended.dat")
+    assert depth == pytest.approx(crowdsap * TRUE_DEPTH, rel=1e-9)
+
+
+def test_without_undeblend_the_depth_is_unchanged(patched, tmp_path):
+    """
+    Given the same CROWDSAP = 0.8 light curve,
+    When getdata runs without -u,
+    Then the written depth is the pipeline's undiluted depth.
+    """
+    # Arrange
+    patched["lightcurves"] = [make_lightcurve(meta={"CROWDSAP": 0.8})]
+    args = getdata.build_parser().parse_args(
+        ["TIC375506058", "-n", "-1", "-p", str(tmp_path)]
+    )
+
+    # Act
+    getdata.run(args)
+
+    # Assert
+    depth = written_depth(tmp_path, "*.SPOC.dat")
+    assert depth == pytest.approx(TRUE_DEPTH, rel=1e-9)
+
+
+def test_undeblend_falls_back_to_the_tic_contamination_ratio(
+    patched, tmp_path
+):
+    """
+    Given a light curve with no CROWDSAP but a TIC Rcont of 0.25,
+    When getdata runs with -u,
+    Then the depth is diluted by 1 / (1 + Rcont).
+    """
+    # Arrange
+    patched["lightcurves"] = [make_lightcurve()]
+    patched["contratio"] = 0.25
+
+    args = getdata.build_parser().parse_args(
+        ["TIC375506058", "-u", "-n", "-1", "-p", str(tmp_path)]
+    )
+
+    # Act
+    getdata.run(args)
+
+    # Assert
+    depth = written_depth(tmp_path, "*.undeblended.dat")
+    assert depth == pytest.approx(TRUE_DEPTH / 1.25, rel=1e-9)
+
+
+def test_undeblend_without_any_crowding_information_warns_and_proceeds(
+    patched, tmp_path, capsys
+):
+    """
+    Given no CROWDSAP and no TIC contamination,
+    When getdata runs with -u,
+    Then it warns and writes the light curve unchanged.
+    """
+    # Arrange
+    args = getdata.build_parser().parse_args(
+        ["TIC375506058", "-u", "-n", "-1", "-p", str(tmp_path)]
+    )
+
+    # Act
+    getdata.run(args)
+
+    # Assert
+    assert "WARNING: no CROWDSAP" in capsys.readouterr().out
+    depth = written_depth(tmp_path, "*.undeblended.dat")
+    assert depth == pytest.approx(TRUE_DEPTH, rel=1e-9)
+
+
+def test_reblend_uses_the_additive_form(patched):
+    """
+    Given a light curve and a crowding fraction,
+    When reblend_lightcurve is applied,
+    Then flux and error follow f -> C f + (1 - C) once normalized.
+    """
+    # Arrange
+    crowdsap = 0.6
+    lc = make_lightcurve()
+    reference = lc.normalize()
+
+    # Act
+    blended = getdata.reblend_lightcurve(lc, crowdsap).normalize()
+
+    # Assert
+    expected_flux = crowdsap * reference.flux.value + (1.0 - crowdsap)
+    assert np.allclose(blended.flux.value, expected_flux, rtol=1e-12)
+    assert np.allclose(
+        blended.flux_err.value,
+        crowdsap * reference.flux_err.value,
+        rtol=1e-12,
+    )
+
+
+def test_reblend_rejects_an_out_of_range_crowding_fraction():
+    """
+    Given a crowding fraction outside (0, 1],
+    When reblend_lightcurve is called,
+    Then it raises rather than applying a wrong correction.
+    """
+    # Arrange
+    lc = make_lightcurve()
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="crowdsap must be in"):
+        getdata.reblend_lightcurve(lc, 1.5)
+
+
+def test_crowding_fraction_prefers_the_header_over_the_tic(patched):
+    """
+    Given both a CROWDSAP header and a TIC contamination ratio,
+    When crowding_fraction is asked,
+    Then it returns the header value.
+    """
+    # Arrange
+    lc = make_lightcurve(meta={"CROWDSAP": 0.75, "FLFRCSAP": 0.62})
+
+    # Act
+    crowdsap, source = getdata.crowding_fraction(lc, contratio=0.25)
+
+    # Assert
+    assert crowdsap == pytest.approx(0.75)
+    assert source == "CROWDSAP"
+
+
+def test_crowding_fraction_ignores_an_unusable_header_value(patched, capsys):
+    """
+    Given a nonsensical CROWDSAP,
+    When crowding_fraction is asked,
+    Then it warns and falls back on the TIC contamination ratio.
+    """
+    # Arrange
+    lc = make_lightcurve(meta={"CROWDSAP": -1.0})
+
+    # Act
+    crowdsap, source = getdata.crowding_fraction(lc, contratio=0.25)
+
+    # Assert
+    assert "WARNING: ignoring unusable CROWDSAP" in capsys.readouterr().out
+    assert crowdsap == pytest.approx(1.0 / 1.25)
+    assert source == "Rcont"
+
+
+# ---------------------------------------------------------------- 2.5.7
+
+
+def test_zero_match_tic_id_raises(patched, tmp_path):
+    """
+    Given a TIC ID that matches none of the returned target names,
+    When getdata runs,
+    Then it raises naming the targets that were found, and writes nothing.
+    """
+    # Arrange
+    patched["target_names"] = ["375506058", "99999999"]
+    patched["lightcurves"] = [make_lightcurve(), make_lightcurve()]
+    args = getdata.build_parser().parse_args(
+        ["TIC12345678", "-n", "-1", "-p", str(tmp_path)]
+    )
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="No light curves match"):
+        getdata.run(args)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_matching_tic_id_still_selects_its_light_curves(patched, tmp_path):
+    """
+    Given a TIC ID that does match one of several target names,
+    When getdata runs,
+    Then only that target's light curve is written.
+    """
+    # Arrange
+    patched["target_names"] = ["375506058", "99999999"]
+    patched["lightcurves"] = [make_lightcurve(), make_lightcurve(depth=0.05)]
+    args = getdata.build_parser().parse_args(
+        ["TIC375506058", "-n", "-1", "-p", str(tmp_path)]
+    )
+
+    # Act
+    getdata.run(args)
+
+    # Assert
+    depth = written_depth(tmp_path, "*.SPOC.dat")
+    assert depth == pytest.approx(TRUE_DEPTH, rel=1e-9)


### PR DESCRIPTION
## 2.5.4 -- `-u/--undeblend` was a no-op, i.e. a silent scientific error

Reproduced at the `run()` level with a synthetic PDCSAP-like light curve (undiluted depth 0.01, `CROWDSAP = 0.8`, TIC `Rcont = 0.25`): pre-fix, `-u` wrote `depth = 0.010000000000000009` -- **bit-identical to the run without `-u`**. `lc *= (1.0 + contratio)` followed by `lc.normalize()` divides the constant straight back out.

**Direction of the flag**, since it inverts the harm: PDCSAP is *already* deblended, so `-u` exists to put the blend **back**, handing the fit a diluted light curve that its own dilution parameter models. So users of `-u` were getting **undiluted** depths in a file named `.undeblended.dat`.

### The algebra

SPOC/PDC removes crowding additively, then divides by aperture throughput (KSCI-19081; `CROWDSAP` = target's share of flux in the aperture, `FLFRCSAP` = target's flux captured by it):

```
F_pdc = (F_sap - (1 - CROWDSAP) * median(F_sap)) / FLFRCSAP
```

Taking the median of both sides gives `median(F_sap) = FLFRCSAP * median(F_pdc) / CROWDSAP`, and substituting back inverts it exactly:

```
F_sap = FLFRCSAP * (F_pdc + (1 - CROWDSAP)/CROWDSAP * median(F_pdc))
```

`FLFRCSAP` is a constant and cancels under `normalize()` -- **which is exactly why no multiplicative form can ever work** -- while the additive term does not. In normalized units the whole operation is

```
f_blended = CROWDSAP * f + (1 - CROWDSAP)
```

so depth `d -> CROWDSAP * d`, with errors scaling by `CROWDSAP` too (transit S/N unchanged, as it must be). The TIC contamination ratio is the same quantity in another form: `crowdsap = 1/(1 + Rcont)`, so `Rcont = 0.25` gives `0.01 -> 0.008`.

### Changes

- `reblend_lightcurve(lc, crowdsap)` -- additive, applied **before** `normalize()` (the loop was `download -> remove_nans -> *= -> normalize`; the multiply is replaced in place). Raises on a crowdsap outside `(0, 1]` or a non-positive median.
- `crowding_fraction(lc, contratio)` -- prefers the light curve's **own per-sector `CROWDSAP`** header (the aperture actually used) over the TIC's single all-sky number; falls back to `1/(1 + Rcont)` **with a warning**; with neither, **warns and leaves the light curve as delivered**. Warn-and-proceed rather than raise, because "no known contaminants" is a legitimate outcome and delivering the pipeline product unchanged is the correct non-destructive answer -- but it is now loud, where before it was indistinguishable from a real correction. An unusable header value is warned about and ignored rather than trusted.
- `FLFRCSAP` deliberately unused (it cancels) -- documented in the docstring.
- The Vizier lookup moved into `tic_contamination_ratio()` (mockable, no behavior change). `contratio = None` means "leave alone", preserving the existing Kepler/K2 opt-out.

## 2.5.7 -- `len(np.where(...)) > 0` is always true

`np.where(...)` returns a 1-tuple, so `len(...) == 1` regardless. Pre-fix, a TIC ID matching none of the returned target names **returned normally, wrote no files, and printed nothing** -- the user believes they downloaded data. Now indexes `[0]` and raises `ValueError` naming the target names the search actually returned, so the process exits non-zero.

**Sibling sweep** (AST scan of `src/`): this was the only single-argument `np.where` assigned without `[0]`. Every other hit is the three-argument select form, which returns an array.

## EXOFASTv2: both bugs present

`/pool/radish1/scratch/EXOFASTv2/getdata.py` (commit `902d06d2`):

```
125:        match = np.where(search_results.target_name == args.id[3:])
126:        if len(match) > 0:
...
229:    lc *= (1.0 + contratio)
230:    lc = lc.normalize()
```

A ready-to-apply patch is at **`/pool/radish1/claude-tmp-getdata/exofastv2_getdata.patch`** -- nothing in that repo was modified. Dry-run verified: applies cleanly, the result parses, and its `crowding_fraction`/`reblend_lightcurve` return 0.008 for the 0.01/CROWDSAP=0.8 case. It keeps EXOFASTv2's script style (`sys.exit(1)` rather than a raise). Noted in passing, not touched: lines 210-216 there are dead code after a `continue`.

## Tests

`tests/test_getdata.py`, 10 tests, **no network** -- `lk.search_lightcurve` and the TIC lookup are monkeypatched, and "downloads" are in-memory synthetic light curves behind a table-backed fake `SearchResult` so tuple indexing behaves exactly as lightkurve's does. Assertions are on the written depth, not on internals.

Pre-fix verification needed a `run()`-level harness patching what the *old* code calls (the new fixture patches a function that did not exist): `-u` wrote `0.010` where `0.008` is correct, and the zero-match ID "succeeded" having written nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)