### PR TITLE
mkticsed: fix the APASS dedup row, the missing 99 sentinel, and APASS B/V loss when no Tycho source exists (review 2.5.5, 2.5.6)

### DIFF
--- a/src/exozippy/utilities/mkticsed.py
+++ b/src/exozippy/utilities/mkticsed.py
@@ -698,6 +698,12 @@ def mkticsed(
         notes.append("[Fe/H]: no value found; using wide prior N(0, 1)")
 
     # --- 8. Optional: Tycho-2 BT/VT (disabled by default) ---------------------
+    # BT/VT of the *matched* Tycho star, carried into section 9 as the APASS
+    # dedup reference. Reading row 0 instead would compare the target's APASS
+    # photometry against an unrelated star whenever the cone holds more than
+    # one Tycho source.
+    bt_ref = float("nan")
+    vt_ref = float("nan")
     qtyc2 = query_region("I/259/TYC2", tic_ra, tic_dec, dist / 60.0)
     if qtyc2 is not None and len(qtyc2) > 0:
         t_row = 0
@@ -707,6 +713,8 @@ def mkticsed(
         ebt = _get(qtyc2, "e_BTmag", t_row)
         vt = _get(qtyc2, "VTmag", t_row)
         evt = _get(qtyc2, "e_VTmag", t_row)
+        bt_ref = bt
+        vt_ref = vt
         if np.isfinite(bt) and np.isfinite(ebt):
             sed_entries.append(
                 _sed_entry("TYCHO/TYCHO.B", bt, max(0.02, ebt), enabled=tycho)
@@ -715,8 +723,6 @@ def mkticsed(
             sed_entries.append(
                 _sed_entry("TYCHO/TYCHO.V", vt, max(0.02, evt), enabled=tycho)
             )
-    else:
-        qtyc2 = None
 
     # --- 9. Optional: UCAC4 / APASS DR6 (disabled by default) -----------------
     qucac = query_region("UCAC4", tic_ra, tic_dec, dist / 60.0)
@@ -724,8 +730,6 @@ def mkticsed(
         u_row = 0
         if len(qucac) > 1:
             u_row, _ = _nearest(qucac, tic_ra, tic_dec)
-        bt_ref = _get(qtyc2, "BTmag", 0) if qtyc2 is not None else float("nan")
-        vt_ref = _get(qtyc2, "VTmag", 0) if qtyc2 is not None else float("nan")
         B_mag = _get(qucac, "Bmag", u_row)
         eB = _get(qucac, "e_Bmag", u_row)
         V_mag = _get(qucac, "Vmag", u_row)
@@ -736,7 +740,11 @@ def mkticsed(
         er = _get(qucac, "e_rmag", u_row)
         i_mag = _get(qucac, "imag", u_row)
         ei = _get(qucac, "e_imag", u_row)
-        # UCAC4 stores APASS errors as 0.01 mag integers; avoid duplicating Tycho
+        # UCAC4 stores APASS errors as 0.01 mag integers, with 99 as the
+        # catalog's "no data" sentinel -- it must be rejected on every band,
+        # or it survives as a fabricated max(0.02, 99 * 0.01) = 0.99 mag error
+        # on a magnitude that was never measured. Also avoid duplicating the
+        # Tycho photometry the SED already carries.
         if (
             np.isfinite(B_mag)
             and np.isfinite(eB)
@@ -765,19 +773,19 @@ def mkticsed(
                     enabled=ucac,
                 )
             )
-        if np.isfinite(g_mag) and np.isfinite(eg):
+        if np.isfinite(g_mag) and np.isfinite(eg) and eg != 99:
             sed_entries.append(
                 _sed_entry(
                     "SLOAN/SDSS.g", g_mag, max(0.02, eg * 0.01), enabled=ucac
                 )
             )
-        if np.isfinite(r_mag) and np.isfinite(er):
+        if np.isfinite(r_mag) and np.isfinite(er) and er != 99:
             sed_entries.append(
                 _sed_entry(
                     "SLOAN/SDSS.r", r_mag, max(0.02, er * 0.01), enabled=ucac
                 )
             )
-        if np.isfinite(i_mag) and np.isfinite(ei):
+        if np.isfinite(i_mag) and np.isfinite(ei) and ei != 99:
             sed_entries.append(
                 _sed_entry(
                     "SLOAN/SDSS.i", i_mag, max(0.02, ei * 0.01), enabled=ucac

--- a/src/exozippy/utilities/mkticsed.py
+++ b/src/exozippy/utilities/mkticsed.py
@@ -86,6 +86,20 @@ def _gets(table, col, row=0):
         return ""
 
 
+def _is_distinct(mag, ref, tol=0.01):
+    """True if `mag` is a different measurement from the reference `ref`.
+
+    Used to keep a catalog's photometry from entering the SED twice when two
+    catalogs report the same measurement. A non-finite `ref` means the
+    comparison star was never found, so there is nothing to duplicate and the
+    magnitude is kept -- the NaN must not silently vote "drop it", which is
+    what a bare ``abs(mag - ref) > tol`` does.
+    """
+    if not np.isfinite(ref):
+        return True
+    return abs(mag - ref) > tol
+
+
 def _sep(ra1, dec1, ra2, dec2):
     """Angular separation in arcseconds; inf if any coordinate is NaN."""
     if not all(np.isfinite(v) for v in (ra1, dec1, ra2, dec2)):
@@ -749,7 +763,7 @@ def mkticsed(
             np.isfinite(B_mag)
             and np.isfinite(eB)
             and eB != 99
-            and abs(B_mag - bt_ref) > 0.01
+            and _is_distinct(B_mag, bt_ref)
         ):
             sed_entries.append(
                 _sed_entry(
@@ -763,7 +777,7 @@ def mkticsed(
             np.isfinite(V_mag)
             and np.isfinite(eV)
             and eV != 99
-            and abs(V_mag - vt_ref) > 0.01
+            and _is_distinct(V_mag, vt_ref)
         ):
             sed_entries.append(
                 _sed_entry(

--- a/tests/test_mkticsed.py
+++ b/tests/test_mkticsed.py
@@ -266,3 +266,28 @@ def test_apass_bv_sentinel_error_is_skipped(tmp_path, patched_catalogs):
     # Assert
     assert "Generic/Bessell.B" not in rows
     assert "Generic/Bessell.V" not in rows
+
+
+def test_apass_bv_kept_when_no_tycho_source_exists(tmp_path, patched_catalogs):
+    """
+    Given APASS B/V photometry and no Tycho-2 source anywhere in the cone,
+    When mkticsed writes the SED,
+    Then the Bessell B and V rows are written -- with no Tycho counterpart
+      there is nothing to deduplicate against, so the NaN reference must not
+      suppress them (mkticsed.pro uses a -99 sentinel and keeps them).
+    """
+    # Arrange: no "I/259/TYC2" entry at all -> the query returns None.
+    patched_catalogs["UCAC4"] = _ucac_table(bmag=11.0, vmag=10.5)
+
+    # Act
+    rows = _run(tmp_path, priorfile=str(tmp_path / "p.yaml"))
+
+    # Assert
+    assert rows["Generic/Bessell.B"] == (
+        pytest.approx(11.0),
+        pytest.approx(0.03),
+    )
+    assert rows["Generic/Bessell.V"] == (
+        pytest.approx(10.5),
+        pytest.approx(0.03),
+    )

--- a/tests/test_mkticsed.py
+++ b/tests/test_mkticsed.py
@@ -1,0 +1,268 @@
+"""Tests for the mkticsed catalog-to-SED utility.
+
+Every catalog query is monkeypatched with a synthetic astropy Table, so no
+test here touches Vizier, MAST or IRSA. Assertions are on the rows actually
+written into the .sed file, not on module internals.
+"""
+
+import numpy as np
+import pytest
+from astropy.table import Table
+
+from exozippy.utilities import mkticsed as mk
+
+# --- synthetic catalogs -------------------------------------------------------
+
+TARGET_RA = 100.0
+TARGET_DEC = 20.0
+# A contaminant 30" away -- inside the default 120" cone, but not the target.
+OTHER_RA = TARGET_RA + 30.0 / 3600.0 / np.cos(np.radians(TARGET_DEC))
+OTHER_DEC = TARGET_DEC
+
+
+def _tic_table():
+    """One-row TICv8.2 result for TIC 12345678."""
+    return Table(
+        {
+            "TIC": ["12345678"],
+            "Disp": [""],
+            "m_TIC": ["-1"],
+            "RAJ2000": [TARGET_RA],
+            "DEJ2000": [TARGET_DEC],
+            "Mass": [1.0],
+            "Rad": [1.0],
+            "Teff": [5800.0],
+            "[M/H]": [0.0],
+            "e_[M/H]": [0.08],
+            "E_B-V": [0.01],
+            "s_E_B-V": [0.01],
+            "GAIA": ["999"],
+            "_2MASS": ["j2m"],
+            "WISEA": ["wise"],
+            "TYC": ["1234-5678-1"],
+        }
+    )
+
+
+def _tycho_table(rows):
+    """Tycho-2 cone result. `rows` = list of (ra, dec, BTmag, VTmag) tuples."""
+    return Table(
+        {
+            "RAmdeg": [r[0] for r in rows],
+            "DEmdeg": [r[1] for r in rows],
+            "BTmag": [r[2] for r in rows],
+            "e_BTmag": [0.03] * len(rows),
+            "VTmag": [r[3] for r in rows],
+            "e_VTmag": [0.03] * len(rows),
+        }
+    )
+
+
+def _ucac_table(bmag=11.0, vmag=10.5, eg=3.0, er=3.0, ei=3.0):
+    """One-row UCAC4/APASS cone result centered on the target.
+
+    UCAC4 stores the APASS errors as hundredths of a magnitude; 99 is the
+    catalog's "no data" sentinel.
+    """
+    return Table(
+        {
+            "RAJ2000": [TARGET_RA],
+            "DEJ2000": [TARGET_DEC],
+            "Bmag": [bmag],
+            "e_Bmag": [3.0],
+            "Vmag": [vmag],
+            "e_Vmag": [3.0],
+            "gmag": [10.8],
+            "e_gmag": [eg],
+            "rmag": [10.3],
+            "e_rmag": [er],
+            "imag": [10.1],
+            "e_imag": [ei],
+        }
+    )
+
+
+@pytest.fixture
+def patched_catalogs(monkeypatch):
+    """Route every network call through a dict of synthetic tables.
+
+    Yields the dict; tests fill in the catalogs they care about and every
+    other catalog resolves to None (not found).
+    """
+    catalogs = {}
+
+    def fake_query_id(catalog, target_id):
+        return catalogs.get(catalog)
+
+    def fake_query_region(catalog, ra, dec, radius_arcmin):
+        return catalogs.get(catalog)
+
+    monkeypatch.setattr(mk, "query_id", fake_query_id)
+    monkeypatch.setattr(mk, "query_region", fake_query_region)
+    monkeypatch.setattr(mk, "schlegel_av", lambda ra, dec: 0.5)
+
+    catalogs["IV/39/tic82"] = _tic_table()
+    return catalogs
+
+
+# --- .sed reader --------------------------------------------------------------
+
+
+def _read_sed_rows(path):
+    """Parse a written .sed YAML into {band_name: (mag, err)} for live rows.
+
+    Commented-out (disabled) entries are deliberately excluded -- they are not
+    part of the fit.
+    """
+    rows = {}
+    name = None
+    entry = {}
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- name:"):
+            if name is not None:
+                rows[name] = (entry.get("mag"), entry.get("err"))
+            name = stripped.split(":", 1)[1].strip().strip('"')
+            entry = {}
+        elif name is not None and stripped.startswith(("mag:", "err:")):
+            field, val = stripped.split(":", 1)
+            entry[field.strip()] = float(val)
+    if name is not None:
+        rows[name] = (entry.get("mag"), entry.get("err"))
+    return rows
+
+
+def _run(tmp_path, **kwargs):
+    """Run mkticsed into tmp_path and return the parsed .sed rows."""
+    mk.mkticsed(
+        ticid="12345678",
+        star_name="Host",
+        outpath=str(tmp_path),
+        ucac=True,
+        tycho=True,
+        **kwargs,
+    )
+    return _read_sed_rows(tmp_path / "12345678.sed")
+
+
+# --- 2.5.5: APASS-vs-Tycho dedup must use the matched Tycho row ---------------
+
+
+def test_apass_dedup_uses_matched_tycho_row_not_row_zero(
+    tmp_path, patched_catalogs
+):
+    """
+    Given a Tycho cone whose row 0 is a 30" contaminant and whose *matched*
+      (nearest) row is the target, and an APASS B/V that duplicates the
+      matched star's BT/VT,
+    When mkticsed writes the SED,
+    Then the duplicate APASS B and V rows are dropped (the dedup compared
+      against the matched star, not against row 0).
+    """
+    # Arrange: row 0 = contaminant (BT 15), row 1 = target (BT 11, VT 10.5).
+    patched_catalogs["I/259/TYC2"] = _tycho_table(
+        [
+            (OTHER_RA, OTHER_DEC, 15.0, 14.5),
+            (TARGET_RA, TARGET_DEC, 11.0, 10.5),
+        ]
+    )
+    patched_catalogs["UCAC4"] = _ucac_table(bmag=11.0, vmag=10.5)
+
+    # Act
+    rows = _run(tmp_path, priorfile=str(tmp_path / "p.yaml"))
+
+    # Assert: the Tycho rows are the matched star's, and APASS B/V are deduped.
+    assert rows["TYCHO/TYCHO.B"][0] == pytest.approx(11.0)
+    assert rows["TYCHO/TYCHO.V"][0] == pytest.approx(10.5)
+    assert "Generic/Bessell.B" not in rows
+    assert "Generic/Bessell.V" not in rows
+
+
+def test_apass_kept_when_only_unmatched_tycho_row_duplicates_it(
+    tmp_path, patched_catalogs
+):
+    """
+    Given a Tycho cone whose row 0 is a contaminant that happens to share the
+      APASS B/V magnitudes, while the matched row is a different star,
+    When mkticsed writes the SED,
+    Then the APASS B and V rows survive -- an unrelated star must not suppress
+      the target's photometry.
+    """
+    # Arrange: row 0 = contaminant with the same mags as APASS; row 1 = target.
+    patched_catalogs["I/259/TYC2"] = _tycho_table(
+        [
+            (OTHER_RA, OTHER_DEC, 11.0, 10.5),
+            (TARGET_RA, TARGET_DEC, 15.0, 14.5),
+        ]
+    )
+    patched_catalogs["UCAC4"] = _ucac_table(bmag=11.0, vmag=10.5)
+
+    # Act
+    rows = _run(tmp_path, priorfile=str(tmp_path / "p.yaml"))
+
+    # Assert
+    assert rows["TYCHO/TYCHO.B"][0] == pytest.approx(15.0)
+    assert rows["Generic/Bessell.B"][0] == pytest.approx(11.0)
+    assert rows["Generic/Bessell.V"][0] == pytest.approx(10.5)
+
+
+# --- 2.5.6: the 99 "no data" sentinel must gate g/r/i too ---------------------
+
+
+def test_apass_gri_with_sentinel_error_is_skipped(tmp_path, patched_catalogs):
+    """
+    Given APASS g/r/i whose UCAC4 errors are the 99 "no data" sentinel,
+    When mkticsed writes the SED,
+    Then no SDSS g/r/i rows are written (pre-fix they were written with a
+      fabricated 0.99 mag error).
+    """
+    # Arrange
+    patched_catalogs["UCAC4"] = _ucac_table(eg=99.0, er=99.0, ei=99.0)
+
+    # Act
+    rows = _run(tmp_path, priorfile=str(tmp_path / "p.yaml"))
+
+    # Assert
+    assert "SLOAN/SDSS.g" not in rows
+    assert "SLOAN/SDSS.r" not in rows
+    assert "SLOAN/SDSS.i" not in rows
+
+
+def test_apass_gri_with_real_errors_is_written(tmp_path, patched_catalogs):
+    """
+    Given APASS g/r/i with genuine UCAC4 errors (hundredths of a magnitude),
+    When mkticsed writes the SED,
+    Then the SDSS g/r/i rows are written with those errors -- the sentinel
+      guard must not swallow real data.
+    """
+    # Arrange: 3 hundredths -> 0.03 mag, above the 0.02 floor.
+    patched_catalogs["UCAC4"] = _ucac_table(eg=3.0, er=3.0, ei=5.0)
+
+    # Act
+    rows = _run(tmp_path, priorfile=str(tmp_path / "p.yaml"))
+
+    # Assert
+    assert rows["SLOAN/SDSS.g"] == (pytest.approx(10.8), pytest.approx(0.03))
+    assert rows["SLOAN/SDSS.r"] == (pytest.approx(10.3), pytest.approx(0.03))
+    assert rows["SLOAN/SDSS.i"] == (pytest.approx(10.1), pytest.approx(0.05))
+
+
+def test_apass_bv_sentinel_error_is_skipped(tmp_path, patched_catalogs):
+    """
+    Given APASS B/V errors of 99 and no Tycho counterpart,
+    When mkticsed writes the SED,
+    Then no Bessell B/V rows are written -- the pre-existing B/V sentinel
+      guard is pinned alongside the new g/r/i one.
+    """
+    # Arrange
+    ucac = _ucac_table(bmag=11.0, vmag=10.5)
+    ucac["e_Bmag"] = [99.0]
+    ucac["e_Vmag"] = [99.0]
+    patched_catalogs["UCAC4"] = ucac
+
+    # Act
+    rows = _run(tmp_path, priorfile=str(tmp_path / "p.yaml"))
+
+    # Assert
+    assert "Generic/Bessell.B" not in rows
+    assert "Generic/Bessell.V" not in rows


### PR DESCRIPTION
Two review items plus a third bug found in the same statement. **Nothing under EXOFASTv2 was modified** (verified by md5 and mtime).

## 2.5.5 -- APASS-vs-Tycho dedup read row 0

Fails in *both* directions, and both are pinned:
- the matched Tycho row duplicates the APASS B/V, so the same measurement enters the SED chi2 twice;
- row 0 is an unrelated contaminant that happens to match APASS -> `KeyError: 'Generic/Bessell.B'`, and the target's real photometry is silently dropped.

Fixed by capturing the matched row's BT/VT as `bt_ref`/`vt_ref` in section 8 and carrying them into section 9, so there is no second unsynchronized row index left to get wrong.

**IDL verdict: NOT inherited -- the port introduced it.** `mkticsed.pro:663-668` collapses the array to the matched element before any downstream use:

```idl
   if n_elements(qtyc2) gt 1 then begin
      junk = min(qtyc2._r,m)
      qtyc2=qtyc2[m]
   endif
```

so `qtyc2.btmag` at 691-692 is unambiguously the matched star. The port kept the full table and used `t_row` only locally. **No IDL patch needed.**

**Sibling sweep**: every cross-match (TIC, Gaia DR2/DR3, 2MASS, WISE, Paunzen, Tycho, UCAC, Mermilliod, GALEX) correctly uses its matched row index. The only other literal row-0 read formats a WDS warning string and writes no data.

## 2.5.6 -- missing `!= 99` sentinel on APASS g/r/i

Reproduced exactly as predicted: `{'SLOAN/SDSS.g': (10.8, 0.99), 'SLOAN/SDSS.r': (10.3, 0.99), 'SLOAN/SDSS.i': (10.1, 0.99)}`. 0.99 slips under the `< 1` cut used elsewhere, so nothing downstream catches it. Fixed with the same guard B/V already have.

**IDL verdict: INHERITED.** `mkticsed.pro:693-695` has no sentinel guard, immediately below B/V at 691-692 that do.

**Ready-to-apply patch: `<scratchpad>/mkticsed_exofastv2.patch`**, dry-run verified against both EXOFASTv2 copies (byte-identical, md5 `49814b6...`). It adds the guard to 693-695 and fixes a **bonus IDL-only bug at line 692**: the V row tests `qucac4.bmag gt -9` where it means `vmag`, so a star with a missing APASS B loses its V too. The Python port never had that one.

**Sentinel sweep**: `ne 99` appears only on those two UCAC4 lines in the whole IDL file, so 99 is UCAC4/APASS-specific and g/r/i was the only gap. The other IDL sentinel `gt -9` is covered in Python by `np.isfinite()` -- equivalent, since astroquery returns masked nulls (-> NaN) where `Exofast_Queryvizier` fills -99. Different mechanism, not a bug.

## Third bug, same statement (separate commit `6c50db1`, droppable)

`abs(B_mag - bt_ref) > 0.01` is **False when `bt_ref` is NaN** -- i.e. whenever no Tycho-2 source is in the cone -- so APASS B and V were silently dropped for every such star. Tycho-2 runs out around V ~ 11-12, so **most faint TESS targets lost both optical anchors**, leaving only the g/r/i pair that carried the 2.5.6 junk errors.

Also port-introduced: `mkticsed.pro:672` falls back to `qtyc2={btmag:-99.,vtmag:-99.}`, making the IDL comparison trivially true. Fixed with an `_is_distinct()` helper, in its own commit so it can be dropped independently.

This also revealed that `test_apass_bv_sentinel_error_is_skipped` had been passing for the wrong reason -- the NaN dropped the rows regardless of the sentinel it meant to exercise. It is meaningful now.

## Scope note

Review item 1.8 (deferred to the SED's owner) records that mkticsed writes AB-native SDSS g/r/i rows labelled Vega. Same lines, different and larger issue -- deliberately **not** touched here.

## Tests

`tests/test_mkticsed.py`, 6 tests, fully synthetic astropy Tables with `query_id`/`query_region`/`schlegel_av` monkeypatched -- no network. Assertions are on rows parsed back out of the written `.sed`. Verified failing pre-fix by stashing `src/` (3 for the review items, 1 for the third bug); all 6 pass in 0.30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)