### PR TITLE
rvinstrument: make the per-file unit: key work, and stop absolute-RV offsets poisoning the K seed (review 2.3.1, 2.3.3)

### DIFF
--- a/src/exozippy/components/rvinstrument/rvinstrument.py
+++ b/src/exozippy/components/rvinstrument/rvinstrument.py
@@ -18,7 +18,9 @@ class RVInstrument(Instrument):
     def __init__(self, config, config_manager):
         super().__init__(config, config_manager)
         self.label = "Instrument Parameters"
-        self.units = [c.get("unit", u.m / u.s) for c in self.config]
+        self.units = [
+            self._parse_rv_unit(i, c) for i, c in enumerate(self.config)
+        ]
         # Which star the RVs are of; its Doppler signal is the sum over
         # every orbit that star is a body of (planetary reflex and stellar
         # companions alike).
@@ -44,6 +46,26 @@ class RVInstrument(Instrument):
     @property
     def prefix(self):
         return "rvinstrument"
+
+    def _parse_rv_unit(self, i, entry):
+        """Resolve a file's ``unit:`` key to an astropy Unit.
+
+        The YAML value is a plain string (``unit: km/s``), so it has to go
+        through ``u.Unit`` before ``load_data`` can call ``.to()`` on it --
+        exactly what ``astrometryinstrument`` does for its ``sep_unit``.
+        Anything astropy accepts as a velocity works; the default is m/s.
+        """
+        raw = entry.get("unit", "m/s")
+        name = entry.get("name", i)
+        try:
+            unit = u.Unit(raw)
+            unit.to(u.m / u.s)
+        except Exception as exc:
+            raise ValueError(
+                f"[{self.prefix}] {name}: unit: {raw!r} is not a velocity "
+                f"astropy can parse (e.g. 'm/s', 'km/s', 'km s-1')."
+            ) from exc
+        return unit
 
     @classmethod
     def get_utilities(cls):

--- a/src/exozippy/components/rvinstrument/rvinstrument.py
+++ b/src/exozippy/components/rvinstrument/rvinstrument.py
@@ -169,9 +169,7 @@ class RVInstrument(Instrument):
         self.inst_map = np.concatenate(inst_indices).astype(int)
 
         self.n_total_obs = len(self.time)
-        self.k_init = (
-            ((u.solRad / u.d).to(u.m / u.s)) * np.sqrt(2.0) * np.std(self.rv)
-        )
+        self.k_init = self._estimate_k_init()
 
         # Block Diagonal Matrix (shared builder keeps coeffs per-instrument)
         (
@@ -195,6 +193,52 @@ class RVInstrument(Instrument):
             self.inst_map,
             user_factor=(u.solRad / u.d).to(u.m / u.s),
         )
+
+    def _estimate_k_init(self):
+        """Seed for the planetary RV semi-amplitude, in m/s.
+
+        ``sqrt(2) * std`` is the semi-amplitude of a sinusoid, but only when
+        the scatter it is measured on is the SIGNAL's.  Measured on the raw
+        concatenation of every instrument it is dominated instead by the
+        constant offsets BETWEEN instruments: one absolute-RV instrument
+        sitting at a ~30 km/s systemic velocity next to a relative one seeds
+        ``planet.K`` at ~20 km/s for an m/s-level planet.  So each file's own
+        ``gamma_init`` (its mean, already computed above) is removed first.
+
+        With a single instrument this is identical to the old expression --
+        subtracting a constant does not change a standard deviation.
+
+        Degenerate inputs (one point per file, a file whose RVs are all
+        identical, zero-variance data) leave no scatter to measure at all and
+        would seed K = 0, which the relaxation engine happily turns into a
+        ~1e-20 Mjup planet mass.  There the median error bar -- the white
+        noise level, i.e. the amplitude at the detection limit -- is the
+        honest answer, and 1 m/s the last resort if even that vanishes.
+        """
+        to_ms = (u.solRad / u.d).to(u.m / u.s)
+        gammas = np.asarray(self.gamma_init, dtype=float)
+        residual = self.rv * to_ms - gammas[self.inst_map]
+        k = np.sqrt(2.0) * np.std(residual)
+        if np.isfinite(k) and k > 0.0:
+            return float(k)
+
+        median_err = float(np.median(self.err)) * to_ms
+        if np.isfinite(median_err) and median_err > 0.0:
+            logger.warning(
+                "[%s] the RVs carry no scatter about their per-instrument "
+                "means; seeding K from the median error bar (%.3g m/s) "
+                "instead.",
+                self.prefix,
+                median_err,
+            )
+            return median_err
+
+        logger.warning(
+            "[%s] the RVs carry neither scatter nor usable error bars; "
+            "seeding K at 1 m/s.",
+            self.prefix,
+        )
+        return 1.0
 
     def register_parameters(self, system):
         """Stage 2: Embed data-driven hints into the PyMC manifest."""

