### PR TITLE
astrometry: fix the rel-mode jitter floor, pinned-parameter plots, orbit-less rendering, and live-chart deps (review 2.6.1-2.6.4)

### DIFF
--- a/src/exozippy/components/astrometryinstrument/astrometryinstrument.py
+++ b/src/exozippy/components/astrometryinstrument/astrometryinstrument.py
@@ -854,13 +854,25 @@ class AstrometryInstrument(Instrument):
         s = d["star_ndx"]
         dt_yr = (t - self.epoch) / DAYS_PER_YEAR
 
-        def get(label, default):
-            return np.atleast_1d(point.get(label, default))[s]
+        def get(param):
+            """This star's value of ``param`` from the point, else its own
+            initval -- the same fallback _point_values uses.
 
-        ra = get(star.ra.label, d["ra_ref"])
-        dec = get(star.dec.label, d["dec_ref"])
-        pm_ra = get(star.pm_ra.label, 0.0)
-        pm_dec = get(star.pm_dec.label, 0.0)
+            A ``point.get(label, 0.0)`` here silently substituted ZERO for
+            any parameter absent from the draws, and pinned (``sigma: 0``)
+            parameters are always absent: a fit with a fixed nonzero proper
+            motion plotted a star that does not move while the likelihood
+            used the pinned value.
+            """
+            val = point.get(param.label)
+            if val is None:
+                val = param.initval
+            return np.atleast_1d(val)[s]
+
+        ra = get(star.ra)
+        dec = get(star.dec)
+        pm_ra = get(star.pm_ra)
+        pm_dec = get(star.pm_dec)
         # parallax is a derived parameter and is usually absent from
         # posterior draws; falling back to 0 silently removed the parallax
         # wiggles from the plots.  Recover it from the sampled distance.
@@ -868,10 +880,7 @@ class AstrometryInstrument(Instrument):
         if plx is not None:
             plx = np.atleast_1d(plx)[s]
         else:
