### PR TITLE
galacticmodel: seed proper motions at the kinematic prior's mean

### DIFF
--- a/src/exozippy/components/galacticmodel/galacticmodel.py
+++ b/src/exozippy/components/galacticmodel/galacticmodel.py
@@ -1,10 +1,8 @@
 import logging
 
-import astropy.units as u
 import numpy as np
 import pymc as pm
 import pytensor.tensor as pt
-from astropy.coordinates import CartesianDifferential, Galactocentric, SkyCoord
 from scipy.special import erf, erfc
 
 from exozippy.components.component import Component
@@ -31,9 +29,7 @@ from exozippy.constants import (
     DISK_VELOCITY_SIGMA_W,
     K_VEL_CONVERSION,
     SALPETER_IMF_SLOPE,
-    SUN_GALCEN_V,
     SUN_GC_DISTANCE,
-    SUN_Z_OFFSET,
     THICK_DISK_LOCAL_NUMBER_DENSITY,
     THICK_DISK_ROTATION_VELOCITY,
     THICK_DISK_SCALE_HEIGHT,
@@ -65,15 +61,13 @@ stays microlensing-agnostic.
 
 logger = logging.getLogger(__name__)
 
-# One consistent galactocentric frame for the velocity transform, matching
-# the density grid's R0/z_sun (genulens: R0 = 8160 pc, zsun = 25 pc,
-# vsun = (10, 243, 7) km/s toward-GC/rotation/up).  Astropy's default
-# Galactocentric (R0 = 8.122 kpc) would put the velocities in a slightly
-# different frame than the densities.
-GALACTOCENTRIC_FRAME = Galactocentric(
-    galcen_distance=SUN_GC_DISTANCE * u.kpc,
-    z_sun=SUN_Z_OFFSET * u.kpc,
-    galcen_v_sun=CartesianDifferential(list(SUN_GALCEN_V) * (u.km / u.s)),
+# The frame, the line-of-sight basis and the position transform live in
+# physics.py (the numpy layer) so the start-value hints in
+# mulensing/lens.py use exactly the code this likelihood uses.
+from .physics import (  # noqa: E402
+    GALACTOCENTRIC_FRAME,
+    galactic_xyz as _galactic_xyz_np,
+    line_of_sight_basis,
 )
 
 
@@ -352,45 +346,23 @@ class GalacticModel(Component):
         ra_rad = float(np.atleast_1d(stars.ra.initval)[self.anchor_idx])
         dec_rad = float(np.atleast_1d(stars.dec.initval)[self.anchor_idx])
 
-        sc = SkyCoord(ra=ra_rad * u.rad, dec=dec_rad * u.rad)
-        d = 1.0  # kpc, arbitrary distance for velocity basis projection
-        pm_1 = 1.0 / (K_VEL_CONVERSION * d)  # mas/yr
-
-        def _basis(pm_ra_cosdec, pm_dec, rv):
-            return SkyCoord(
-                ra=sc.ra,
-                dec=sc.dec,
-                distance=d * u.kpc,
-                pm_ra_cosdec=pm_ra_cosdec * u.mas / u.yr,
-                pm_dec=pm_dec * u.mas / u.yr,
-                radial_velocity=rv * u.km / u.s,
-            ).transform_to(GALACTOCENTRIC_FRAME)
-
-        gal0 = _basis(0, 0, 0)
-        gal1 = _basis(pm_1, 0, 0)
-        gal2 = _basis(0, pm_1, 0)
-        gal3 = _basis(0, 0, 1)
-
-        v0_arr = np.array([gal0.v_x.value, gal0.v_y.value, gal0.v_z.value])
-        v1 = (
-            np.array([gal1.v_x.value, gal1.v_y.value, gal1.v_z.value]) - v0_arr
-        )
-        v2 = (
-            np.array([gal2.v_x.value, gal2.v_y.value, gal2.v_z.value]) - v0_arr
-        )
-        v3 = (
-            np.array([gal3.v_x.value, gal3.v_y.value, gal3.v_z.value]) - v0_arr
-        )
-
-        l_rad = sc.galactic.l.rad
-        b_rad = sc.galactic.b.rad
+        # Shared with the start-value hints (physics.line_of_sight_basis):
+        # the affine (pm_ra_cosdec, pm_dec, rv) -> galactocentric velocity map,
+        # as one offset plus three unit-response columns.
+        (
+            m_rot_np,
+            v0_arr,
+            cosl_cosb_np,
+            sinl_cosb_np,
+            sinb_np,
+        ) = line_of_sight_basis(ra_rad, dec_rad)
 
         # Convert to tensors for graph injection
-        M_rot = pt.as_tensor_variable(np.column_stack([v1, v2, v3]))  # (3, 3)
+        M_rot = pt.as_tensor_variable(m_rot_np)  # (3, 3)
         v0 = pt.as_tensor_variable(v0_arr)  # (3,)
-        cosl_cosb = pt.as_tensor_variable(np.cos(l_rad) * np.cos(b_rad))
-        sinl_cosb = pt.as_tensor_variable(np.sin(l_rad) * np.cos(b_rad))
-        sinb = pt.as_tensor_variable(np.sin(b_rad))
+        cosl_cosb = pt.as_tensor_variable(cosl_cosb_np)
+        sinl_cosb = pt.as_tensor_variable(sinl_cosb_np)
+        sinb = pt.as_tensor_variable(sinb_np)
 
         # 2. PyTensor Math Helpers
         def get_galactocentric_velocity(dist_kpc, pm_ra, pm_dec, rv_ms):
@@ -404,15 +376,9 @@ class GalacticModel(Component):
             return v0 + v_gal_offset
 
         def get_galactic_xyz(dist):
-            # genulens Dlb2xyz: the Sun sits SUN_Z_OFFSET above the plane,
-            # handled as a small rotation of z by bsun = z_sun/R0 (so a
-            # star at d=0 lands at z = +z_sun).  x and y keep the flat
-            # convention (Sun at x = +R0, GC at the origin).
-            x = SUN_GC_DISTANCE - dist * cosl_cosb
-            y = dist * sinl_cosb
-            bsun = SUN_Z_OFFSET / SUN_GC_DISTANCE
-            z = dist * sinb * np.cos(bsun) + x * np.sin(bsun)
-            return x, y, z
+            # physics.galactic_xyz is pure arithmetic, so the same function
+            # serves numpy scalars (the hints) and tensors (here).
+            return _galactic_xyz_np(dist, cosl_cosb, sinl_cosb, sinb)
 
         def get_polar_velocity(x, y, r, v_x, v_y):
             cos_phi = x / r  # unitless

--- a/src/exozippy/components/galacticmodel/physics.py
+++ b/src/exozippy/components/galacticmodel/physics.py
@@ -1,3 +1,173 @@
-# No standalone parameters to sample;
-# it acts strictly as a prior penalty.
-galactic_model: {}
+"""Numpy side of the galactic kinematic model.
+
+``GalacticModel.build_likelihood`` evaluates the kinematic prior symbolically,
+but the *mean* of that prior is also wanted in plain numpy, early, as a start
+value: the relaxation engine has to seed ``star.pm_ra``/``star.pm_dec`` before
+any PyMC node exists (stage 2), and with nothing better to go on it used to
+leave both at their defaults.yaml value and let one of them absorb whatever the
+``t_E`` constraint implied -- which is how the direction of relative proper
+motion ended up arbitrary (see issue #93).
+
+The line-of-sight basis here is the *same* code the likelihood uses; the
+likelihood calls ``line_of_sight_basis`` and wraps the result in tensors, so
+there is one implementation rather than two that can drift.
+
+Sign/unit conventions, all matching the likelihood:
+
+- ``pm_ra`` means mu_alpha * cos(delta) (astropy's ``pm_ra_cosdec``), in mas/yr.
+  The model treats ``star.pm_ra`` as that quantity throughout.
+- Velocities are galactocentric, km/s. ``v_phi`` is positive for co-rotation at
+  every position.
+- Distances in this module are kpc unless the name says ``_pc``.
+"""
+
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import CartesianDifferential, Galactocentric, SkyCoord
+
+from ...constants import (
+    BULGE_ROTATION_ANGULAR_VELOCITY,
+    DISK_ROTATION_VELOCITY,
+    K_VEL_CONVERSION,
+    SUN_GALCEN_V,
+    SUN_GC_DISTANCE,
+    SUN_Z_OFFSET,
+    THICK_DISK_ROTATION_VELOCITY,
+)
+
+# One consistent galactocentric frame for the velocity transform, matching
+# the density grid's R0/z_sun (genulens: R0 = 8160 pc, zsun = 25 pc,
+# vsun = (10, 243, 7) km/s toward-GC/rotation/up).  Astropy's default
+# Galactocentric (R0 = 8.122 kpc) would put the velocities in a slightly
+# different frame than the densities.
+#
+# Defined here rather than in galacticmodel.py so this module stays the numpy
+# layer that the pytensor layer imports, not the other way round.
+GALACTOCENTRIC_FRAME = Galactocentric(
+    galcen_distance=SUN_GC_DISTANCE * u.kpc,
+    z_sun=SUN_Z_OFFSET * u.kpc,
+    galcen_v_sun=CartesianDifferential(list(SUN_GALCEN_V) * (u.km / u.s)),
+)
+
+#: Populations whose mean velocity this module can supply.
+POPULATIONS = ("thin_disk", "thick_disk", "bulge")
+
+
+def line_of_sight_basis(ra_rad, dec_rad):
+    """Linearize the (pm_ra_cosdec, pm_dec, rv) -> galactocentric velocity map.
+
+    The map is affine, so one offset plus three unit-response columns describe
+    it exactly:
+
+        v_gal = v0 + M_rot @ [v_alpha, v_delta, v_rad]
+
+    with ``v_alpha = K_VEL_CONVERSION * pm_ra * d_kpc`` (and likewise for
+    ``v_delta``), ``v_rad`` in km/s.  Evaluated at an arbitrary 1 kpc because
+    only the *direction* of the response matters -- the distance scaling is
+    carried explicitly by the caller.
+
+    Returns ``(M_rot, v0, cosl_cosb, sinl_cosb, sinb)``: a (3, 3) array, a (3,)
+    array, and three scalars fixing the Galactic direction.
+    """
+    sc = SkyCoord(ra=ra_rad * u.rad, dec=dec_rad * u.rad)
+    d = 1.0  # kpc, arbitrary: only the response direction is used
+    pm_1 = 1.0 / (K_VEL_CONVERSION * d)  # mas/yr giving 1 km/s at d
+
+    def _basis(pm_ra_cosdec, pm_dec, rv):
+        return SkyCoord(
+            ra=sc.ra,
+            dec=sc.dec,
+            distance=d * u.kpc,
+            pm_ra_cosdec=pm_ra_cosdec * u.mas / u.yr,
+            pm_dec=pm_dec * u.mas / u.yr,
+            radial_velocity=rv * u.km / u.s,
+        ).transform_to(GALACTOCENTRIC_FRAME)
+
+    def _vec(gal):
+        return np.array([gal.v_x.value, gal.v_y.value, gal.v_z.value])
+
+    v0 = _vec(_basis(0, 0, 0))
+    m_rot = np.column_stack(
+        [
+            _vec(_basis(pm_1, 0, 0)) - v0,
+            _vec(_basis(0, pm_1, 0)) - v0,
+            _vec(_basis(0, 0, 1)) - v0,
+        ]
+    )
+
+    l_rad = sc.galactic.l.rad
+    b_rad = sc.galactic.b.rad
+    return (
+        m_rot,
+        v0,
+        np.cos(l_rad) * np.cos(b_rad),
+        np.sin(l_rad) * np.cos(b_rad),
+        np.sin(b_rad),
+    )
+
+
+def galactic_xyz(dist_kpc, cosl_cosb, sinl_cosb, sinb):
+    """Galactocentric cartesian position, genulens Dlb2xyz convention.
+
+    The Sun sits ``SUN_Z_OFFSET`` above the plane, handled as a small rotation
+    of z by ``bsun = z_sun / R0`` so a star at d = 0 lands at z = +z_sun.  x and
+    y keep the flat convention (Sun at x = +R0, GC at the origin).
+    """
+    x = SUN_GC_DISTANCE - dist_kpc * cosl_cosb
+    y = dist_kpc * sinl_cosb
+    bsun = SUN_Z_OFFSET / SUN_GC_DISTANCE
+    z = dist_kpc * sinb * np.cos(bsun) + x * np.sin(bsun)
+    return x, y, z
+
+
+def mean_polar_velocity(r_kpc, population):
+    """Mean ``(v_r, v_phi, v_z)`` km/s of one kinematic branch.
+
+    Every branch in the likelihood is a Gaussian centred on zero radial and
+    vertical motion plus a rotational term, so the mean is exactly the centre
+    of that Gaussian -- read straight off ``log_vel_thin`` / ``log_vel_thick`` /
+    ``log_vel_bulge``.
+    """
+    if population == "thin_disk":
+        return 0.0, DISK_ROTATION_VELOCITY, 0.0
+    if population == "thick_disk":
+        return 0.0, THICK_DISK_ROTATION_VELOCITY, 0.0
+    if population == "bulge":
+        # Cylindrical rotation, Omega * r (Koshimoto & Bennett 2020).
+        return 0.0, BULGE_ROTATION_ANGULAR_VELOCITY * r_kpc, 0.0
+    raise ValueError(
+        f"unknown population {population!r}; expected one of {POPULATIONS}"
+    )
+
+
+def expected_proper_motion(ra_rad, dec_rad, distance_pc, population):
+    """Mean proper motion under the kinematic prior, in mas/yr.
+
+    Inverts ``v_gal = v0 + M_rot @ [v_alpha, v_delta, v_rad]`` at the branch's
+    mean velocity.  Returns ``(pm_ra_cosdec, pm_dec, rv_kms)``.
+
+    This is the prior's *mean*, not a draw: it is a start value, and the
+    dispersions (which are large -- tens of km/s) are what the prior itself
+    contributes during sampling.
+    """
+    dist_kpc = float(distance_pc) / 1e3
+    if not dist_kpc > 0:
+        raise ValueError(f"distance_pc must be positive; got {distance_pc!r}")
+
+    m_rot, v0, cosl_cosb, sinl_cosb, sinb = line_of_sight_basis(
+        ra_rad, dec_rad
+    )
+    x, y, _z = galactic_xyz(dist_kpc, cosl_cosb, sinl_cosb, sinb)
+    r = float(np.hypot(x, y))
+
+    v_r, v_phi, v_z = mean_polar_velocity(r, population)
+    # Inverse of get_polar_velocity: [v_r, v_phi] = R(-phi) [v_x, v_y].
+    cos_phi, sin_phi = x / r, y / r
+    v_x = v_r * cos_phi - v_phi * sin_phi
+    v_y = v_r * sin_phi + v_phi * cos_phi
+
+    v_alpha, v_delta, v_rad = np.linalg.solve(
+        m_rot, np.array([v_x, v_y, v_z], dtype=float) - v0
+    )
+    scale = K_VEL_CONVERSION * dist_kpc
+    return v_alpha / scale, v_delta / scale, v_rad

--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -854,13 +854,56 @@ class Lens(Component):
     def _galactic_pm_expectations(self, system):
         """Line of sight for the galactic-model proper-motion seeds.
 
-        Returns ``(ra_rad, dec_rad)``, or None when the coordinates are still
-        the defaults.yaml placeholder -- the galactic model's mean velocity is a
-        function of direction, so seeding off a placeholder would be worse than
-        not seeding at all.
+        Returns ``(ra_rad, dec_rad)``, or None when the seeding does not apply.
+
+        The prior is only allowed to FILL A GAP, never to contradict.  What is
+        open here is the physical side: no example pins the lens mass or
+        distance, because a published light-curve solution (t_0, u_0, t_E, s, q,
+        alpha, rho, sometimes pi_E) does not close the system -- t_E and pi_E
+        without theta_E leave mass, distance and proper motion free.  That gap
+        is what the engine used to fill by inventing a direction (issue #93).
+
+        But where a config DOES imply the proper motion, a prior mean dropped on
+        top fights it.  Measured at the seed (raw = 0), chi2/N ungated vs gated:
+
+            ob140939 (pi_E_N/pi_E_E measured, Yee+2015)  3.04 -> 179.1 | 3.04
+            ob161003 (two sources, t_E + rho each)       1.72 ->   3.9 | 1.72
+            DC2018_128 (t_0/u_0/t_E/s/q/alpha/rho)       1.42 ->   1.21 (kept)
+            ob08092 (t_0/u_0/t_E only, PSPL)             1.50 ->   1.42 (kept)
+
+        So the gates below are what keeps this from making published solutions
+        worse.  Filling only the *direction* and leaving the magnitude to the
+        data would serve every case at once, but the direction is not a symbol,
+        so provenance cannot express it per-symbol; that needs a basis change
+        (mu_rel_mag, mu_rel_pa) which is a sampling-geometry question and does
+        not belong here.  tests/test_seed_quality.py pins all four numbers.
         """
         if "galacticmodel" not in getattr(system, "config", {}):
             # No galactic model in the topology: nothing to take the mean of.
+            return None
+        # Skip when something already implies the direction or the magnitude.
+        up = self.config_manager.user_params
+        blockers = [
+            k
+            for k in up
+            if k.endswith((".pi_E_N", ".pi_E_E")) or ".pm_ra" in k or ".pm_dec" in k
+        ]
+        if blockers:
+            logger.info(
+                f"[lens] proper motion or parallax already given "
+                f"({', '.join(sorted(blockers))}); not seeding from the "
+                f"galactic model, which would contradict it."
+            )
+            return None
+        if self.n_sources > 1:
+            # Every source would be seeded at the same bulge mean, forcing one
+            # mu_rel for all of them.  A resolved binary source distinguishes
+            # them, so do not impose it.
+            logger.info(
+                f"[lens] {self.n_sources} sources; not seeding proper motions "
+                f"from the galactic model (one mean would tie their mu_rel "
+                f"together)."
+            )
             return None
         try:
             n_stars = system.star.n_elements

--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -5,6 +5,7 @@ import pymc as pm
 import pytensor.tensor as pt
 
 from exozippy.components.component import Component
+from exozippy.config import RANK_DERIVED_DATA
 from exozippy.constants import KAPPA
 from exozippy.corner_utils import (
     collect_parameter_corner_samples,
@@ -12,6 +13,7 @@ from exozippy.corner_utils import (
 )
 from exozippy.potentials import soft_lower_bound
 
+from ..galacticmodel.physics import expected_proper_motion
 from . import mmexofast_support
 from .op import BinaryLensMagOp, MulensMagOp, VBMDirectMagOp
 from .physics import MU_REL_FLOOR, THETA_E_FLOOR
@@ -768,6 +770,14 @@ class Lens(Component):
             alpha_deg = float(np.arctan2(float(sa), float(ca)) * 180.0 / np.pi)
             self.config_manager.add_hint(f"lens.0.alpha", alpha_deg, rank=20)
 
+        # Expected proper motions from the galactic model, for the seeds below.
+        # None when the line of sight is not known yet, in which case the pm
+        # hints are simply skipped (the old behavior).
+        pm_expected = self._galactic_pm_expectations(system)
+
+        # (helpers for the pm seeding live at _galactic_pm_expectations /
+        # _seed_expected_pm, below this method.)
+
         # Inject per-event physical hints
         for i in range(self.n_elements):
             l_type, l_idx = self._primary_lens(i)
@@ -785,6 +795,7 @@ class Lens(Component):
             self.config_manager.add_scale_hint(f"star.{l_idx}.pm_ra", 3.0)
             self.config_manager.add_scale_hint(f"star.{l_idx}.pm_dec", 3.0)
             self.config_manager.add_scale_hint(f"star.{l_idx}.rv", 1e5)
+            self._seed_expected_pm(pm_expected, l_idx, "thin_disk", 4000.0)
 
             # Every source body gets the same bulge-source seeding: each source
             # has its own trajectory chain (distance, pm) to initialize.
@@ -802,6 +813,7 @@ class Lens(Component):
                 self.config_manager.add_scale_hint(f"star.{s_idx}.pm_ra", 3.0)
                 self.config_manager.add_scale_hint(f"star.{s_idx}.pm_dec", 3.0)
                 self.config_manager.add_scale_hint(f"star.{s_idx}.rv", 1e5)
+                self._seed_expected_pm(pm_expected, s_idx, "bulge", 8000.0)
 
             # Companion lens bodies (everything beyond the primary)
             for l2_type, l2_idx in self.lens_bodies[i][1:]:
@@ -838,6 +850,109 @@ class Lens(Component):
                     self.config_manager.add_scale_hint(
                         f"star.{l_idx}.logmass", scale
                     )
+
+    def _galactic_pm_expectations(self, system):
+        """Line of sight for the galactic-model proper-motion seeds.
+
+        Returns ``(ra_rad, dec_rad)``, or None when the coordinates are still
+        the defaults.yaml placeholder -- the galactic model's mean velocity is a
+        function of direction, so seeding off a placeholder would be worse than
+        not seeding at all.
+        """
+        if "galacticmodel" not in getattr(system, "config", {}):
+            # No galactic model in the topology: nothing to take the mean of.
+            return None
+        try:
+            n_stars = system.star.n_elements
+            source_ndx = int(system.lens.source_map[0])
+            ra_all = self.config_manager.resolve(
+                "star", "ra", shape=(n_stars,)
+            )["initval"]
+            dec_all = self.config_manager.resolve(
+                "star", "dec", shape=(n_stars,)
+            )["initval"]
+        except Exception as exc:  # pragma: no cover - seeds are optional
+            logger.debug(
+                f"[lens] could not resolve the line of sight for the "
+                f"galactic-model proper-motion seeds: {exc!r}"
+            )
+            return None
+
+        keys = [f"star.{source_ndx}.ra", "star.ra"]
+        names = getattr(system.star, "names", None)
+        if names:
+            keys.append(f"star.{names[source_ndx]}.ra")
+        if not any(k in self.config_manager.user_params for k in keys):
+            logger.debug(
+                "[lens] no user-set RA/Dec; skipping the galactic-model "
+                "proper-motion seeds."
+            )
+            return None
+
+        # resolve() hands back the value in the parameter's USER unit, which for
+        # ra/dec is degrees (Parameter.__post_init__ is what converts to the
+        # internal radians, and it has not run at stage 2).  The galactic-model
+        # helpers take radians.
+        return (
+            float(np.radians(np.atleast_1d(ra_all)[source_ndx])),
+            float(np.radians(np.atleast_1d(dec_all)[source_ndx])),
+        )
+
+    def _seed_expected_pm(self, line_of_sight, star_idx, population, dist_pc):
+        """Seed one star's pm_ra/pm_dec at the galactic model's prior mean.
+
+        RANK_DERIVED_DATA: this is derived from the galactic model the same way
+        an RV offset is derived from the data, so it belongs in that tier and
+        must yield to anything in params.yaml.
+
+        It ties with the MMEXOFAST seeds (also RANK_DERIVED_DATA), which is the
+        point.  Both proper-motion components are now pinned, so ``mu_rel`` has
+        a magnitude AND a direction, and the engine no longer has to invert
+        ``mu_rel_mag**2 = mu_ra_rel**2 + mu_dec_rel**2`` -- one equation in two
+        unknowns -- by choosing a point on a circle (issue #93).  Where that
+        disagrees with the seeded ``t_E``, Condition B rewrites the lowest-rank
+        symbol in ``t_E = theta_E / |mu_rel_geo|``, which is ``theta_E`` via the
+        lens mass (defaults.yaml, rank 20) and distance (rank 25).  So ``t_E``
+        keeps its measured value, the proper motion keeps the prior's, and the
+        lens mass absorbs the difference -- which is the standard microlensing
+        chain (a measured t_E plus an assumed mu_rel implies theta_E, hence a
+        mass) and is the quantity a light curve genuinely cannot pin down.
+
+        `dist_pc` must match the distance hint seeded for the same star: the
+        mean velocity is position-dependent, so a mismatch would seed a proper
+        motion for a place the star is not.
+        """
+        if line_of_sight is None:
+            return
+        ra_rad, dec_rad = line_of_sight
+        try:
+            pm_ra, pm_dec, _rv = expected_proper_motion(
+                ra_rad, dec_rad, dist_pc, population
+            )
+        except Exception as exc:
+            # WARNING, not debug: this silently disabled the whole feature once
+            # already (degrees were passed where radians were wanted, astropy
+            # raised, and the seeds just quietly never happened).  A failure
+            # here is not fatal -- the old arbitrary start still works -- but it
+            # must be visible.
+            logger.warning(
+                f"[lens] could not seed star.{star_idx}'s proper motion from "
+                f"the galactic model ({population} at {dist_pc:.0f} pc): "
+                f"{exc!r}.  Falling back to the defaults.yaml value; the "
+                f"direction of mu_rel will be arbitrary (see issue #93)."
+            )
+            return
+        self.config_manager.add_hint(
+            f"star.{star_idx}.pm_ra", pm_ra, rank=RANK_DERIVED_DATA
+        )
+        self.config_manager.add_hint(
+            f"star.{star_idx}.pm_dec", pm_dec, rank=RANK_DERIVED_DATA
+        )
+        logger.info(
+            f"[lens] star.{star_idx} proper motion seeded at the "
+            f"{population} prior mean for {dist_pc:.0f} pc: "
+            f"pm_ra={pm_ra:+.3f}, pm_dec={pm_dec:+.3f} mas/yr."
+        )
 
     def add_parameter(self, model, param_name, system, context_nodes=None):
         """Inject the Earth-velocity context constants for the mu_rel_geo

--- a/tests/test_galactic_pm_hints.py
+++ b/tests/test_galactic_pm_hints.py
@@ -167,6 +167,67 @@ def test_unknown_population_is_rejected():
     assert "thin_disk" in POPULATIONS
 
 
+def test_seeds_are_skipped_when_parallax_is_already_measured():
+    """
+    Given a config that supplies pi_E_N/pi_E_E (a measured parallax vector),
+    When start values are resolved,
+    Then the proper motions are NOT seeded from the prior.
+
+    pi_E is parallel to mu_rel, so a measured pi_E already fixes the direction.
+    Seeding the prior's direction on top of it contradicts the measurement:
+    on examples/ob140939 (Yee+2015 pi_E) doing so took chi2/N at the seed from
+    3.04 to 179.1.
+    """
+    # Arrange
+    config, user_params = _inputs()
+    user_params["lens.Lens.pi_E_N"] = {"initval": -0.2}
+    user_params["lens.Lens.pi_E_E"] = {"initval": 0.1}
+
+    ra, dec = np.radians(267.595), np.radians(-28.982)
+    prior_pm_dec = expected_proper_motion(ra, dec, 4000.0, "thin_disk")[1]
+
+    # Act
+    params = _prepared(config, user_params)
+
+    # Assert: whatever the engine derives from the measured pi_E, it is NOT the
+    # prior's mean.  (It need not be the bare default either -- deriving the
+    # proper motion FROM the measurement is the desired outcome; the point is
+    # that the prior did not overwrite it.)
+    pm_dec = np.atleast_1d(np.asarray(params["star.pm_dec"].initval, float))
+    assert pm_dec[0] != pytest.approx(prior_pm_dec, rel=1e-3), (
+        "the galactic-model mean overrode a measured pi_E direction"
+    )
+
+
+def test_seeds_are_skipped_for_a_multi_source_event():
+    """
+    Given more than one source body,
+    When start values are resolved,
+    Then the proper motions are NOT seeded from the prior.
+
+    Every source would take the same bulge mean, tying their mu_rel together;
+    a resolved binary source distinguishes them.  On examples/ob161003 (two
+    sources, t_E and rho pinned for each) seeding took chi2/N from 1.72 to 3.9.
+    """
+    # Arrange: add a second source body to the lens block.
+    config, user_params = _inputs()
+    lens_block = config["lens"][0] if isinstance(config["lens"], list) else config["lens"]
+    sources = lens_block.get("sources")
+    if not sources:
+        pytest.skip("example does not use the explicit sources: list")
+    star_entries = config["star"]
+    star_entries.append(copy.deepcopy(star_entries[int(sources[0].split(".")[1])]))
+    star_entries[-1]["name"] = "SourceB"
+    lens_block["sources"] = list(sources) + [f"star.{len(star_entries) - 1}"]
+
+    # Act
+    params = _prepared(config, user_params)
+
+    # Assert
+    pm_dec = np.atleast_1d(np.asarray(params["star.pm_dec"].initval, float))
+    assert pm_dec[0] == pytest.approx(-3.0)
+
+
 def test_seeds_are_skipped_without_user_coordinates():
     """
     Given a config whose RA/Dec are left at the defaults.yaml placeholder,

--- a/tests/test_galactic_pm_hints.py
+++ b/tests/test_galactic_pm_hints.py
@@ -1,0 +1,191 @@
+"""Proper-motion start values come from the galactic model, not from a guess.
+
+Before this, ``star.pm_ra``/``star.pm_dec`` sat at their defaults.yaml value and
+the relaxation engine let ONE of them absorb whatever the seeded ``t_E``
+implied, leaving the other at the default.  That made the direction of relative
+proper motion arbitrary: the pair
+``mu_rel_mag**2 = mu_ra_rel**2 + mu_dec_rel**2`` is one equation in two
+unknowns, and the MMEXOFAST seed carries no ``pi_E`` to break it (issue #93).
+
+Seeding both components at the kinematic prior's mean closes that hole.  The
+interesting part is what the provenance ranking then does on its own: the
+proper motions and the MMEXOFAST ``t_E`` are both RANK_DERIVED_DATA, so
+``t_E = theta_E / |mu_rel_geo|`` is over-determined, and Condition B rewrites
+its lowest-rank symbol -- ``theta_E``, through the lens mass (defaults.yaml,
+rank 20) and distance (rank 25).  So the measured ``t_E`` survives and the lens
+mass absorbs the difference, which is the standard microlensing chain rather
+than a special case anyone had to code.
+"""
+
+import copy
+import os
+import pathlib
+import shutil
+import tempfile
+
+import numpy as np
+import pytest
+import yaml
+
+from exozippy.components.galacticmodel.physics import (
+    POPULATIONS,
+    expected_proper_motion,
+)
+from exozippy.system import System
+
+EXAMPLE_DIR = pathlib.Path(__file__).parent / ".." / "examples" / "DC2018_128"
+
+pytestmark = pytest.mark.slow
+
+
+def _inputs():
+    with open(EXAMPLE_DIR / "DC2018_128.yaml") as f:
+        config = yaml.safe_load(f)
+    with open(EXAMPLE_DIR / "DC2018_128.params.yaml") as f:
+        user_params = yaml.safe_load(f)
+    for entry in config.get("planet", []):
+        entry.setdefault("mass_parameterization", "linear")
+    return config, user_params
+
+
+def _prepared(config, user_params):
+    work = pathlib.Path(tempfile.mkdtemp()) / "DC2018_128"
+    shutil.copytree(
+        EXAMPLE_DIR,
+        work,
+        ignore=shutil.ignore_patterns("fitresults", ".#*", "#*#"),
+    )
+    cwd = os.getcwd()
+    os.chdir(work)
+    try:
+        system = System(copy.deepcopy(config), copy.deepcopy(user_params))
+        system.prepare()
+        system.build_model()
+        return {p.label: p for p in system.get_all_parameters()}
+    finally:
+        os.chdir(cwd)
+
+
+@pytest.fixture(scope="module")
+def params():
+    return _prepared(*_inputs())
+
+
+def test_proper_motions_are_seeded_at_the_galactic_prior_mean(params):
+    """
+    Given a microlensing config with a galacticmodel block and known RA/Dec,
+    When the relaxation engine resolves start values,
+    Then both proper-motion components equal the prior's mean for that
+    line of sight, distance and population.
+    """
+    # Arrange: the same expectation the seeding claims to use.  DC2018_128 is
+    # at (267.595, -28.982) deg; lens seeded as thin disk at 4 kpc, source as
+    # bulge at 8 kpc, matching the distance hints in Lens.register_parameters.
+    ra, dec = np.radians(267.595), np.radians(-28.982)
+    lens_pm = expected_proper_motion(ra, dec, 4000.0, "thin_disk")
+    source_pm = expected_proper_motion(ra, dec, 8000.0, "bulge")
+
+    # Act
+    pm_ra = np.atleast_1d(np.asarray(params["star.pm_ra"].initval, float))
+    pm_dec = np.atleast_1d(np.asarray(params["star.pm_dec"].initval, float))
+
+    # Assert
+    assert pm_ra[0] == pytest.approx(lens_pm[0], rel=1e-6)
+    assert pm_dec[0] == pytest.approx(lens_pm[1], rel=1e-6)
+    assert pm_ra[1] == pytest.approx(source_pm[0], rel=1e-6)
+    assert pm_dec[1] == pytest.approx(source_pm[1], rel=1e-6)
+
+
+def test_neither_pm_component_is_left_at_zero(params):
+    """
+    Given the seeded start values,
+    When mu_rel and pi_E are formed from them,
+    Then no component is (numerically) zero.
+
+    The old seeding put the whole magnitude in one component and left the other
+    at 0 exactly -- so pi_E_N or pi_E_E started at a cusp of its normalization.
+    """
+    # Act / Assert
+    for label in (
+        "lens.mu_ra_rel",
+        "lens.mu_dec_rel",
+        "lens.pi_E_N",
+        "lens.pi_E_E",
+    ):
+        value = float(
+            np.atleast_1d(np.asarray(params[label].initval, float))[0]
+        )
+        assert abs(value) > 1e-6, f"{label} was seeded at ~0 ({value!r})"
+
+
+def test_measured_t_E_survives_and_theta_E_yields(params):
+    """
+    Given proper motions at RANK_DERIVED_DATA that disagree with the seeded t_E,
+    When Condition B rewrites the over-determined relation,
+    Then t_E keeps the MMEXOFAST value and theta_E is what moves.
+
+    This is the load-bearing assertion: it is the difference between "the
+    provenance ranking sorts this out" and "the measured timescale silently got
+    overwritten by a prior".
+    """
+    # Arrange: t_E as MMEXOFAST measured it, in days.
+    import json
+
+    with open(EXAMPLE_DIR / "mmexofast.json") as f:
+        mmx = json.load(f)
+    seeded_t_E = float(mmx["fits"][0]["parameters"]["t_E"])
+
+    # Act
+    t_E = float(np.atleast_1d(np.asarray(params["lens.t_E"].initval, float))[0])
+    theta_E = float(
+        np.atleast_1d(np.asarray(params["lens.theta_E"].initval, float))[0]
+    )
+    mu_rel = float(
+        np.atleast_1d(np.asarray(params["lens.mu_rel_mag"].initval, float))[0]
+    )
+
+    # Assert
+    assert t_E == pytest.approx(seeded_t_E, rel=1e-6), (
+        "t_E moved off the MMEXOFAST seed; the proper-motion hints are "
+        "outranking a measured quantity."
+    )
+    # theta_E is the symbol that absorbed the difference, so it must be
+    # consistent with t_E and the prior's mu_rel rather than with the old
+    # mass/distance guess (which gave 0.5677 mas).
+    assert theta_E == pytest.approx(t_E / 365.25 * mu_rel, rel=0.05)
+
+
+def test_unknown_population_is_rejected():
+    """
+    Given a population name the kinematic prior does not define,
+    When an expected proper motion is requested,
+    Then it raises rather than silently returning a disk velocity.
+    """
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="unknown population"):
+        expected_proper_motion(0.0, 0.0, 4000.0, "halo")
+    assert "thin_disk" in POPULATIONS
+
+
+def test_seeds_are_skipped_without_user_coordinates():
+    """
+    Given a config whose RA/Dec are left at the defaults.yaml placeholder,
+    When start values are resolved,
+    Then the proper motions fall back to defaults rather than being seeded off
+    a placeholder direction.
+
+    The prior's mean is a function of direction, so seeding from a placeholder
+    would be worse than not seeding.
+    """
+    # Arrange
+    config, user_params = _inputs()
+    for key in list(user_params):
+        if key.endswith(".ra") or key.endswith(".dec"):
+            del user_params[key]
+
+    # Act
+    params = _prepared(config, user_params)
+
+    # Assert: back to the defaults.yaml value, not a galactic-model number.
+    pm_ra = np.atleast_1d(np.asarray(params["star.pm_ra"].initval, float))
+    assert pm_ra[1] == pytest.approx(-3.0)

--- a/tests/test_runaway_logp_regression.py
+++ b/tests/test_runaway_logp_regression.py
@@ -174,7 +174,22 @@ def _point(raw_dict):
 # log(sigma*sqrt(2pi)*(Phi(u_hi) - Phi(u_lo))) = +0.3568196 nats PER STAR.
 # This config has two (star.Lens, star.Source), so the shift is exactly
 # -0.7136392 and nothing else moved.
-GOOD_EXPECTED_LP = -945.5716
+# Re-measured 2026-08-11: star.pm_ra/pm_dec are now seeded at the galactic
+# model's prior mean instead of being left at defaults.yaml for the t_E
+# constraint to absorb (issue #93).  This is the largest re-measurement in the
+# list and needs the caveat spelled out: RAW values are offsets from the
+# initvals, so changing a start value changes which PHYSICAL point a pinned raw
+# vector decodes to.  These raw numbers came from a trace taken under the old
+# seeding, so the point they now land on is no longer the well-fitting draw the
+# name suggests -- chi2/N there is ~261, against ~1.2 at the new seed itself
+# (raw = 0), which is better than either arbitrary branch the old seeding could
+# produce (~1.42 and ~1.51).
+#
+# The test therefore still does the job it was written for -- pinning that
+# System.prepare() is bit-for-bit reproducible, and that GOOD_RAW is read
+# against the right free_RVs -- but it is no longer a statement about fit
+# quality.  Do not read this number as one.
+GOOD_EXPECTED_LP = -109962.6577
 
 
 def test_good_draw_logp_matches_deterministic_build(dc2018_128_logp):

--- a/tests/test_seed_quality.py
+++ b/tests/test_seed_quality.py
@@ -1,0 +1,128 @@
+"""Guard the goodness of fit AT THE SEED for every microlensing example.
+
+The seed (``System.get_raw_start``) is where a production fit starts, so its
+chi2 is the number
+that says whether initialization is doing its job -- reproducing the solution
+the observables came from.  Nothing checked it before, and that is exactly how a
+change to the proper-motion start values passed 1272 tests while making two
+examples' starts 60x and 2x worse:
+
+    ob140939  chi2/N  3.04 -> 179.1
+    ob161003  chi2/N  1.72 ->   3.9
+
+A whole-suite pass means the model still *builds* and the physics still agrees
+with its references.  It says nothing about starting somewhere sensible.
+
+The bounds below are deliberately loose (a generous ceiling per example, not the
+measured value to 4 decimals): they are here to catch a regression of that
+magnitude, not to freeze the seeding.  Tighten only with a reason.
+
+Note chi2/N > 1 at the seed is expected and is not a defect: MMEXOFAST fits with
+pi_E = 0, so its seeded t_E/u_0/t_0 describe a no-parallax model while this one
+applies a derived pi_E, and the published configs leave the lens mass, distance
+and proper motion open for the engine to fill.
+"""
+
+import glob
+import os
+import pathlib
+import shutil
+import tempfile
+
+import numpy as np
+import pytensor
+import pytest
+import yaml
+
+from exozippy.system import System
+
+EXAMPLES_DIR = pathlib.Path(__file__).parent / ".." / "examples"
+
+pytestmark = pytest.mark.slow
+
+# (example, ceiling on chi2/N at the seed).  Measured values as of 2026-08-11:
+#   DC2018_128 1.213, ob08092 1.415, ob140939 3.039, ob161003 1.717
+CEILINGS = [
+    ("DC2018_128", 2.0),
+    ("ob08092", 2.5),
+    ("ob140939", 5.0),
+    ("ob161003", 3.0),
+]
+
+
+def _seed_chi2(name):
+    """chi2 and chi2/N of the mulens observation at the raw start point."""
+    src = EXAMPLES_DIR / name
+    cfg_path = [
+        p
+        for p in glob.glob(str(src / "*.yaml"))
+        if "params" not in os.path.basename(p)
+        and "hpc" not in os.path.basename(p)
+    ][0]
+    work = pathlib.Path(tempfile.mkdtemp()) / name
+    shutil.copytree(
+        src, work, ignore=shutil.ignore_patterns("fitresults", ".#*", "#*#")
+    )
+    cwd = os.getcwd()
+    os.chdir(work)
+    try:
+        with open(os.path.basename(cfg_path)) as f:
+            config = yaml.safe_load(f)
+        param_file = config.get("parameter_file")
+        user_params = {}
+        if param_file and os.path.exists(param_file):
+            with open(param_file) as f:
+                user_params = yaml.safe_load(f) or {}
+
+        system = System(config, user_params)
+        system.prepare()
+        model = system.build_model()
+
+        # The REAL start, not an assumed all-zeros vector: get_raw_start is
+        # 0 for logit-transformed elements but (initval - mu)/sigma for
+        # Gaussian-path ones, which is nonzero whenever a prior mean differs
+        # from the start value.
+        point = system.get_raw_start(model)
+
+        obs = [v for v in model.observed_RVs if "mulens" in v.name]
+        assert obs, f"{name} has no mulens observation"
+        node = obs[0]
+        ins = node.owner.inputs
+        fn = pytensor.function(
+            model.value_vars,
+            model.replace_rvs_by_values([ins[-2], ins[-1]]),
+            on_unused_input="ignore",
+        )
+        mu, sigma = [
+            np.asarray(a, dtype=float).ravel()
+            for a in fn(*[point[v.name] for v in model.value_vars])
+        ]
+        data = np.asarray(node.tag.observations.eval(), dtype=float).ravel()
+        chi2 = float(np.sum(((data - mu) / sigma) ** 2))
+        return chi2, chi2 / data.size, data.size
+    finally:
+        os.chdir(cwd)
+
+
+@pytest.mark.parametrize("name,ceiling", CEILINGS)
+def test_seed_is_a_sensible_starting_point(name, ceiling):
+    """
+    Given a microlensing example,
+    When its model is evaluated at its raw start point,
+    Then the light curve already fits to better than `ceiling` chi2 per point.
+
+    This is the check that would have caught the proper-motion seeding
+    regression; see the module docstring.
+    """
+    # Arrange / Act
+    chi2, reduced, n = _seed_chi2(name)
+
+    # Assert
+    assert np.isfinite(chi2), f"{name}: chi2 at the seed is not finite"
+    assert reduced < ceiling, (
+        f"{name}: chi2/N at the seed is {reduced:.3f} (chi2={chi2:.1f}, "
+        f"N={n}), above the {ceiling} ceiling.  The start values no longer "
+        f"reproduce the solution the observables came from -- check what the "
+        f"relaxation engine resolved for the lens mass, distance and proper "
+        f"motion."
+    )


### PR DESCRIPTION
Closes #93 for the case it was filed about; see "What this does not fix".

## The problem

`star.pm_ra`/`star.pm_dec` sat at their defaults.yaml value and the relaxation engine let **one** component absorb whatever the seeded `t_E` implied, leaving the other at the default. So the direction of relative proper motion was arbitrary: `mu_rel_mag**2 = mu_ra_rel**2 + mu_dec_rel**2` is one equation in two unknowns, and MMEXOFAST fits with `pi_E = 0` and emits no `pi_E` at all, so nothing in its output breaks the tie.

That family is **not** degenerate. `scripts/diag_rotation.py` holds `|mu_rel|` fixed and rotates it 90 degrees: **delta chi2 ~ 77** at the seed, because the helio -> geo conversion is a vector subtraction (not rotationally symmetric, so `t_E` moves) and `pi_E` is parallel to `mu_rel` (so annual parallax sees the rotation).

## The fix, and the gate that makes it safe

Seed both components at the kinematic prior's mean for the line of sight, distance and population -- thin disk for the lens at its 4 kpc hint, bulge for each source at 8 kpc.

**But the prior may only fill a gap, never contradict.** The first version of this PR seeded unconditionally and made two of the four microlensing examples' *starts* much worse. Measured at the raw start point:

| example | before | ungated | gated (this PR) |
|---|---|---|---|
| DC2018_128 | 1.424 | **1.213** | **1.213** |
| ob08092 | 1.500 | **1.415** | **1.415** |
| ob140939 (`pi_E_N`/`pi_E_E` measured, Yee+2015) | 3.039 | **179.11** | 3.039 |
| ob161003 (two sources, `t_E` + `rho` each) | 1.717 | **3.91** | 1.717 |

(chi2/N at the seed.) So the seeding is skipped when something already implies the proper motion:

- the user supplies `pi_E_N`/`pi_E_E` or a star's `pm_ra`/`pm_dec` -- `pi_E` is parallel to `mu_rel`, so a measured `pi_E` fixes the direction outright; or
- the event has more than one source -- every source would take the same bulge mean, tying their `mu_rel` together, and a resolved binary source distinguishes them.

Both improvements survive, both regressions go away.

Worth recording why the gap exists at all: **no example pins the lens mass or distance.** A published light-curve solution (`t_0, u_0, t_E, s, q, alpha, rho`, sometimes `pi_E`) does not close the system -- `t_E` and `pi_E` without `theta_E` leave mass, distance and proper motion free. That open region is what the engine used to fill by inventing a direction.

## Provenance does the rest, with no special-casing

On the events that are seeded, the hints go in at `RANK_DERIVED_DATA`, tying with the MMEXOFAST seeds, so `t_E = theta_E / |mu_rel_geo|` is over-determined and Condition B rewrites its **lowest-rank** symbol -- `theta_E`, through the lens mass (defaults.yaml, rank 20) and distance (rank 25). On DC2018_128:

| initval | before | after |
|---|---|---|
| `star.pm_ra` | [-14.411, -3.0] | **[-0.346, -3.008]** |
| `star.pm_dec` | [-3.0, -3.0] | **[-1.323, -5.415]** |
| `\|mu_rel\|` | 11.411 | **4.882** (the canonical microlensing value) |
| `lens.t_E` | 18.170 | **18.170** (unchanged) |
| `lens.theta_E` | 0.5677 | **0.2429** |
| lens `distance` | 4000 | 6762 |
| `pi_E_N`, `pi_E_E` | 0.0, -0.2202 | **0.0790, 0.0514** |

The measured `t_E` survives, the proper motion keeps the prior's value, and the lens mass absorbs the difference -- the standard microlensing chain (measured `t_E` plus assumed `mu_rel` implies `theta_E`, hence a mass), and the mass is exactly what a light curve cannot pin down. No rule had to be written for it.

## New tests

**`tests/test_seed_quality.py`** -- chi2/N at the seed for all four microlensing examples, loose ceilings (2.0/2.5/5.0/3.0 against measured 1.213/1.415/3.039/1.717). This is the check whose absence let the ungated version pass 1272 tests while making two starts 60x and 2x worse: a green suite says the model still *builds* and the physics still matches its references, and nothing about starting somewhere sensible. It evaluates `System.get_raw_start` rather than assuming `raw = 0`, since raw is 0 only for logit-transformed elements and `(initval - mu)/sigma` for Gaussian-path ones.

**`tests/test_galactic_pm_hints.py`** (7 tests) -- seeded values equal the prior mean for that line of sight/distance/population; no component left at ~0; **`t_E` stays at the MMEXOFAST value while `theta_E` yields** (the load-bearing one); both gates skip correctly; unknown population raises; seeds skipped without user coordinates.

`GOOD_EXPECTED_LP` re-measured **-945.5716 -> -109962.6577**. Raw values are offsets from the initvals, so changing a start value changes which *physical* point a pinned raw vector decodes to, and those raw numbers came from a trace taken under the old seeding. The comment there says the test is now a reproducibility guard only and that this number is not a statement about fit quality -- chi2/N at that point is ~261, against 1.213 at the seed itself. Restoring a meaningful "good draw" needs fresh raw values from a trace under the new seeding; not done here.

## One implementation, not two

`galacticmodel/physics.py` was an accidental no-op (`galactic_model: {}` parses as a bare annotation). It is now the numpy layer, and `galacticmodel.py` **imports** the line-of-sight basis, the galactocentric frame and the position transform from it instead of keeping inline copies -- `get_galactic_xyz` is pure arithmetic, so one function serves numpy scalars (hints) and tensors (likelihood). That is why `galacticmodel.py` shrinks ~60 lines, and it is the reason the seeds cannot drift from the prior they are meant to be the mean of.

A failure to seed now **warns** rather than logging at debug: during development I passed degrees where radians were wanted, astropy raised, a broad `except` swallowed it, and the whole feature was silently disabled -- no error anywhere, initvals simply unchanged.

## What this does not fix

Filling only the **direction** and leaving the magnitude to the data would serve every case at once, including the two now gated out. But the direction is not a symbol, so provenance cannot express it per-symbol; that needs a `(mu_rel_mag, mu_rel_pa)` basis change. Note that would **not** change sampling: `mu_ra_rel`/`mu_dec_rel` are derived and the sampled coordinates are `star.pm_ra`/`star.pm_dec`, so it is an initialization-only reparameterization and does not meet the bar of making sampling easier. #93 stays open for that.

**Correction (edited after merge).** An earlier version of this description claimed that no example exercises the MMEXOFAST auto-seeding path. That was wrong, twice over:

- `examples/DC2018/run_event.py:180` builds its params with the microlensing start values **deliberately absent** so that auto-initialization triggers (its docstring says so). It generates the event directory at run time, which is why it is not visible as a static example directory.
- `examples/DC2018_128` reaches that path too. Running it logs `Multi-seed sampling: solved 2 seed start points` and applies the seeding (`[lens] star.0 proper motion seeded at the thin_disk prior mean for 4000 pc: pm_ra=-0.346, pm_dec=-1.323 mas/yr`), despite having no `mmexofast:` key in its YAML.

So the automated path this feature is aimed at *is* exercised, and the gates let the seeding through there: no `pi_E`, no `pm`, one source. The claim was based on grepping static example directories rather than on running anything.

## Verification

CI green on `d3396c1`: macOS 3.12 and ubuntu 3.12/3.13/3.14. Locally, the two new test files pass (11 tests) and the seed measurements above were taken directly; the local full-suite run for the gated commit was abandoned mid-way after a worker was killed on a memory-constrained box, so CI is the authoritative signal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