--- a/tests/test_rv_unit_and_k_seed.py
+++ b/tests/test_rv_unit_and_k_seed.py
@@ -1,11 +1,18 @@
-"""rvinstrument load_data defects from the 2026-08-08 code review.
+"""Two rvinstrument load_data defects from the 2026-08-08 code review.
 
 2.3.1 -- the per-file ``unit:`` key is documented in ``config_schema`` but
 crashed: the YAML string was stored raw and ``load_data`` then called
 ``.to()`` on it.  ``astrometryinstrument`` handles its ``sep_unit`` correctly
 with ``u.Unit(...)``; rvinstrument now does the same.
 
-This is load-time only, so these tests drive ``RVInstrument.load_data``
+2.3.3 -- ``k_init`` (the seed for ``planet.K``) was ``sqrt(2) * std`` of every
+instrument's RVs concatenated raw.  The scatter that dominates there is the
+constant offset BETWEEN instruments, not any planet's amplitude: a single
+absolute-RV instrument at a ~30 km/s systemic velocity seeded K at ~21 km/s
+for a 20 m/s planet.  Each file's own mean (its ``gamma_init``) is removed
+first now.
+
+Both are load-time only, so these tests drive ``RVInstrument.load_data``
 directly rather than a whole ``System``.
 """
 
@@ -117,3 +124,118 @@ def test_astropy_unit_object_still_accepted(tmp_path):
     f = _write_rv(tmp_path / "a.rv", _T, _RV_MS / 1000.0, _ERR_MS / 1000.0)
     inst = _load([{"name": "A", "file": f, "unit": u.km / u.s}])
     np.testing.assert_allclose(inst.rv * _MS_PER_INTERNAL, _RV_MS, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 2.3.3 -- k_init must not see the offsets between instruments
+# ---------------------------------------------------------------------------
+_T2 = np.linspace(2455000.0, 2455010.0, 41)
+_PLANET_MS = 20.0 * np.sin(2 * np.pi * (_T2 - 2455000.0) / 10.0)
+_GAMMA_ABS_MS = 30000.0  # a 30 km/s absolute-RV instrument
+_TRUE_K = float(np.sqrt(2.0) * np.std(_PLANET_MS))  # 19.7484... m/s
+
+
+@pytest.fixture
+def rv_pair(tmp_path):
+    """One relative-RV file and one at a 30 km/s systemic velocity."""
+    rel = _write_rv(tmp_path / "rel.rv", _T2, _PLANET_MS, np.full(41, 2.0))
+    abs_ = _write_rv(
+        tmp_path / "abs.rv", _T2, _PLANET_MS + _GAMMA_ABS_MS, np.full(41, 2.0)
+    )
+    return rel, abs_
+
+
+def test_single_instrument_k_seed_is_unchanged(rv_pair):
+    """
+    Given a single relative-RV instrument (the control),
+    When it is loaded,
+    Then k_init is sqrt(2)*std of the RVs -- removing a constant mean cannot
+    change a standard deviation, so this case is bit-for-bit as before.
+    """
+    rel, _ = rv_pair
+    inst = _load([{"name": "REL", "file": rel}])
+    assert inst.k_init == pytest.approx(_TRUE_K, rel=1e-12)
+
+
+def test_absolute_rv_instrument_does_not_inflate_k_seed(rv_pair):
+    """
+    Given two instruments observing the same 20 m/s planet, one of them
+    reporting absolute RVs offset by 30 km/s,
+    When they are loaded together,
+    Then k_init still lands at the planet's amplitude (~19.7 m/s) instead of
+    the ~21 km/s the raw concatenated scatter used to give.
+    """
+    rel, abs_ = rv_pair
+
+    inst = _load([{"name": "REL", "file": rel}, {"name": "ABS", "file": abs_}])
+
+    np.testing.assert_allclose(
+        inst.gamma_init, [0.0, _GAMMA_ABS_MS], atol=1e-9
+    )
+    assert inst.k_init == pytest.approx(_TRUE_K, rel=1e-9)
+    # The pre-fix value, for the record: sqrt(2)*std of the raw union.
+    buggy = float(
+        np.sqrt(2.0)
+        * np.std(np.concatenate([_PLANET_MS, _PLANET_MS + _GAMMA_ABS_MS]))
+    )
+    assert buggy > 21000.0
+    assert inst.k_init < 0.01 * buggy
+
+
+def test_k_seed_survives_a_unit_tagged_absolute_instrument(tmp_path):
+    """
+    Given the absolute-RV instrument reported in km/s (both fixes at once),
+    When the pair is loaded,
+    Then the seed is still the planet's amplitude.
+    """
+    rel = _write_rv(tmp_path / "rel.rv", _T2, _PLANET_MS, np.full(41, 2.0))
+    abs_ = _write_rv(
+        tmp_path / "abs.rv",
+        _T2,
+        (_PLANET_MS + _GAMMA_ABS_MS) / 1000.0,
+        np.full(41, 0.002),
+    )
+    inst = _load(
+        [
+            {"name": "REL", "file": rel},
+            {"name": "ABS", "file": abs_, "unit": "km/s"},
+        ]
+    )
+    assert inst.k_init == pytest.approx(_TRUE_K, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 2.3.3 -- degenerate inputs leave no scatter to measure
+# ---------------------------------------------------------------------------
+def test_constant_rvs_fall_back_to_the_median_error(tmp_path):
+    """
+    Given a file whose RVs are all identical,
+    When it is loaded,
+    Then k_init falls back to the median error bar rather than 0 (which the
+    relaxation engine turns into a ~1e-20 Mjup planet).
+    """
+    f = _write_rv(tmp_path / "c.rv", _T2, np.full(41, 5.0), np.full(41, 3.0))
+    assert _load([{"name": "C", "file": f}]).k_init == pytest.approx(3.0)
+
+
+def test_one_point_per_file_falls_back_to_the_median_error(tmp_path):
+    """
+    Given two files of one point each, far apart in absolute RV,
+    When they are loaded,
+    Then the mean-removed residuals are all zero and the median error bar
+    seeds K -- the offset between the two points never leaks in.
+    """
+    a = _write_rv(tmp_path / "a.rv", [2455000.0], [4.0], [2.5])
+    b = _write_rv(tmp_path / "b.rv", [2455001.0], [9000.0], [2.5])
+    inst = _load([{"name": "A", "file": a}, {"name": "B", "file": b}])
+    assert inst.k_init == pytest.approx(2.5)
+
+
+def test_zero_variance_and_zero_errors_fall_back_to_one(tmp_path):
+    """
+    Given constant RVs AND zero error bars,
+    When the file is loaded,
+    Then k_init is a strictly positive last-resort 1 m/s.
+    """
+    f = _write_rv(tmp_path / "z.rv", _T2, np.full(41, 5.0), np.zeros(41))
+    assert _load([{"name": "Z", "file": f}]).k_init == pytest.approx(1.0)

--- a/tests/test_rv_unit_and_k_seed.py
+++ b/tests/test_rv_unit_and_k_seed.py
@@ -1,0 +1,119 @@
+"""rvinstrument load_data defects from the 2026-08-08 code review.
+
+2.3.1 -- the per-file ``unit:`` key is documented in ``config_schema`` but
+crashed: the YAML string was stored raw and ``load_data`` then called
+``.to()`` on it.  ``astrometryinstrument`` handles its ``sep_unit`` correctly
+with ``u.Unit(...)``; rvinstrument now does the same.
+
+This is load-time only, so these tests drive ``RVInstrument.load_data``
+directly rather than a whole ``System``.
+"""
+
+import astropy.units as u
+import numpy as np
+import pytest
+
+from exozippy.components.rvinstrument.rvinstrument import RVInstrument
+from exozippy.config import ConfigManager
+
+_MS_PER_INTERNAL = (u.solRad / u.d).to(u.m / u.s)
+
+
+def _write_rv(path, times, rvs, errs):
+    """Write a whitespace RV file at full float64 precision."""
+    np.savetxt(
+        path,
+        np.column_stack(
+            [
+                np.asarray(times, float),
+                np.asarray(rvs, float),
+                np.asarray(errs, float),
+            ]
+        ),
+        header="time rv err",
+        fmt="%.17g",
+    )
+    return str(path)
+
+
+def _load(config):
+    inst = RVInstrument(config, ConfigManager({}))
+    inst.load_data(system=None)
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# 2.3.1 -- the documented per-file `unit:` key
+# ---------------------------------------------------------------------------
+_T = np.linspace(2455000.0, 2455010.0, 21)
+_RV_MS = 50.0 * np.sin(2 * np.pi * (_T - 2455000.0) / 10.0) + 12.0
+_ERR_MS = np.full(_T.size, 5.0)
+
+
+def test_km_per_s_unit_key_loads_and_converts(tmp_path):
+    """
+    Given one RV file written in km/s and tagged ``unit: km/s``,
+    When it is loaded,
+    Then its internal arrays equal those of the identical data in m/s.
+    """
+    # ARRANGE
+    kms = _write_rv(tmp_path / "a.rv", _T, _RV_MS / 1000.0, _ERR_MS / 1000.0)
+    ms = _write_rv(tmp_path / "b.rv", _T, _RV_MS, _ERR_MS)
+
+    # ACT
+    tagged = _load([{"name": "A", "file": kms, "unit": "km/s"}])
+    plain = _load([{"name": "B", "file": ms}])
+
+    # ASSERT -- the values, not merely the absence of a crash
+    np.testing.assert_allclose(tagged.rv, plain.rv, rtol=1e-12)
+    np.testing.assert_allclose(tagged.err, plain.err, rtol=1e-12)
+    np.testing.assert_allclose(tagged.gamma_init, [12.0], rtol=1e-12)
+    np.testing.assert_allclose(
+        tagged.rv * _MS_PER_INTERNAL, _RV_MS, rtol=1e-12
+    )
+    np.testing.assert_allclose(
+        tagged.err * _MS_PER_INTERNAL, _ERR_MS, rtol=1e-12
+    )
+    # The jitter floor is quoted in m/s^2 too, so it must not scale with the
+    # file's unit either.
+    np.testing.assert_allclose(
+        tagged.jittervar_lower, plain.jittervar_lower, rtol=1e-12
+    )
+
+
+def test_default_unit_is_metres_per_second(tmp_path):
+    """
+    Given an RV file with no ``unit:`` key,
+    When it is loaded,
+    Then the columns are read as m/s, as config_schema documents.
+    """
+    f = _write_rv(tmp_path / "a.rv", _T, _RV_MS, _ERR_MS)
+    inst = _load([{"name": "A", "file": f}])
+    assert inst.units[0] == u.Unit("m/s")
+    np.testing.assert_allclose(inst.rv * _MS_PER_INTERNAL, _RV_MS, rtol=1e-12)
+
+
+@pytest.mark.parametrize("bad", ["bananas", "kg", "d"])
+def test_unparseable_or_non_velocity_unit_raises(tmp_path, bad):
+    """
+    Given a ``unit:`` key that is not a velocity astropy understands,
+    When the component is constructed,
+    Then a ValueError naming the instrument and the offending string is
+    raised (rather than an AttributeError deep inside load_data).
+    """
+    f = _write_rv(tmp_path / "a.rv", _T, _RV_MS, _ERR_MS)
+    with pytest.raises(ValueError, match=r"unit: .*is not a velocity"):
+        RVInstrument(
+            [{"name": "HIRES", "file": f, "unit": bad}], ConfigManager({})
+        )
+
+
+def test_astropy_unit_object_still_accepted(tmp_path):
+    """
+    Given an in-memory config whose ``unit:`` is already an astropy Unit,
+    When the component is constructed,
+    Then it is used as-is (run_fit accepts dict configs, not only YAML).
+    """
+    f = _write_rv(tmp_path / "a.rv", _T, _RV_MS / 1000.0, _ERR_MS / 1000.0)
+    inst = _load([{"name": "A", "file": f, "unit": u.km / u.s}])
+    np.testing.assert_allclose(inst.rv * _MS_PER_INTERNAL, _RV_MS, rtol=1e-12)


### PR DESCRIPTION
## 2.3.1 -- the documented per-file `unit:` key crashed

```
inst = RVInstrument([{"name": "A", "file": f, "unit": "km/s"}], ConfigManager({}))
inst.load_data(system=None)
-> AttributeError: 'str' object has no attribute 'to'   (rvinstrument.py:125)
```

The YAML string was stored raw and `.to()` called on it later, so any config using the feature died on its first data file.

**Where it is documented**: only in `RVInstrument.config_schema()` -- *"Astropy unit string for the RV/error columns. Default 'm/s'."* -- which is what feeds the GUI and `test_known_keys.py`'s accepted-key set. Not in CLAUDE.md, no docstring, no example uses it. After the fix the schema text is accurate as written, so it was left alone.

New `_parse_rv_unit()` uses `u.Unit(entry.get("unit", "m/s"))` -- the `astrometryinstrument.py:344` `sep_unit` pattern -- and additionally probes `.to(u.m/u.s)`, so a non-velocity (`kg`, `d`) or unparseable string raises a `ValueError` **naming the instrument at construction** rather than an `AttributeError` deep inside `load_data`. An astropy `Unit` object still works, for in-memory `run_fit` configs.

**Sibling sweep: none.** `sep_unit` is the only other per-file unit key across the four instrument children and already goes through `u.Unit`; `transit` and `mulensinstrument` have no unit keys. A repo-wide grep for `.to(` on config-derived values found nothing else raw.

## 2.3.3 -- `k_init` contaminated by absolute-RV offsets

A 20 m/s planet, one relative instrument plus one at a 30 km/s systemic velocity, 40 points each:

| | before | after |
|---|---|---|
| single instrument (control) | 19.748417549992624 | 19.748417549992624 (bit-identical) |
| two instruments | **21213.21** | **19.7484** |
| truth, `sqrt(2)*std(planet)` | 19.7484 | |

A **1074x** inflation, fed straight into `planet.K` through `Planet.register_parameters`' `k_init/sqrt(n_planets)` hint.

`_estimate_k_init()` now subtracts `gamma_init[inst_map]` before the `sqrt(2)*std`. Verified that `gamma_init` is per-file, in m/s, and fully populated before that line (written in the same load loop, one entry per file, as `mean(rv_column) * m_s_factor`). Single-instrument configs are unchanged **exactly** -- subtracting a constant cannot change a standard deviation.

### Degenerate cases, and the one behavior change

One point per file, per-file-constant RVs, and zero-variance input all collapse the residual to zero. That was **already** reachable pre-fix for a single constant-RV file: `k_init ~ 2.5e-15`, which `prepare()` turned into a `planet.mass` initval of `3.1e-20` Mjup and a start logp of `-1.5e10` (probed directly). Mean-removal makes zero reachable in more configs, so there is now a two-step fallback with a warning: the median error bar in m/s (the white-noise level, i.e. the amplitude at the detection limit), then 1 m/s if the errors are zero too.

This is the only place a previously-"working" config changes behavior -- and only for configs that were already seeding a ~1e-20 Mjup planet.

## Tests

New `tests/test_rv_unit_and_k_seed.py`, 12 tests. **9 of 12 fail on pre-fix code** (verified by stashing `src/`); the 3 that pass are deliberate controls -- default unit is m/s, an astropy `Unit` object is accepted, and the single-instrument seed is unchanged.

Assertions are on values rather than absence of a crash: the km/s file's internal `rv`/`err`/`gamma_init`/`jittervar_lower` are compared against the identical data expressed in m/s **and** against the m/s truth arrays; the two-instrument case asserts `k_init ~ 19.7484` and `< 1%` of the pre-fix 21213.

No existing test encoded either behavior -- nothing in `tests/` referenced `k_init` or an rvinstrument `unit:` key -- so nothing was weakened.

Regression: `test_instrument_base` 14, `test_instrument_mask`+`test_instrument_time_columns` 27, `test_multiplanet` 12, `test_chen` 36, `test_planet_log_q` 20, `test_gp` 46, `test_known_keys`+`test_introspect` 22, `test_examples_prepare` 20, `test_robust_likelihood` 37 -- all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)