-            dist = get(
-                star.distance.label, np.atleast_1d(star.distance.initval)[s]
-            )
-            plx = 1000.0 / dist
+            plx = 1000.0 / get(star.distance)
 
         dE = (
             (ra - d["ra_ref"]) * np.cos(d["dec_ref"]) * RAD2MAS

--- a/src/exozippy/components/astrometryinstrument/astrometryinstrument.py
+++ b/src/exozippy/components/astrometryinstrument/astrometryinstrument.py
@@ -350,7 +350,19 @@ class AstrometryInstrument(Instrument):
                 d["err_pa"] = (
                     df.iloc[:, 4].values.astype(float) * np.pi / 180.0
                 )
-                min_err = np.min(d["err_sep"])
+                # BOTH rel channels constrain the jitter floor.  The PA
+                # channel's variance is err_pa**2 + jv/sep**2 (see
+                # build_likelihood), i.e. in mas the tangential error is
+                # err_pa*sep -- so a jitter that is legal for the
+                # separation channel can still drive the PA variance
+                # negative (sqrt -> NaN logp and NaN gradient) whenever
+                # err_pa*sep < sqrt(0.95)*min(err_sep).  That is the
+                # common case for interferometric data, whose tangential
+                # error is far better than its radial one.  Floor on
+                # whichever channel is tighter.
+                min_err = min(
+                    np.min(d["err_sep"]), np.min(d["err_pa"] * d["sep"])
+                )
 
             # Parallax factors (needed for gaia/abs only)
             if mode in ("gaia", "abs"):

--- a/src/exozippy/components/astrometryinstrument/astrometryinstrument.py
+++ b/src/exozippy/components/astrometryinstrument/astrometryinstrument.py
@@ -860,6 +860,12 @@ class AstrometryInstrument(Instrument):
             return z, z.copy()
         return fn(np.asarray(t, dtype=np.float64), *vals)
 
+    # Star parameters the numpy _linear_terms model reads.  Kept next to it
+    # because _linear_term_deps has to declare exactly these labels: the
+    # function is NumPy, not pytensor, so there is no graph for
+    # _model_trace_param_deps to walk.
+    _LINEAR_STAR_PARAMS = ("ra", "dec", "pm_ra", "pm_dec", "distance")
+
     def _linear_terms(self, d, t, point, system):
         """Numpy pm+parallax+offset model (mas) at the reference point."""
         star = system.star
@@ -911,6 +917,45 @@ class AstrometryInstrument(Instrument):
             for label in self._model_trace_param_deps(node, system):
                 if label not in deps:
                     deps.append(label)
+        return deps
+
+    @staticmethod
+    def _merge_deps(*dep_lists):
+        """Order-preserving union of param_deps lists."""
+        deps = []
+        for lst in dep_lists:
+            for label in lst:
+                if label not in deps:
+                    deps.append(label)
+        return deps
+
+    def _linear_term_deps(self, system):
+        """param_deps of the numpy pm+parallax model (``_linear_terms``).
+
+        ``_model_trace_param_deps`` walks a pytensor graph, and this model
+        has none: ``_linear_terms`` reads the point with NumPy, which is
+        what lets the chart be drawn straight after ``load_data``, before
+        any model exists.  The dependencies are therefore declared
+        explicitly, from the one list (``_LINEAR_STAR_PARAMS``) that
+        ``_linear_terms`` itself reads, and filtered to labels the
+        Evaluator can actually send (``system.plot_params``;
+        ``star.parallax`` is derived, so ``distance`` is the sampled
+        coordinate that moves it).
+
+        Without these the Evaluator's ``changed_label`` filter skipped
+        this component for every ra/dec/pm/distance slider -- and in an
+        orbit-less gaia/abs fit those are ALL the parameters that move the
+        star, so the live chart froze completely.
+        """
+        star = getattr(system, "star", None)
+        if star is None or not hasattr(system, "plot_params"):
+            return []
+        known = {p.label for p in system.plot_params}
+        deps = []
+        for attr in self._LINEAR_STAR_PARAMS:
+            label = getattr(getattr(star, attr, None), "label", None)
+            if label in known and label not in deps:
+                deps.append(label)
         return deps
 
     def plot(self, system, points, filename_prefix="debug"):
@@ -995,8 +1040,14 @@ class AstrometryInstrument(Instrument):
                     w_model = (dE_lin + dE_orb) * d["sin_psi"] + (
                         dN_lin + dN_orb
                     ) * d["cos_psi"]
-                    deps = self._node_pair_deps(
-                        photo_nodes[i] if photo_nodes else None, system
+                    # The model is linear terms + photocenter orbit, so the
+                    # deps are the union of both -- and with no orbit the
+                    # linear ones are all there is (see _linear_term_deps).
+                    deps = self._merge_deps(
+                        self._linear_term_deps(system),
+                        self._node_pair_deps(
+                            photo_nodes[i] if photo_nodes else None, system
+                        ),
                     )
                     traces.append(
                         Trace(
@@ -1037,8 +1088,15 @@ class AstrometryInstrument(Instrument):
                     )
                 )
                 if point is not None:
-                    deps = self._node_pair_deps(
-                        photo_nodes[i] if photo_nodes else None, system
+                    # The DATA trace subtracts the linear terms (see
+                    # dynamic_data below), so this chart moves with the
+                    # ra/dec/pm/distance sliders even when the model trace
+                    # is the orbit alone -- or absent.
+                    deps = self._merge_deps(
+                        self._linear_term_deps(system),
+                        self._node_pair_deps(
+                            photo_nodes[i] if photo_nodes else None, system
+                        ),
                     )
                     if photo_fns and photo_fns[i] is not None:
                         vals = self._point_values(system, point)

--- a/src/exozippy/components/astrometryinstrument/astrometryinstrument.py
+++ b/src/exozippy/components/astrometryinstrument/astrometryinstrument.py
@@ -753,9 +753,16 @@ class AstrometryInstrument(Instrument):
     # Plotting
     # ------------------------------------------------------------------
     def compile_plotters(self, model, system):
-        """Compile fast PyTensor functions for plotting."""
-        if not hasattr(system, "orbit") or not hasattr(system.orbit, "arsun"):
-            return
+        """Compile fast PyTensor functions for plotting.
+
+        An orbit is NOT required: a gaia/abs fit for proper motion and
+        parallax alone is legal, and its data, its linear model and its
+        sky plot need no orbit.  The per-instrument slots are therefore
+        always populated (with None where nothing is compiled), so plot()
+        and plot_data() render the same charts either way; only the
+        orbit-dependent pieces are skipped.
+        """
+        has_orbit = hasattr(system, "orbit") and hasattr(system.orbit, "arsun")
 
         param_symbols = [p.value for p in system.plot_params]
         t_input = pt.vector("t_input")
@@ -768,7 +775,7 @@ class AstrometryInstrument(Instrument):
         self._compiled_photo = []
         self._photo_nodes = []
         for i in range(self.n_elements):
-            if self.modes[i] == "rel":
+            if self.modes[i] == "rel" or not has_orbit:
                 self._compiled_photo.append(None)
                 self._photo_nodes.append(None)
                 continue
@@ -799,7 +806,9 @@ class AstrometryInstrument(Instrument):
         self._compiled_rel = []
         self._rel_nodes = []
         for i in range(self.n_elements):
-            if self.modes[i] != "rel":
+            # rel data always require an orbit (build_likelihood raises
+            # without one), so has_orbit only ever skips an empty list here.
+            if self.modes[i] != "rel" or not has_orbit:
                 self._compiled_rel.append(None)
                 self._rel_nodes.append(None)
                 continue
@@ -814,19 +823,22 @@ class AstrometryInstrument(Instrument):
             )
 
         # Orbital elements in internal units (all orbits), for the node/
-        # direction annotations of the sky plot.
-        orb = system.orbit
-        self._compiled_elements = pytensor.function(
-            inputs=param_symbols,
-            outputs=[
-                orb.tp.value,
-                orb.n.value,
-                orb.ecc.value,
-                orb.omega.value,
-                orb.bigomega.value,
-            ],
-            on_unused_input="ignore",
-        )
+        # direction annotations of the sky plot.  None with no orbit: the
+        # sky plot then drops its orbit panel (see plot_sky).
+        self._compiled_elements = None
+        if has_orbit:
+            orb = system.orbit
+            self._compiled_elements = pytensor.function(
+                inputs=param_symbols,
+                outputs=[
+                    orb.tp.value,
+                    orb.n.value,
+                    orb.ecc.value,
+                    orb.omega.value,
+                    orb.bigomega.value,
+                ],
+                on_unused_input="ignore",
+            )
 
     def _point_values(self, system, point):
         vals = []
@@ -909,6 +921,11 @@ class AstrometryInstrument(Instrument):
         the GUI draws the same ones via plotly (see plotrender.py's module
         docstring).  plot_sky stays hand-drawn: its arrows and node
         annotations are outside the PlotSpec vocabulary.
+
+        The guard below means "compile_plotters has not run yet", nothing
+        more: an orbit is not required (review 2.6.3) -- compile_plotters
+        populates both lists for every topology, so a pm+parallax fit
+        renders exactly the same charts, minus the orbit pieces.
         """
         if not hasattr(self, "_compiled_photo") and not hasattr(
             self, "_compiled_rel"
@@ -940,6 +957,7 @@ class AstrometryInstrument(Instrument):
 
         sysname = getattr(system, "name", "")
         photo_nodes = getattr(self, "_photo_nodes", None)
+        photo_fns = getattr(self, "_compiled_photo", None)
         rel_nodes = getattr(self, "_rel_nodes", None)
         rel_fns = getattr(self, "_compiled_rel", None)
 
@@ -1019,22 +1037,23 @@ class AstrometryInstrument(Instrument):
                     )
                 )
                 if point is not None:
-                    vals = self._point_values(system, point)
-                    t_pretty = np.linspace(t.min(), t.max(), 2000)
-                    dE_p, dN_p = self._eval_photo(i, t_pretty, vals)
                     deps = self._node_pair_deps(
                         photo_nodes[i] if photo_nodes else None, system
                     )
-                    traces.append(
-                        Trace(
-                            name="photocenter orbit",
-                            role="model",
-                            kind="line",
-                            x=dE_p,
-                            y=dN_p,
-                            style={"legend": True, "lw": 1},
+                    if photo_fns and photo_fns[i] is not None:
+                        vals = self._point_values(system, point)
+                        t_pretty = np.linspace(t.min(), t.max(), 2000)
+                        dE_p, dN_p = self._eval_photo(i, t_pretty, vals)
+                        traces.append(
+                            Trace(
+                                name="photocenter orbit",
+                                role="model",
+                                kind="line",
+                                x=dE_p,
+                                y=dN_p,
+                                style={"legend": True, "lw": 1},
+                            )
                         )
-                    )
                 meta["x_inverted"] = True  # East to the left
                 meta["aspect_equal"] = True
                 # The data trace subtracts the point's pm+plx linear terms,
@@ -1122,11 +1141,27 @@ class AstrometryInstrument(Instrument):
         Right: the photocenter orbit alone, with the barycenter, the line
         of nodes, the ascending node (where the photocenter recedes from
         the observer), and the direction of motion.
+
+        The right panel is dropped -- and the figure becomes a single
+        panel -- when no orbit moves this dataset's star (a pm+parallax
+        fit, or an orbit that has the star in its companion group): its
+        curve would be identically zero and the left panel's "with orbit"
+        trace would duplicate the "pm + parallax" one.
         """
         d = self.datasets[i]
         t = d["time"]
         vals = self._point_values(system, point)
-        fig, (axL, axR) = plt.subplots(1, 2, figsize=(13, 6))
+        photo = getattr(self, "_compiled_photo", None)
+        has_orbit = (
+            getattr(self, "_compiled_elements", None) is not None
+            and photo is not None
+            and photo[i] is not None
+        )
+        if has_orbit:
+            fig, (axL, axR) = plt.subplots(1, 2, figsize=(13, 6))
+        else:
+            fig, axL = plt.subplots(1, 1, figsize=(7, 6))
+            axR = None
 
         # ---------------- left: full path over the data span ----------------
         t_dense = np.linspace(t.min(), t.max(), 4000)
@@ -1152,15 +1187,16 @@ class AstrometryInstrument(Instrument):
             zorder=1,
             label="pm + parallax",
         )
-        axL.plot(
-            dE_lin + dE_orb,
-            dN_lin + dN_orb,
-            "-",
-            color="0.4",
-            lw=0.8,
-            zorder=2,
-            label="pm + parallax + orbit",
-        )
+        if has_orbit:
+            axL.plot(
+                dE_lin + dE_orb,
+                dN_lin + dN_orb,
+                "-",
+                color="0.4",
+                lw=0.8,
+                zorder=2,
+                label="pm + parallax + orbit",
+            )
 
         dE_lin_o, dN_lin_o = self._linear_terms(d, t, point, system)
         dE_orb_o, dN_orb_o = self._eval_photo(i, t, vals)
@@ -1193,96 +1229,101 @@ class AstrometryInstrument(Instrument):
         axL.set_title("Path on sky")
         axL.legend(loc="best", fontsize="small")
 
-        # ---------------- right: orbit alone, with annotations --------------
-        # elements in internal units (per planet)
-        tp_arr, n_arr, ecc_arr, w_arr, bigom_arr = self._compiled_elements(
-            *vals
-        )
-        P_orb = 2.0 * np.pi / np.atleast_1d(n_arr)
-        t1 = t.max()
-        t_orb = np.linspace(t1 - np.max(P_orb), t1, 2000)
-        dE_o, dN_o = self._eval_photo(i, t_orb, vals)
-        axR.plot(dE_o, dN_o, "k-", lw=1.2, zorder=2, label="photocenter orbit")
-        dE_ep, dN_ep = self._eval_photo(i, t, vals)
-        axR.plot(
-            dE_ep, dN_ep, "r.", ms=5, zorder=3, label="observation epochs"
-        )
-        axR.plot(0, 0, "k+", ms=12, mew=2, zorder=4)  # barycenter
-
-        n_planets = len(np.atleast_1d(tp_arr))
-        if n_planets == 1:
-            tp = float(np.atleast_1d(tp_arr)[0])
-            n_mm = float(np.atleast_1d(n_arr)[0])
-            ecc = float(np.atleast_1d(ecc_arr)[0])
-            w = float(np.atleast_1d(w_arr)[0])
-            bigom = float(np.atleast_1d(bigom_arr)[0])
-            P = 2.0 * np.pi / n_mm
-
-            # Line of nodes: through the barycenter at PA = bigomega
-            r_max = 1.1 * np.max(np.hypot(dE_o, dN_o))
+        if has_orbit:
+            # ---------------- right: orbit alone, with annotations --------------
+            # elements in internal units (per planet)
+            tp_arr, n_arr, ecc_arr, w_arr, bigom_arr = self._compiled_elements(
+                *vals
+            )
+            P_orb = 2.0 * np.pi / np.atleast_1d(n_arr)
+            t1 = t.max()
+            t_orb = np.linspace(t1 - np.max(P_orb), t1, 2000)
+            dE_o, dN_o = self._eval_photo(i, t_orb, vals)
             axR.plot(
-                [r_max * np.sin(bigom), -r_max * np.sin(bigom)],
-                [r_max * np.cos(bigom), -r_max * np.cos(bigom)],
-                "--",
-                color="0.5",
-                lw=1,
-                zorder=1,
-                label="line of nodes",
+                dE_o, dN_o, "k-", lw=1.2, zorder=2, label="photocenter orbit"
             )
-
-            # Ascending node: f = -omega_*; with our conventions the
-            # photocenter crosses it moving AWAY from the observer (max RV)
-            f_node = -w
-            E_node = 2.0 * np.arctan2(
-                np.sqrt(1 - ecc) * np.sin(f_node / 2.0),
-                np.sqrt(1 + ecc) * np.cos(f_node / 2.0),
-            )
-            M_node = E_node - ecc * np.sin(E_node)
-            t_node = tp + M_node / n_mm
-            # shift into the plotted window
-            t_node += np.ceil((t_orb[0] - t_node) / P) * P
-            (xn,), (yn,) = self._eval_photo(
-                i, np.array([t_node], dtype=np.float64), vals
-            )
+            dE_ep, dN_ep = self._eval_photo(i, t, vals)
             axR.plot(
-                xn,
-                yn,
-                "o",
-                color="tab:blue",
-                ms=10,
-                mfc="none",
-                mew=2,
-                zorder=5,
-                label="ascending node",
+                dE_ep, dN_ep, "r.", ms=5, zorder=3, label="observation epochs"
             )
+            axR.plot(0, 0, "k+", ms=12, mew=2, zorder=4)  # barycenter
 
-            # Direction of motion: a curved arrow tracing the orbit away
-            # from the ascending node, drawn 25% outside the orbit itself.
-            t_arc = np.linspace(t_node, t_node + 0.06 * P, 60)
-            xa, ya = self._eval_photo(i, t_arc, vals)
-            xa, ya = 1.25 * np.asarray(xa), 1.25 * np.asarray(ya)
-            axR.plot(xa[:-1], ya[:-1], "-", color="tab:blue", lw=2, zorder=6)
-            axR.annotate(
-                "",
-                xy=(xa[-1], ya[-1]),
-                xytext=(xa[-2], ya[-2]),
-                zorder=6,
-                arrowprops=dict(
-                    arrowstyle="-|>",
+            n_planets = len(np.atleast_1d(tp_arr))
+            if n_planets == 1:
+                tp = float(np.atleast_1d(tp_arr)[0])
+                n_mm = float(np.atleast_1d(n_arr)[0])
+                ecc = float(np.atleast_1d(ecc_arr)[0])
+                w = float(np.atleast_1d(w_arr)[0])
+                bigom = float(np.atleast_1d(bigom_arr)[0])
+                P = 2.0 * np.pi / n_mm
+
+                # Line of nodes: through the barycenter at PA = bigomega
+                r_max = 1.1 * np.max(np.hypot(dE_o, dN_o))
+                axR.plot(
+                    [r_max * np.sin(bigom), -r_max * np.sin(bigom)],
+                    [r_max * np.cos(bigom), -r_max * np.cos(bigom)],
+                    "--",
+                    color="0.5",
+                    lw=1,
+                    zorder=1,
+                    label="line of nodes",
+                )
+
+                # Ascending node: f = -omega_*; with our conventions the
+                # photocenter crosses it moving AWAY from the observer (max RV)
+                f_node = -w
+                E_node = 2.0 * np.arctan2(
+                    np.sqrt(1 - ecc) * np.sin(f_node / 2.0),
+                    np.sqrt(1 + ecc) * np.cos(f_node / 2.0),
+                )
+                M_node = E_node - ecc * np.sin(E_node)
+                t_node = tp + M_node / n_mm
+                # shift into the plotted window
+                t_node += np.ceil((t_orb[0] - t_node) / P) * P
+                (xn,), (yn,) = self._eval_photo(
+                    i, np.array([t_node], dtype=np.float64), vals
+                )
+                axR.plot(
+                    xn,
+                    yn,
+                    "o",
                     color="tab:blue",
-                    lw=2,
-                    mutation_scale=22,
-                    shrinkA=0,
-                    shrinkB=0,
-                ),
-            )
+                    ms=10,
+                    mfc="none",
+                    mew=2,
+                    zorder=5,
+                    label="ascending node",
+                )
 
-        axR.invert_xaxis()  # East to the left
-        axR.set_aspect("equal", adjustable="datalim")
-        axR.set_xlabel(r"$\Delta\alpha^*$ [mas]")
-        axR.set_ylabel(r"$\Delta\delta$ [mas]")
-        axR.set_title("Photocenter orbit")
-        axR.legend(loc="best", fontsize="small")
+                # Direction of motion: a curved arrow tracing the orbit away
+                # from the ascending node, drawn 25% outside the orbit itself.
+                t_arc = np.linspace(t_node, t_node + 0.06 * P, 60)
+                xa, ya = self._eval_photo(i, t_arc, vals)
+                xa, ya = 1.25 * np.asarray(xa), 1.25 * np.asarray(ya)
+                axR.plot(
+                    xa[:-1], ya[:-1], "-", color="tab:blue", lw=2, zorder=6
+                )
+                axR.annotate(
+                    "",
+                    xy=(xa[-1], ya[-1]),
+                    xytext=(xa[-2], ya[-2]),
+                    zorder=6,
+                    arrowprops=dict(
+                        arrowstyle="-|>",
+                        color="tab:blue",
+                        lw=2,
+                        mutation_scale=22,
+                        shrinkA=0,
+                        shrinkB=0,
+                    ),
+                )
+
+            axR.invert_xaxis()  # East to the left
+            axR.set_aspect("equal", adjustable="datalim")
+            axR.set_xlabel(r"$\Delta\alpha^*$ [mas]")
+            axR.set_ylabel(r"$\Delta\delta$ [mas]")
+            axR.set_title("Photocenter orbit")
+            axR.legend(loc="best", fontsize="small")
 
         fig.suptitle(f"{d['name']} ({system.name})")
         fig.tight_layout()

--- a/tests/test_astrometry.py
+++ b/tests/test_astrometry.py
@@ -802,3 +802,286 @@ def test_jax_gradient_finite_with_massive_companion(astrometry_system):
         if not np.all(np.isfinite(np.asarray(g)))
     ]
     assert not bad, f"non-finite JAX gradients: {bad}"
+
+
+# ---------------------------------------------------------------------------
+# Review 2.6.1: the rel-mode jitter-variance floor must cover BOTH channels
+# ---------------------------------------------------------------------------
+
+# Interferometric-style relative astrometry: the TANGENTIAL error
+# (err_pa * sep) is far better than the radial one (err_sep).  That is the
+# regime in which a jitter legal for the separation channel still makes the
+# position-angle variance err_pa^2 + jv/sep^2 negative.
+_INTERF = dict(P=300.0, tp=2457000.0, a_rel=50.0, err_sep=0.05, err_pa=0.02)
+
+
+def _write_interferometric_rel(path):
+    """Write a rel-mode file whose PA channel is the tighter constraint."""
+    rng = np.random.default_rng(3)
+    t = np.sort(rng.uniform(2456900.0, 2457900.0, 20))
+    ph = 2 * np.pi * (t - _INTERF["tp"]) / _INTERF["P"]
+    dE = _INTERF["a_rel"] * np.cos(ph)
+    dN = _INTERF["a_rel"] * 0.7 * np.sin(ph)
+    np.savetxt(
+        path,
+        np.column_stack(
+            [
+                t,
+                np.hypot(dE, dN),
+                np.full_like(t, _INTERF["err_sep"]),
+                np.degrees(np.arctan2(dE, dN)),
+                np.full_like(t, _INTERF["err_pa"]),
+            ]
+        ),
+    )
+    return t
+
+
+def test_rel_jitter_floor_covers_the_pa_channel(tmp_path):
+    """
+    Given: rel-mode data whose tangential error (err_pa*sep) is much smaller
+           than its separation error
+    When: load_data computes the jitter-variance floor
+    Then: the floor keeps the PA channel's variance positive as well -- it is
+          set by whichever channel is tighter, not by err_sep alone
+
+    Regression (review 2.6.1): the floor was -0.95*min(err_sep)**2, which for
+    these data still allows a jitter that drives err_pa**2 + jv/sep**2
+    negative -> NaN sigma over a region the sampler may visit.
+    """
+    # Arrange
+    f = tmp_path / "interf.astrom"
+    _write_interferometric_rel(f)
+    comp = AstrometryInstrument(
+        [{"name": "I", "file": str(f), "mode": "rel"}], ConfigManager({})
+    )
+    system = _DummySystem()
+    system.star = _DummyComponent(1)
+
+    # Act
+    comp.load_data(system)
+    floor = float(np.atleast_1d(comp.jittervar_lower[0])[0])
+    d = comp.datasets[0]
+    tangential = d["err_pa"] * d["sep"]  # mas
+
+    # Assert: this file really is PA-limited (else the test proves nothing)
+    assert np.min(tangential) < np.min(d["err_sep"])
+    # every allowed jitter keeps BOTH variances positive
+    assert np.all(d["err_sep"] ** 2 + floor > 0.0)
+    assert np.all(d["err_pa"] ** 2 + floor / d["sep"] ** 2 > 0.0)
+    # and it is the shared -0.95 * min(err)**2 margin over the tighter channel
+    assert floor == pytest.approx(-0.95 * np.min(tangential) ** 2)
+
+
+@pytest.fixture(scope="module")
+def interferometric_rel_system(tmp_path_factory):
+    """A one-instrument rel-mode System on PA-limited data."""
+    tmp_dir = tmp_path_factory.mktemp("interf")
+    _write_interferometric_rel(tmp_dir / "interf.astrom")
+
+    config = {
+        "name": "interf",
+        "star": [{"name": "A", "mist": False}],
+        "planet": [{"name": "b"}],
+        "orbit": [{"name": "b"}],
+        "astrometryinstrument": [
+            {
+                "name": "I",
+                "file": str(tmp_dir / "interf.astrom"),
+                "mode": "rel",
+            }
+        ],
+    }
+    user_params = {
+        "star.A.mass": {"initval": 1.0, "sigma": 0.05},
+        "star.A.radius": {"initval": 1.0, "sigma": 0.1},
+        "star.A.teff": {"initval": 5800, "sigma": 100},
+        "star.A.feh": {"initval": 0.0, "sigma": 0.1},
+        "star.A.distance": {"initval": 100.0},
+        "planet.b.mass": {"initval": 300.0},
+        "orbit.b.period": {"initval": _INTERF["P"]},
+        "orbit.b.tc": {"initval": _INTERF["tp"]},
+    }
+
+    system = System(config, user_params=user_params)
+    system.prepare()
+    model = system.build_model()
+    return system, model, model.initial_point()
+
+
+@pytest.mark.slow
+def test_rel_jitter_inside_its_bound_has_finite_logp_and_gradient(
+    interferometric_rel_system,
+):
+    """
+    Given: a rel-mode model on PA-limited data
+    When: jitter_variance is set to values strictly INSIDE its resolved
+          lower bound (the region the sampler is free to visit)
+    Then: logp and every dlogp entry are finite there
+
+    Regression (review 2.6.1): with the floor taken from err_sep alone the
+    bound resolved to -0.002375 while the PA channel needs jv > -1.5e-4, and
+    logp at jitter_variance = -0.0023726 was -inf with a non-finite
+    gradient -- a wall of NaN inside the allowed interval.
+    """
+    system, model, point = interferometric_rel_system
+    jv = system.astrometryinstrument.jitter_variance
+    lower = float(np.atleast_1d(jv.lower)[0])
+    assert lower < 0.0  # the bound under test is the negative floor
+
+    key = f"{jv.label}_raw"
+    logp_fn = model.compile_logp()
+    dlogp_fn = model.compile_dlogp()
+
+    for frac in (0.999, 0.5, 0.0):  # 0.999*lower is a hair inside the wall
+        probe = dict(point)
+        probe[key] = jv.raw_from_initval(np.array([frac * lower]))
+        logp = logp_fn(probe)
+        dlogp = dlogp_fn(probe)
+        assert np.isfinite(logp), f"logp = {logp} at jv = {frac * lower:.6g}"
+        assert np.all(np.isfinite(dlogp)), (
+            f"non-finite dlogp at jv = {frac * lower:.6g}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reviews 2.6.2 / 2.6.3 / 2.6.4: plots of an orbit-less gaia fit
+# ---------------------------------------------------------------------------
+
+# Proper motion is PINNED here (sigma: 0), so it is absent from every draw --
+# which is exactly what point.get(label, 0.0) used to turn into zero.
+_PM = dict(ra0=262.171207, dec0=-0.581091, pmra=-7.70, pmdec=-25.85, plx=2.09)
+
+
+@pytest.fixture(scope="module")
+def pm_only_gaia_system(tmp_path_factory):
+    """A legal gaia fit with NO orbit: proper motion + parallax only."""
+    tmp_dir = tmp_path_factory.mktemp("pmonly")
+    rng = np.random.default_rng(5)
+    t = np.sort(rng.uniform(2456900.0, 2457900.0, 40))
+    psi = rng.uniform(0, 2 * np.pi, 40)
+    err = np.full(40, 0.1)
+    np.savetxt(
+        tmp_dir / "pm.astrom",
+        np.column_stack([t, rng.normal(0, err), err, np.degrees(psi)]),
+    )
+
+    config = {
+        "name": "pmonly",
+        "star": [{"name": "A", "mist": False}],
+        "astrometryinstrument": [
+            {
+                "name": "G",
+                "file": str(tmp_dir / "pm.astrom"),
+                "mode": "gaia",
+                "observer_location": "earth",
+            }
+        ],
+    }
+    user_params = {
+        "star.A.mass": {"initval": 1.0, "sigma": 0.05},
+        "star.A.radius": {"initval": 1.0, "sigma": 0.1},
+        "star.A.teff": {"initval": 5800, "sigma": 100},
+        "star.A.feh": {"initval": 0.0, "sigma": 0.1},
+        "star.A.ra": {"initval": _PM["ra0"]},
+        "star.A.dec": {"initval": _PM["dec0"]},
+        "star.A.pm_ra": {"initval": _PM["pmra"], "sigma": 0},
+        "star.A.pm_dec": {"initval": _PM["pmdec"], "sigma": 0},
+        "star.A.distance": {"initval": 1000.0 / _PM["plx"]},
+    }
+
+    system = System(config, user_params=user_params)
+    system.prepare()
+    model = system.build_model()
+    point = system.get_internal_point(model, model.initial_point())
+    system.compile_plotter_functions(model)
+    return system, model, point
+
+
+@pytest.mark.slow
+def test_plot_model_uses_pinned_proper_motion(pm_only_gaia_system):
+    """
+    Given: a fit whose proper motion is PINNED (sigma: 0) and therefore
+           absent from the point
+    When: the along-scan model trace is built by plot_data
+    Then: it carries the pinned proper motion, matching an independent
+          pm + parallax evaluation
+
+    Regression (review 2.6.2): _linear_terms read the point with
+    point.get(label, 0.0), so every pinned parameter silently plotted as
+    zero -- the star stood still in the plots while the likelihood used
+    its real proper motion.
+    """
+    system, _, point = pm_only_gaia_system
+    comp = system.astrometryinstrument
+    d = comp.datasets[0]
+
+    # Act
+    spec = comp.plot_data(system, point)[0]
+    model_trace = [tr for tr in spec.traces if tr.role == "model"][0]
+
+    # Assert: independent pm + parallax along-scan reference (no orbit)
+    dt_yr = (d["time"] - comp.epoch) / 365.25
+    dE = _PM["pmra"] * dt_yr + _PM["plx"] * d["P_E"]
+    dN = _PM["pmdec"] * dt_yr + _PM["plx"] * d["P_N"]
+    expected = dE * d["sin_psi"] + dN * d["cos_psi"]
+    np.testing.assert_allclose(model_trace.y, expected, atol=1e-6)
+
+    # ... and the pm term genuinely dominates, so dropping it is not a
+    # rounding-level difference: with pm = 0 the trace would be tiny
+    parallax_only = (
+        _PM["plx"] * d["P_E"] * d["sin_psi"]
+        + _PM["plx"] * d["P_N"] * d["cos_psi"]
+    )
+    assert np.ptp(expected) > 5 * np.ptp(parallax_only)
+
+
+@pytest.mark.slow
+def test_orbitless_gaia_fit_still_renders_its_plots(
+    pm_only_gaia_system, tmp_path
+):
+    """
+    Given: a legal gaia fit with no orbit component
+    When: plot_data (data-only and with a point) and plot() are called
+    Then: specs come back and the PDFs are written -- neither the data nor
+          the pm+parallax model nor the sky plot needs an orbit
+
+    Regression (review 2.6.3): compile_plotters returned early without an
+    orbit, leaving _compiled_photo unset, and plot() bailed on that -- an
+    orbit-less astrometry fit produced no astrometry PDFs at all.
+    """
+    system, _, point = pm_only_gaia_system
+    comp = system.astrometryinstrument
+
+    # data-only specs are usable without a model at all
+    assert len(comp.plot_data(system, None)) == 1
+    assert len(comp.plot_data(system, point)) == 1
+
+    prefix = str(tmp_path / "px")
+    comp.plot(system, [point], filename_prefix=prefix)
+    assert (tmp_path / "px_astrometry_G.pdf").exists()
+    assert (tmp_path / "px_astrometry_G_sky.pdf").exists()
+
+
+@pytest.mark.slow
+def test_gaia_param_deps_include_the_linear_terms(pm_only_gaia_system):
+    """
+    Given: a gaia spec whose model is the numpy pm+parallax _linear_terms
+    When: its param_deps are declared
+    Then: they name the star's ra/dec/pm/distance labels
+
+    Regression (review 2.6.4): param_deps only ever came from walking the
+    photocenter-orbit tensor graph, so the NumPy linear terms contributed
+    nothing.  With no orbit the list was empty, the Evaluator's
+    changed_label filter skipped the component for every slider, and the
+    GUI live chart froze completely.
+    """
+    system, _, point = pm_only_gaia_system
+    spec = system.astrometryinstrument.plot_data(system, point)[0]
+
+    star = system.star
+    for par in (star.ra, star.dec, star.pm_ra, star.pm_dec, star.distance):
+        assert par.label in spec.param_deps, f"{par.label} missing"
+    # every declared dep must be a label the Evaluator can actually send
+    known = {p.label for p in system.plot_params}
+    assert set(spec.param_deps) <= known


### PR DESCRIPTION
## 2.6.1 -- the rel-mode jitter floor ignored the PA channel

The floor was computed over `err_sep` only, but the PA channel's variance is `err_pa^2 + jv/sep^2`, so a jitter variance legal for separation drives PA variance negative. Reproduced on a 20-epoch interferometric-regime dataset (`err_sep = 0.05` mas, `sep` 36-50 mas, `err_pa = 0.02` deg, so the tangential error is 0.0123 mas):

| | pre-fix | post-fix |
|---|---|---|
| resolved `jitter_variance.lower` | -0.0023750 | -0.00014286 |
| logp at `jv = -0.00237263` (inside that bound) | **-inf** | outside the new bound |
| gradient there | **non-finite** | -- |
| logp at 0.999 x the resolved bound | -inf | **finite** (-3.78e8) |
| gradient there | non-finite | **all finite** |

The fix is one line -- `min_err = min(min(err_sep), min(err_pa*sep))` -- reusing `Instrument._jitter_floor` (same `-0.95` margin) and the same `"overrides"` channel as PR #95's RV floor. No new mechanism. The review's threshold checks out: the failure region is `err_pa*sep < sqrt(0.95)*min(err_sep) = 0.9747*min(err_sep)`.

Precision on the symptom: the logp is `-inf` rather than `NaN` -- the `sqrt` does produce a NaN sigma and PyMC's positivity check converts it. Same failure class: a gradient-free wall inside the allowed interval.

## 2.6.2 -- plots silently substituted zero for pinned parameters

`point.get(label, 0.0)` returns the default for anything absent from the draws, and **pinned (`sigma: 0`) parameters are absent**. Reproduced with `pm` pinned at (-7.70, -25.85) mas/yr: the along-scan model trace came out as the parallax term alone -- first epoch **-0.94 mas instead of -30.31**, peak-to-peak 3.9 instead of 43.6 mas. The likelihood used the pinned values; the plot did not.

Fixed by falling back to `param.initval`, matching `_point_values`. This also subsumes the open-coded `distance` fallback and moves ra/dec off the load-time `ra_ref`/`dec_ref` onto their own initvals.

**Audit of every other `point.get` default in the file**: only two exist -- `_point_values` (already correct) and the `star.parallax` lookup (deliberately has no default; it is derived and recovered from the sampled distance).

## 2.6.3 -- an orbit-less gaia/abs fit rendered nothing

A `star` + one gaia instrument config (pm + parallax only, legal) builds and samples, but `compile_plotters` returned early, `_compiled_photo` was never set, and `plot()` bailed: **zero PDFs**. (`plot_data(system, None)` already worked -- the gate was only in `plot`/`compile_plotters`.)

`compile_plotters` now always populates the per-instrument slots (None where nothing compiles) and skips only the orbit-dependent pieces. `plot_sky` becomes a single panel when no orbit moves that dataset's star -- the right panel is genuinely orbit-only, and its curve plus the left panel's combined trace would both duplicate the pm+parallax line. The same guard skips the abs-mode photocenter trace rather than shipping a flat zero. No new plots invented; `px_astrometry_G.pdf` and `px_astrometry_G_sky.pdf` now both appear.

## 2.6.4 -- `param_deps` omitted the linear terms, freezing the GUI

`param_deps == []` on the orbit-less gaia spec while `system.plot_params` contains `star.ra/dec/pm_ra/pm_dec/distance`, so the Evaluator's `changed_label` filter skipped the component for every slider.

**On the numpy-not-symbolic problem:** `_linear_terms` is numpy, so there is no tensor graph to walk. Building a parallel pytensor copy of pm+parallax purely to be walked would duplicate the model and forfeit what the numpy version buys -- `plot_data` working right after `load_data`, before any model exists, which `test_plot_data_data_only_before_build` pins. Since the dependency set is five fixed star parameters, `_linear_term_deps` declares them explicitly from a `_LINEAR_STAR_PARAMS` tuple sitting immediately above `_linear_terms`, filtered against `system.plot_params` so only labels the Evaluator can actually send survive. `_merge_deps` unions that with the existing graph walk, so an orbit-bearing fit gets both sets.

## Tests

Five appended to `tests/test_astrometry.py`; **all five fail on pre-fix source** (verified by `git checkout 8ece8cb -- src/...`: `logp = -inf at jv = -0.00237263`, `Mismatched elements: 40/40`, missing `px_astrometry_G.pdf`, `'star.ra' in []`).

- rel jitter floor covers both channels, and equals the shared `-0.95*min(err)**2` over the tighter one;
- `jitter_variance` probed at 0.999/0.5/0.0 x its resolved lower bound through `raw_from_initval` (a real point of the built model), asserting **logp and every dlogp entry** finite;
- the model trace's **values** compared against an independent pm+parallax reference, plus a check that pm dominates parallax so the pre-fix failure cannot be rounding;
- orbit-less specs and both PDF files;
- the five dep labels present, and every declared dep a subset of `system.plot_params`.

No existing assertion weakened -- in particular `test_plot_data_data_only_before_build`'s `param_deps == []` still holds, since deps are declared only on the with-a-point branch.

`tests/test_astrometry.py` **25 passed**, `tests/test_astrometry_plot_data.py` **3 passed**.

## Flagged, not fixed (different files, different review sections)

The same `point.get(label, default)` pattern is live in two other components:
- `rvinstrument.py:503` `_instrument_gamma` uses `point.get(self.gamma.label, 0.0)` -- a pinned nonzero gamma would plot an entire RV instrument offset to zero;
- `transit.py:744` uses `point.get(self.baseline.label, 1.0)` -- silently substitutes 1.0 for a pinned baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)