### PR TITLE
samplers: seed_polish: 1, hot-group trim, zero-proposal swap pairs, n_chains=2, and four-state hot-search reporting (review 2.9.1-2.9.4)

### DIFF
--- a/examples/ob140939/ob140939.yaml
+++ b/examples/ob140939/ob140939.yaml
@@ -70,7 +70,9 @@ sampler:
   n_temps: 24
   # Keep thinned hot-rung draws: they detect posterior-suppressed modes
   # (occupancy ~exp(-dlp/T)) for the seeded-solution ledger, so solutions
-  # nobody seeded still show up as "considered and rejected".
+  # nobody seeded still show up as "considered and rejected".  Left explicit
+  # for documentation only -- 'auto' (the default) already turns this on for
+  # a microlensing topology.  Costs ~37% of the trace file here.
   store_hot_chains: true
   recompute_trace: True
   # The seeds are literature solution estimates, not posterior draws,

--- a/src/exozippy/components/component.py
+++ b/src/exozippy/components/component.py
@@ -24,6 +24,21 @@ class Component(ABC):
     Stage 6: build_likelihood()    - Defines observational Likelihoods and Potentials.
     """
 
+    # Does this component's parameter space routinely carry posterior-
+    # SUPPRESSED but physically plausible alternative solutions -- distinct
+    # basins with near-zero T=1 occupancy that a referee will still ask
+    # about?  Declared per component and read only in aggregate ("does any
+    # active component say yes"), so the sampler layer can default hot-rung
+    # retention (samplers._common.resolve_store_hot_chains) ON for the
+    # topologies where the suppressed-mode search earns its trace size and
+    # off for the ones where it does not.
+    #
+    # A flag here rather than a component-name test up in run.py for the
+    # same reason `supports_gp` is one: the higher-level code is
+    # component-agnostic by design, and a future component with degenerate
+    # solutions must be able to opt in without anyone editing the sampler.
+    expects_suppressed_modes = False
+
     def __init__(self, component_config, config_manager):
         """Standardized constructor for ALL components."""
         self.config = component_config

--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -59,6 +59,18 @@ class Lens(Component):
         source_ndx: 1
     """
 
+    # Microlensing is THE topology where a solution the posterior abandons
+    # still has to be reported.  Its degeneracies are structural, not
+    # accidental: the u_0 sign flip (ob140939's four Yee+2015 basins), the
+    # close/wide s <-> 1/s pair, and the ecliptic/jerk-parallax families all
+    # give distinct basins that fit the light curve nearly as well while
+    # differing by a factor of a few in lens mass and distance.  Published
+    # solutions routinely quote two or four of them.  A T=1 posterior keeps
+    # only the winner, so without hot-rung draws the alternatives leave no
+    # record of having been examined at all -- see
+    # samplers._common.resolve_store_hot_chains.
+    expects_suppressed_modes = True
+
     # Deps satisfied by context-node injection in add_parameter (constants,
     # not manifest parameters); graph.py skips them when ordering the build.
     context_dep_names = frozenset({"earth_vperp_e", "earth_vperp_n"})

--- a/src/exozippy/outputs/ledger.py
+++ b/src/exozippy/outputs/ledger.py
@@ -299,11 +299,31 @@ def append_ledger_csv(ledger, csv_filename):
     )
 
 
-def write_rejected_latex(ledger, filename):
-    """Standalone LaTeX table of the rejected solutions (Laplace)."""
+def write_rejected_latex(ledger, filename, hot_status=None):
+    """Standalone LaTeX table of the rejected solutions (Laplace).
+
+    ``hot_status`` (see hot_status_to_text) adds a RENDERED caption sentence
+    -- not a % comment -- whenever the hot-chain suppressed-mode search did
+    not run or did not complete.  This table is what goes into a paper, and
+    a reader must not read its completeness as "these are all the
+    alternatives that were considered" when the search for the others never
+    happened.
+    """
     rej = rejected_records(ledger)
     if not rej:
         return False
+    caveat = ""
+    state = (hot_status or {}).get("state")
+    if state == HOT_NOT_SEARCHED:
+        caveat = (
+            r" No search for posterior-suppressed modes was performed, so "
+            r"this list covers only the explicitly seeded solutions."
+        )
+    elif state == HOT_FAILED:
+        caveat = (
+            r" The search for additional posterior-suppressed modes did not "
+            r"complete, so this list may be incomplete."
+        )
     lines = []
     lines.append(r"% Considered-and-rejected solutions (Laplace")
     lines.append(r"% approximations at each seeded basin's polished optimum;")
@@ -314,7 +334,7 @@ def write_rejected_latex(ledger, filename):
         r"\caption{Solutions considered and rejected by the posterior. "
         r"Values are Laplace approximations at each seeded basin's "
         r"optimum; $\Delta \ln \mathcal{L}$ is measured against the best "
-        r"seeded solution.}"
+        r"seeded solution." + caveat + r"}"
     )
     cols = "l" + "c" * len(rej)
     lines.append(r"\begin{tabular}{" + cols + "}")
@@ -369,6 +389,141 @@ HOT_LP_MARGIN = 50.0
 # Fewer near-viable points than this cannot support a cluster.
 HOT_MIN_POINTS = 25
 
+# The four distinguishable outcomes of the hot-chain suppressed-mode search.
+#
+# "no suppressed modes exist" and "the search never ran" and "the search
+# crashed" all used to render identically in the final report -- nothing at
+# all -- which manufactures exactly the false assurance this whole feature
+# exists to prevent: a user reads "no other modes" and believes it was
+# checked.  run.py owns the state machine (it is the only place that knows
+# whether the group exists and whether the call raised); ledger.py owns the
+# vocabulary and the rendering.
+HOT_NOT_SEARCHED = "not-searched"
+HOT_NONE_FOUND = "none-found"
+HOT_FAILED = "failed"
+HOT_FOUND = "found"
+
+
+def run_hot_mode_discovery(system, model, idata, seed_ledger=None, **kwargs):
+    """Run the hot-chain suppressed-mode search and CLASSIFY its outcome.
+
+    Returns ``(seed_ledger, status)``.  The status dict always carries a
+    ``state`` (one of the four HOT_* constants) so the final report can tell
+    "no hot draws were kept, so nothing was searched for" from "we searched
+    and found nothing" from "the search crashed".  Those three used to be
+    indistinguishable in every output a user reads, which turns a silent
+    failure into false assurance that a candidate mode was considered and
+    rejected -- the exact thing this feature exists to provide.
+
+    Non-fatal by contract: a wrap-up diagnostic must never take down a
+    finished multi-day fit, so the catch stays broad -- but the exception's
+    type and message go into the status rather than only into a log line.
+    """
+    if not hasattr(idata, "posterior_hot"):
+        return seed_ledger, {
+            "state": HOT_NOT_SEARCHED,
+            "detail": (
+                "no posterior_hot group in the trace (sampler config "
+                "`store_hot_chains` is off by default)"
+            ),
+        }
+    status = {}
+    try:
+        seed_ledger = discover_hot_modes(
+            system,
+            model,
+            idata.posterior_hot,
+            seed_ledger,
+            status=status,
+            **kwargs,
+        )
+    except Exception as exc:
+        status = {
+            "state": HOT_FAILED,
+            "detail": f"{type(exc).__name__}: {exc}",
+        }
+        logger.warning(
+            "Hot-chain mode discovery failed; the final report will record "
+            "that the suppressed-mode search did NOT complete",
+            exc_info=True,
+        )
+    return seed_ledger, status
+
+
+def hot_status_to_text(status):
+    """Render the hot-chain search outcome for <prefix>_modes.txt.
+
+    ``status`` is the dict discover_hot_modes fills in (plus a ``state`` set
+    by the caller for the states discovery never reaches: it did not run, or
+    it raised).  Returns "" for a falsy status so callers can pass it
+    unconditionally.
+    """
+    if not status:
+        return ""
+    state = status.get("state", HOT_NOT_SEARCHED)
+    detail = status.get("detail", "")
+    lines = [
+        "",
+        "Hot-chain suppressed-mode search",
+        "--------------------------------",
+    ]
+    if state == HOT_NOT_SEARCHED:
+        lines.append(
+            "NOT PERFORMED -- no hot-rung draws were available, so NO search "
+            "for posterior-"
+        )
+        lines.append(
+            "suppressed modes was made. The absence of extra solutions below "
+            "is not evidence"
+        )
+        lines.append(
+            "that none exist. Enable it with sampler config "
+            "`store_hot_chains: true`."
+        )
+    elif state == HOT_FAILED:
+        lines.append(
+            "FAILED -- hot-rung draws were available but the search did not "
+            "complete, so"
+        )
+        lines.append(
+            "no conclusion can be drawn about posterior-suppressed modes. "
+            "This is NOT the"
+        )
+        lines.append("same as having searched and found none.")
+    elif state == HOT_NONE_FOUND:
+        lines.append(
+            "PERFORMED -- hot-rung draws were clustered and no candidate "
+            "solution survived"
+        )
+        lines.append(
+            "as a new basin. Within the limits of the Laplace/clustering "
+            "approximations,"
+        )
+        lines.append("no additional mode was found.")
+    elif state == HOT_FOUND:
+        n = int(status.get("n_new", 0))
+        lines.append(
+            f"PERFORMED -- {n} candidate solution(s) found and recorded "
+            f"below with source"
+        )
+        lines.append(
+            "'hot-chain'. A candidate is a basin the T=1 posterior never "
+            "held; whether it"
+        )
+        lines.append("survived is given by its own ledger entry.")
+    else:  # unknown state -- never silently swallow it
+        lines.append(f"UNKNOWN state '{state}'.")
+    counts = [
+        f"{k} = {status[k]}"
+        for k in ("n_hot_draws", "n_viable", "n_clusters", "n_new")
+        if k in status
+    ]
+    if counts:
+        lines.append("  " + ", ".join(counts))
+    if detail:
+        lines.append(f"  {detail}")
+    return "\n".join(lines) + "\n"
+
 
 def discover_hot_modes(
     system,
@@ -381,6 +536,7 @@ def discover_hot_modes(
     subsample=20000,
     seed=20260711,
     polish_steps=150,
+    status=None,
 ):
     """Find posterior-suppressed modes in the thinned hot-rung draws.
 
@@ -402,15 +558,51 @@ def discover_hot_modes(
     modes like any other record -- a hot-chain record matching a surviving
     mode is simply confirmation; an unmatched one is a mode the T=1
     posterior never held.
+
+    ``status``, if given, is a dict this function fills with the outcome
+    (``state`` in HOT_NONE_FOUND/HOT_FOUND, ``detail``, and the draw/cluster
+    counts) so the final report can say WHICH of the four outcomes occurred
+    instead of rendering "searched and found nothing" and "never searched"
+    and "crashed" identically.  See hot_status_to_text.
     """
     from .modes import _dip_merge, _kmeans_bic
 
+    if status is None:
+        status = {}
     ledger = list(seed_ledger) if seed_ledger else []
+    n_before = len(ledger)
+
+    def _finish(state, detail=""):
+        status["state"] = state
+        status["detail"] = detail
+        status["n_new"] = len(ledger) - n_before
+        return ledger
 
     raw_keys = [str(v) for v in hot.data_vars if str(v) != "lp"]
     if not raw_keys or "lp" not in hot.data_vars:
-        return ledger
+        logger.warning(
+            "Hot-chain discovery: the posterior_hot group carries no raw "
+            "variables and/or no lp; no suppressed-mode search was made."
+        )
+        return _finish(
+            HOT_FAILED, "the posterior_hot group has no raw variables or no lp"
+        )
     lp = np.asarray(hot["lp"].values, dtype=float).reshape(-1)
+    status["n_hot_draws"] = int(lp.size)
+    if lp.size == 0:
+        # An empty group is what a mis-sliced posterior_hot looks like (the
+        # burn-in/stuck-chain trim used to index it by T=1 chains and draws
+        # -- notes/code_review_20260808.txt 2.9.2).  Report it as a FAILED
+        # search, never as "searched and found nothing".
+        logger.warning(
+            "Hot-chain discovery: the posterior_hot group holds no draws; "
+            "no suppressed-mode search was performed. This group must reach "
+            "discovery UNTRIMMED (samplers.convergence._TRIMMED_GROUPS)."
+        )
+        return _finish(
+            HOT_FAILED,
+            "the posterior_hot group reached discovery with 0 draws",
+        )
 
     cols, names, shapes = [], [], {}
     for key in raw_keys:
@@ -425,15 +617,27 @@ def discover_hot_modes(
 
     good = np.isfinite(lp) & np.all(np.isfinite(X), axis=1)
     if not good.any():
-        return ledger
+        logger.warning(
+            "Hot-chain discovery: every hot draw is non-finite in lp or in "
+            "at least one variable; no suppressed-mode search was made."
+        )
+        return _finish(HOT_FAILED, "no finite hot draws to cluster")
     viable = good & (lp >= np.nanmax(lp[good]) - margin_nats)
     n_viable = int(viable.sum())
+    status["n_viable"] = n_viable
     if n_viable < min_points:
+        # Genuinely searched: the hot rungs simply never came near the best
+        # solution, which IS the "nothing else is competitive" answer.
         logger.info(
             f"Hot-chain discovery: only {n_viable} near-viable hot draws "
             f"(need {min_points}); nothing to cluster."
         )
-        return ledger
+        return _finish(
+            HOT_NONE_FOUND,
+            f"only {n_viable} of {lp.size} hot draws came within "
+            f"{margin_nats:g} nats of the best (need {min_points} to "
+            f"cluster)",
+        )
     Xv, lpv = X[viable], lp[viable]
 
     rng = np.random.default_rng(seed)
@@ -454,6 +658,7 @@ def discover_hot_modes(
         if not changed:
             break
     n_clusters = len(np.unique(labels[labels >= 0]))
+    status["n_clusters"] = int(n_clusters)
     logger.info(
         f"Hot-chain discovery: {n_viable} near-viable draws -> "
         f"{n_clusters} cluster(s)."
@@ -514,4 +719,15 @@ def discover_hot_modes(
         best_lp = max(r.lp_max for r in ledger)
         for r in ledger:
             r.delta_lp = best_lp - r.lp_max
-    return ledger
+    n_new = len(ledger) - n_before
+    if n_new:
+        return _finish(
+            HOT_FOUND,
+            f"{n_clusters} hot cluster(s) -> {n_new} new basin(s) after "
+            f"dedup against the existing ledger",
+        )
+    return _finish(
+        HOT_NONE_FOUND,
+        f"{n_clusters} hot cluster(s), all of them rediscoveries of basins "
+        f"already in the ledger",
+    )

--- a/src/exozippy/outputs/ledger.py
+++ b/src/exozippy/outputs/ledger.py
@@ -424,7 +424,8 @@ def run_hot_mode_discovery(system, model, idata, seed_ledger=None, **kwargs):
             "state": HOT_NOT_SEARCHED,
             "detail": (
                 "no posterior_hot group in the trace (sampler config "
-                "`store_hot_chains` is off by default)"
+                "`store_hot_chains`, which defaults on only for topologies "
+                "that expect posterior-suppressed modes)"
             ),
         }
     status = {}
@@ -477,7 +478,11 @@ def hot_status_to_text(status):
             "is not evidence"
         )
         lines.append(
-            "that none exist. Enable it with sampler config "
+            "that none exist. Hot-rung retention defaults on only for "
+            "topologies that expect"
+        )
+        lines.append(
+            "suppressed modes (microlensing); force it with sampler config "
             "`store_hot_chains: true`."
         )
     elif state == HOT_FAILED:
@@ -513,6 +518,19 @@ def hot_status_to_text(status):
         lines.append("survived is given by its own ledger entry.")
     else:  # unknown state -- never silently swallow it
         lines.append(f"UNKNOWN state '{state}'.")
+    if state in (HOT_NONE_FOUND, HOT_FOUND):
+        # A microlensing fit gets hot-rung retention without asking for it,
+        # so say plainly that a search HAPPENED -- otherwise a reader who
+        # never typed `store_hot_chains` reads this section as boilerplate.
+        lines.append(
+            "The search ran on the retained hot-rung draws (sampler config "
+            "`store_hot_chains`,"
+        )
+        lines.append(
+            "on by default for topologies that expect suppressed modes); it "
+            "did not have to be"
+        )
+        lines.append("requested.")
     counts = [
         f"{k} = {status[k]}"
         for k in ("n_hot_draws", "n_viable", "n_clusters", "n_new")

--- a/src/exozippy/outputs/report_pipeline.py
+++ b/src/exozippy/outputs/report_pipeline.py
@@ -32,6 +32,7 @@ def build_mode_reports(
     raise_on_invalid=True,
     evidence_weights=False,
     seed_ledger=None,
+    hot_status=None,
 ):
     """Identify posterior modes, distribute the posterior, write tables.
 
@@ -87,6 +88,13 @@ def build_mode_reports(
         CSV and a standalone <prefix>_rejected_modes.tex table. Absent for
         single-seed fits and for the trace-reprocessing CLI (the seeds no
         longer exist there).
+    hot_status : dict, optional
+        Outcome of the hot-chain suppressed-mode search
+        (outputs.ledger.discover_hot_modes / hot_status_to_text), as built
+        by run.py.  Rendered into <prefix>_modes.txt INDEPENDENTLY of
+        ``seed_ledger``: "never searched" and "search failed" are exactly
+        the states in which no ledger records exist, and they are precisely
+        the states the report must not render as silence.
 
     Returns
     -------
@@ -178,6 +186,25 @@ def build_mode_reports(
                 exc_info=True,
             )
 
+    # Hot-chain suppressed-mode search outcome.  Written whether or not a
+    # ledger exists: the states worth distinguishing most ("never searched",
+    # "search failed") are the ones that produce no ledger records at all,
+    # so gating this on `seed_ledger` would silence exactly the cases it is
+    # here to surface.
+    if hot_status:
+        try:
+            from .ledger import hot_status_to_text
+
+            if modes_path is None:
+                modes_path = Path(str(prefix) + "_modes.txt")
+            with open(modes_path, "a", encoding="utf-8") as f:
+                f.write(hot_status_to_text(hot_status))
+        except Exception:
+            logger.warning(
+                "Hot-chain status reporting failed; continuing without it",
+                exc_info=True,
+            )
+
     # Seeded-solution ledger: match every (polished) seed to a surviving
     # mode or mark it rejected, and report the rejected ones -- the
     # "considered and rejected" record that pure T=1 occupancy loses.
@@ -200,7 +227,9 @@ def build_mode_reports(
             n_rej = len(rejected_records(seed_ledger))
             if n_rej:
                 write_rejected_latex(
-                    seed_ledger, str(prefix) + "_rejected_modes.tex"
+                    seed_ledger,
+                    str(prefix) + "_rejected_modes.tex",
+                    hot_status=hot_status,
                 )
                 logger.info(
                     f"Seed ledger: {n_rej} seeded solution(s) rejected by "

--- a/src/exozippy/polish.py
+++ b/src/exozippy/polish.py
@@ -29,26 +29,34 @@ Two engines, dispatched on gradient availability:
   the gradient graph cannot be built or is non-finite at the start -- e.g.
   the binary-lens magnification Op has no analytic gradient.
 
-Stopping: BOTH engines stop on a tolerance and treat the configured step
-count (`seed_polish: N`, default DEFAULT_POLISH_STEPS) as a safety cap only.
-The two tolerances are deliberately different because the two engines see
-different information, and neither measure exists on the other path:
+Stopping: `seed_polish: N` (default DEFAULT_POLISH_STEPS) is a step CAP, not
+a target -- "at most N".  The two engines stop differently, because they see
+different information and the differentiable one's criterion has no
+counterpart on the other path:
 
-- L-BFGS-B stops on the GRADIENT NORM (_LBFGS_GTOL, nats per raw unit).
-  That is the strongest available statement of "this is the top of the
-  basin" and it needs no history; the gradient is right there.  It is also
-  the reason a logp-improvement rule must NOT be layered on here -- see the
-  _LBFGS_FTOL note below for what per-iteration improvement tests do to a
-  curved valley.
+- L-BFGS-B stops on the GRADIENT NORM (_LBFGS_GTOL, nats per raw unit) with
+  maxiter as its safety net.  That is a real statement about the local
+  surface and needs no history.  Measured on examples/ob140939 (4 literature
+  seeds): 2 of 4 reach |grad| < 0.01 at 432 and 655 iterations; the other 2
+  are still crawling along a flat direction at 5000, where 33x the default
+  cap buys 9 nats out of a 547-nat climb (1.6%) and doubles the wall time.
+  So the cap is not a stand-in for the tolerance -- it is the bound on
+  hierarchical-MAP drift it was documented to be, and 150 is a reasonable
+  place for it.  Do NOT layer a logp-improvement rule on top: the
+  _LBFGS_FTOL note below records what per-iteration improvement tests do to
+  a curved valley.
 - The gradient-free DE polish (samplers.ptde.polish_seed_starts) has no
   gradient by construction -- it exists because the binary-lens
-  magnification Op has none -- so it stops on the ABSOLUTE logp gain of the
-  best point over a WINDOW of sweeps (ptde.POLISH_TOL_NATS /
-  POLISH_TOL_WINDOW).  Absolute, not relative to |lp|, for the same reason
-  ftol is disabled below.
+  magnification Op has none -- and its only observable, the best-lp history,
+  is a STAIRCASE of exactly-flat plateaus.  A best-lp improvement window
+  therefore cannot separate "converged" from "has not jumped yet": on
+  examples/DC2018_128 it stops 38-137 nats short, by the SAME amount for
+  tol = 0.05, 0.5 and 2.0 nats.  The measurement is tabulated on
+  ptde.POLISH_TOL_NATS.  That engine's default stopping criterion is
+  therefore the step cap; the tolerance is an opt-in
+  (polish_raw_starts(tol=...)) for a surface known to be smooth.
 
-The cap always remains: neither rule can run away, and a pathological
-surface stops at N steps as before.
+The cap always remains, so nothing can polish forever.
 
 Seed-provenance gate (resolve_polish_steps): 'auto' polishes SOLUTION
 ESTIMATES -- the single canonical start (user/literature initvals, the
@@ -65,9 +73,10 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-# Safety CAP on the polish, not a target: both engines stop on their own
-# tolerance well before this on any well-behaved surface (see "Stopping" in
-# the module docstring).
+# Step CAP on the polish -- "at most this many" -- not a target.  On the
+# L-BFGS path the gradient tolerance usually ends it first; on the
+# gradient-free path the cap IS the criterion (see "Stopping" in the module
+# docstring for the measurement behind both statements).
 DEFAULT_POLISH_STEPS = 150
 
 # L-BFGS stopping: terminate on the GRADIENT (plus the maxiter cap),

--- a/src/exozippy/polish.py
+++ b/src/exozippy/polish.py
@@ -29,6 +29,27 @@ Two engines, dispatched on gradient availability:
   the gradient graph cannot be built or is non-finite at the start -- e.g.
   the binary-lens magnification Op has no analytic gradient.
 
+Stopping: BOTH engines stop on a tolerance and treat the configured step
+count (`seed_polish: N`, default DEFAULT_POLISH_STEPS) as a safety cap only.
+The two tolerances are deliberately different because the two engines see
+different information, and neither measure exists on the other path:
+
+- L-BFGS-B stops on the GRADIENT NORM (_LBFGS_GTOL, nats per raw unit).
+  That is the strongest available statement of "this is the top of the
+  basin" and it needs no history; the gradient is right there.  It is also
+  the reason a logp-improvement rule must NOT be layered on here -- see the
+  _LBFGS_FTOL note below for what per-iteration improvement tests do to a
+  curved valley.
+- The gradient-free DE polish (samplers.ptde.polish_seed_starts) has no
+  gradient by construction -- it exists because the binary-lens
+  magnification Op has none -- so it stops on the ABSOLUTE logp gain of the
+  best point over a WINDOW of sweeps (ptde.POLISH_TOL_NATS /
+  POLISH_TOL_WINDOW).  Absolute, not relative to |lp|, for the same reason
+  ftol is disabled below.
+
+The cap always remains: neither rule can run away, and a pathological
+surface stops at N steps as before.
+
 Seed-provenance gate (resolve_polish_steps): 'auto' polishes SOLUTION
 ESTIMATES -- the single canonical start (user/literature initvals, the
 relaxation engine's solution) and MMEXOFAST seed sets -- but never a
@@ -44,6 +65,9 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+# Safety CAP on the polish, not a target: both engines stop on their own
+# tolerance well before this on any well-behaved surface (see "Stopping" in
+# the module docstring).
 DEFAULT_POLISH_STEPS = 150
 
 # L-BFGS stopping: terminate on the GRADIENT (plus the maxiter cap),
@@ -65,22 +89,43 @@ _LBFGS_GTOL = 1e-2
 # toward the last finite iterate's neighborhood (gradient points home).
 _NONFINITE_PENALTY = 1e15
 
+# Sentinel: "caller said nothing", so the DE engine's own defaults apply.
+# `None` cannot serve -- tol=None is the meaningful "disable the tolerance,
+# run the full n_steps" request.
+_UNSET = object()
+
 
 def resolve_polish_steps(spec, n_seeds, has_seed_hints):
-    """Map the sampler-config `seed_polish` value to a step count.
+    """Map the sampler-config `seed_polish` value to a step CAP.
 
     'auto' (default): DEFAULT_POLISH_STEPS when the starts are solution
     estimates -- a single canonical start (n_seeds == 1) or component-pushed
     seed hints (MMEXOFAST) -- and 0 for a multi-seed set without hints
     (posterior-draw restarts; see module docstring).  True/'on' and
-    False/None/'off' force it; an int gives the step count directly.
+    False/None/'off' force it; an int gives the cap directly (`seed_polish: N`
+    = "at most N steps", not "exactly N" -- both engines stop on their own
+    tolerance first; see "Stopping" in the module docstring).
+
+    The bool test comes FIRST and by isinstance.  `spec in (True, "on")`
+    matched the integer 1 (1 == True in Python), so `seed_polish: 1` asked
+    for one step and got 150 (notes/code_review_20260808.txt 2.9.1).  The
+    symmetric `0 == False` match was harmless -- 0 steps IS off -- and stays
+    harmless here: 0 now falls through to the int path and returns 0.
     """
-    if isinstance(spec, str) and spec.lower() == "auto":
-        return DEFAULT_POLISH_STEPS if (n_seeds == 1 or has_seed_hints) else 0
-    if spec in (True, "on"):
-        return DEFAULT_POLISH_STEPS
-    if spec in (False, None, "off"):
+    if isinstance(spec, bool):
+        return DEFAULT_POLISH_STEPS if spec else 0
+    if spec is None:
         return 0
+    if isinstance(spec, str):
+        key = spec.lower()
+        if key == "auto":
+            return (
+                DEFAULT_POLISH_STEPS if (n_seeds == 1 or has_seed_hints) else 0
+            )
+        if key == "on":
+            return DEFAULT_POLISH_STEPS
+        if key == "off":
+            return 0
     return max(0, int(spec))
 
 
@@ -108,8 +153,10 @@ def _compile_logp_grad(model):
 
 
 def _lbfgs_polish_one(center, fn_lp_grad, keys, shapes, sizes, maxiter):
-    """L-BFGS-B ascent of logp from one raw start dict.  Returns
-    (polished_dict, lp0, lp_best, n_evals)."""
+    """L-BFGS-B ascent of logp from one raw start dict.
+
+    Stops on the gradient norm (_LBFGS_GTOL); `maxiter` is the safety cap.
+    Returns (polished_dict, lp0, lp_best, n_evals, n_iter, hit_cap)."""
     from scipy.optimize import minimize
 
     def flatten(d):
@@ -159,13 +206,17 @@ def _lbfgs_polish_one(center, fn_lp_grad, keys, shapes, sizes, maxiter):
     # res.x is the best iterate L-BFGS-B saw; never worse than the start
     # except pathological line-search exits -- guard anyway.
     lp_best = -float(res.fun)
+    n_iter = int(getattr(res, "nit", 0))
+    hit_cap = n_iter >= int(maxiter)
     if np.isfinite(lp_best) and lp_best >= lp0:
-        return unflatten(res.x), lp0, lp_best, n_evals[0]
+        return unflatten(res.x), lp0, lp_best, n_evals[0], n_iter, hit_cap
     return (
         {k: np.array(v, dtype=float, copy=True) for k, v in center.items()},
         lp0,
         lp0,
         n_evals[0],
+        n_iter,
+        hit_cap,
     )
 
 
@@ -176,6 +227,8 @@ def polish_raw_starts(
     seed_indices=None,
     logp_fn=None,
     rng=None,
+    tol=_UNSET,
+    tol_window=_UNSET,
 ):
     """Polish each raw start toward its own basin's optimum.
 
@@ -184,6 +237,12 @@ def polish_raw_starts(
     (samplers/ptde.polish_seed_starts) with unit jitter scales (one raw unit
     = one preliminary whitening scale, DE's population self-adapts from
     there).
+
+    ``n_steps`` is the safety CAP for either engine; each stops on its own
+    tolerance first (see "Stopping" in the module docstring).  ``tol`` /
+    ``tol_window`` override the DE engine's tolerance (``tol=None`` restores
+    a fixed ``n_steps`` sweeps); they do not reach the L-BFGS path, which
+    stops on _LBFGS_GTOL.
 
     Returns (polished_starts, dlps, method) with method in
     {"lbfgs", "de", "none"}.  A seed is never made worse: any engine result
@@ -213,15 +272,20 @@ def polish_raw_starts(
     if fn_lp_grad is not None:
         polished, dlps = [], []
         for s, center in enumerate(raw_starts):
-            best, lp0, lp_best, n_evals = _lbfgs_polish_one(
+            best, lp0, lp_best, n_evals, n_iter, hit_cap = _lbfgs_polish_one(
                 center, fn_lp_grad, keys, shapes, sizes, maxiter=n_steps
             )
             polished.append(best)
             dlps.append(lp_best - lp0)
+            reason = (
+                f"hit the {int(n_steps)}-iteration cap"
+                if hit_cap
+                else f"converged: |grad| < {_LBFGS_GTOL} nats/unit"
+            )
             logger.info(
                 f"Seed polish (L-BFGS): seed {seed_indices[s]} lp "
                 f"{lp0:.1f} -> {lp_best:.1f} (dlp=+{lp_best - lp0:.1f}, "
-                f"{n_evals} evaluations)"
+                f"{n_iter} iterations / {n_evals} evaluations, {reason})"
             )
         return polished, dlps, "lbfgs"
 
@@ -235,7 +299,12 @@ def polish_raw_starts(
     scales = {
         k: np.ones(np.shape(raw_starts[0][k]), dtype=float) for k in keys
     }
+    de_kwargs = {}
+    if tol is not _UNSET:
+        de_kwargs["tol"] = tol
+    if tol_window is not _UNSET:
+        de_kwargs["tol_window"] = tol_window
     polished, dlps = polish_seed_starts(
-        raw_starts, logp_fn, rng, scales, n_steps=n_steps
+        raw_starts, logp_fn, rng, scales, n_steps=n_steps, **de_kwargs
     )
     return polished, dlps, "de"

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -227,8 +227,13 @@ def _run_fit(config, gui, user_params=None):
     )
     # Thinned hot-rung retention (ptde_async only): detector data for
     # post-hoc discovery of posterior-suppressed modes; see
-    # outputs.ledger.discover_hot_modes. False | True (thin 20) | int thin.
-    store_hot_chains = sampler_cfg.get("store_hot_chains", False)
+    # outputs.ledger.discover_hot_modes.  "auto" | False | True (thin 20) |
+    # int thin.  "auto" (the default) is resolved from the TOPOLOGY -- on for
+    # microlensing, off otherwise -- in
+    # samplers._common.resolve_store_hot_chains, which logs the decision and
+    # its trace-size cost.  Passed through unresolved on purpose: the
+    # component list does not exist yet at this point in run_fit.
+    store_hot_chains = sampler_cfg.get("store_hot_chains", "auto")
     rung_thin_factor = int(sampler_cfg.get("rung_thin_factor", 1))
     _rung_thin_start_raw = sampler_cfg.get("rung_thin_start", None)
     rung_thin_start = (
@@ -647,10 +652,10 @@ def _run_fit(config, gui, user_params=None):
     # burn-in semantics) and tolerates a missing/empty group.
     # The outcome is recorded in `hot_status` and rendered into
     # <prefix>_modes.txt: "searched and found nothing", "never searched"
-    # (store_hot_chains defaults to OFF, so this is the common case) and
-    # "the search crashed" used to be indistinguishable in every output the
-    # user reads, which turns a silent failure into false assurance that a
-    # candidate mode was considered.  The catch stays broad and stays
+    # (what a non-microlensing topology gets by default) and "the search
+    # crashed" used to be indistinguishable in every output the user reads,
+    # which turns a silent failure into false assurance that a candidate
+    # mode was considered.  The catch stays broad and stays
     # NON-FATAL -- a wrap-up diagnostic must not kill a finished multi-day
     # fit -- but the exception type and message now reach the report.
     from .outputs.ledger import run_hot_mode_discovery

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -645,18 +645,19 @@ def _run_fit(config, gui, user_params=None):
     # never held still shows up as "considered and rejected" in the final
     # report. Runs BEFORE burn-in trimming (hot draws are detectors; no
     # burn-in semantics) and tolerates a missing/empty group.
-    if hasattr(idata, "posterior_hot"):
-        try:
-            from .outputs.ledger import discover_hot_modes
+    # The outcome is recorded in `hot_status` and rendered into
+    # <prefix>_modes.txt: "searched and found nothing", "never searched"
+    # (store_hot_chains defaults to OFF, so this is the common case) and
+    # "the search crashed" used to be indistinguishable in every output the
+    # user reads, which turns a silent failure into false assurance that a
+    # candidate mode was considered.  The catch stays broad and stays
+    # NON-FATAL -- a wrap-up diagnostic must not kill a finished multi-day
+    # fit -- but the exception type and message now reach the report.
+    from .outputs.ledger import run_hot_mode_discovery
 
-            seed_ledger = discover_hot_modes(
-                system, model, idata.posterior_hot, seed_ledger
-            )
-        except Exception:
-            logger.warning(
-                "Hot-chain mode discovery failed; continuing without it",
-                exc_info=True,
-            )
+    seed_ledger, hot_status = run_hot_mode_discovery(
+        system, model, idata, seed_ledger
+    )
 
     idata, burn_diag = convergence.analyze_idata(
         idata, min_ess=min_ess, max_rhat=max_rhat
@@ -686,6 +687,7 @@ def _run_fit(config, gui, user_params=None):
         evidence_weights=str(modes_cfg.get("weights", "")).lower()
         == "evidence",
         seed_ledger=seed_ledger,
+        hot_status=hot_status,
     )
 
     summary_path = Path(str(prefix) + "_summary.txt")

--- a/src/exozippy/samplers/_common.py
+++ b/src/exozippy/samplers/_common.py
@@ -293,11 +293,68 @@ def _map_logp_timeout(pool, proposals, timeout):
 # warn_if_population_degenerate for the mixing side).
 DE_JITTER = 1e-4
 
+# Smallest DE population this code will run with.
+#
+# A DE proposal for member i is x_i + gamma*(x_j1 - x_j2) with j1 != j2 != i,
+# so it needs two OTHER members: n = 2 has only one other and _pick_two used
+# to die inside numpy with "Cannot take a larger sample than population when
+# replace is False" (notes/code_review_20260808.txt 2.9.4).  n = 2 is not a
+# perverse setting -- it is what the DEFAULT n_chains = 2 * n_params produces
+# for a one-parameter model.  n = 3 is the smallest population that can move
+# at all, but the two others are then FORCED, so every proposal for member i
+# lies along the single direction +/-(x_j1 - x_j2); 4 is the smallest that
+# offers any choice of difference vector, and is what the default is floored
+# at.  This is a hard floor on the MOVE being defined, not a mixing
+# recommendation -- warn_if_population_degenerate below owns that, and it
+# asks for a great deal more (n_params + 2).
+MIN_DE_CHAINS = 4
+
 
 def _pick_two(rng, n, exclude):
     """Pick two distinct indices from [0, n) excluding `exclude`."""
+    if n < 3:
+        raise ValueError(
+            f"A DE proposal needs two other population members, but n={n} "
+            f"leaves only {max(n - 1, 0)}. There is no meaningful "
+            f"difference vector to propose with -- raise n_chains to at "
+            f"least {MIN_DE_CHAINS} (the default is 2 x n_params, floored "
+            f"at {MIN_DE_CHAINS})."
+        )
     idx = rng.choice(n - 1, 2, replace=False)
     return tuple(int(i + (1 if i >= exclude else 0)) for i in idx)
+
+
+def resolve_n_chains(n_chains, n_params, label, log):
+    """Resolve and validate the DE population size for one rung.
+
+    ``None`` takes the default 2 * n_params, floored at MIN_DE_CHAINS so the
+    default can never land on a population too small to form a difference
+    vector (n_params = 1 -> 2; see MIN_DE_CHAINS).  An explicit value below 3
+    RAISES rather than being silently bumped: the user asked for something
+    the DE move cannot do, and quietly running a different sampler than the
+    one requested is worse than stopping.  Also emits the
+    warn_if_population_degenerate mixing warning.
+    """
+    if n_chains is None:
+        n_chains = max(2 * n_params, MIN_DE_CHAINS)
+        if n_chains > 2 * n_params:
+            log.info(
+                f"{label}: default n_chains = 2 x n_params = "
+                f"{2 * n_params} is below the DE minimum; using "
+                f"{n_chains} chains/rung."
+            )
+    else:
+        n_chains = int(n_chains)
+        if n_chains < 3:
+            raise ValueError(
+                f"{label}: n_chains={n_chains} is too small for a DE "
+                f"proposal, which needs two OTHER population members "
+                f"(x_i + gamma*(x_j1 - x_j2), j1 != j2 != i). Use "
+                f"n_chains >= {MIN_DE_CHAINS}, or omit n_chains for the "
+                f"default 2 x n_params."
+            )
+    warn_if_population_degenerate(n_chains, n_params, label, log)
+    return n_chains
 
 
 def de_proposal(rng, pop, i, gamma, keys, jitter=DE_JITTER):

--- a/src/exozippy/samplers/_common.py
+++ b/src/exozippy/samplers/_common.py
@@ -357,6 +357,134 @@ def resolve_n_chains(n_chains, n_params, label, log):
     return n_chains
 
 
+# ---------------------------------------------------------------------------
+# Hot-rung retention (store_hot_chains)
+# ---------------------------------------------------------------------------
+
+# Thinning applied when hot-rung retention is on but no factor was given.
+DEFAULT_HOT_THIN = 20
+
+
+def hot_chain_trace_share(n_temps, hot_thin, n_raw_elements, n_out_elements):
+    """Fraction of the saved trace the ``posterior_hot`` group will occupy.
+
+    Both groups scale with n_chains x draws, so those cancel exactly and the
+    share is fixed by three things: the ladder height, the thinning, and --
+    the term nobody expects -- the DERIVED-variable count.  The cold group
+    stores PHYSICAL variables (sampled plus every pm.Deterministic), the hot
+    group stores RAW ones only, so a model with many derived quantities
+    dilutes the hot share even at the same n_temps.
+
+    examples/ob140939: n_temps=24, hot_thin=20, 19 raw and 39 output
+    elements -> 23 x 20/20 = 23 against 40, i.e. 36.5% of the file.
+    """
+    if n_temps < 2 or hot_thin <= 0:
+        return 0.0
+    hot = (n_temps - 1) * (n_raw_elements + 1) / float(hot_thin)
+    cold = float(n_out_elements + 1)
+    return hot / (hot + cold)
+
+
+def resolve_store_hot_chains(
+    spec, system, n_temps, n_raw_elements, n_out_elements, label, log
+):
+    """Resolve ``store_hot_chains`` to a thinning factor (0 = off).
+
+    Vocabulary, matching the rest of the sampler block ('auto' as in
+    `seed_polish`, `n_temps` and `mmexofast`): ``True``/'on' -> the default
+    thinning, ``False``/None/'off' -> off, an int -> that thinning factor,
+    and 'auto' (the default) -> decided by TOPOLOGY.
+
+    'auto' turns retention on when any active component declares
+    ``expects_suppressed_modes`` -- today the microlensing lens, whose
+    degeneracies are structural rather than accidental.  Hot-rung draws are
+    the only detector for a basin the T=1 posterior abandons
+    (outputs.ledger.discover_hot_modes), and they cost real trace size, so
+    the default follows the topology the way `chen` and
+    `mass_parameterization` do on the planet component: resolved from the
+    built system, overridable per fit, and never silent -- the decision and
+    its price are logged where it is made.
+
+    ``isinstance(spec, bool)`` comes first deliberately: ``spec is True``
+    already guarded the ``store_hot_chains: 1`` case here, but the same
+    ``1 == True`` collision cost `seed_polish` a whole value
+    (notes/code_review_20260808.txt 2.9.1), so the guard is now explicit
+    rather than incidental.
+    """
+    auto = False
+    if isinstance(spec, bool):
+        hot_thin = DEFAULT_HOT_THIN if spec else 0
+    elif spec is None:
+        hot_thin = 0
+    elif isinstance(spec, str):
+        key = spec.strip().lower()
+        if key == "auto":
+            auto = True
+            hot_thin = 0
+        elif key == "on":
+            hot_thin = DEFAULT_HOT_THIN
+        elif key == "off":
+            hot_thin = 0
+        else:
+            raise ValueError(
+                f"{label}: store_hot_chains={spec!r} is not recognized; use "
+                f"auto (default), true/on, false/off, or an integer "
+                f"thinning factor."
+            )
+    else:
+        hot_thin = max(1, int(spec))
+
+    named = sorted(
+        name
+        for name, comp in getattr(system, "active_components", {}).items()
+        if getattr(comp, "expects_suppressed_modes", False)
+    )
+    if auto:
+        hot_thin = DEFAULT_HOT_THIN if named else 0
+
+    if n_temps < 2:
+        if hot_thin:
+            log.info(
+                f"{label}: store_hot_chains is set but n_temps={n_temps} "
+                f"leaves no hot rungs; nothing will be stored."
+            )
+        return 0
+
+    share = hot_chain_trace_share(
+        n_temps, hot_thin, n_raw_elements, n_out_elements
+    )
+    if auto and hot_thin:
+        log.info(
+            f"{label}: store_hot_chains: auto -> ON (thin {hot_thin}). "
+            f"Component(s) {named} expect posterior-suppressed modes, so "
+            f"thinned draws from the {n_temps - 1} hot rungs are kept to "
+            f"search for solutions the T=1 posterior abandons "
+            f"(outputs.ledger.discover_hot_modes). Cost: roughly "
+            f"{100 * share:.0f}% of the trace file. Set "
+            f"`store_hot_chains: false` to opt out."
+        )
+    elif auto:
+        log.info(
+            f"{label}: store_hot_chains: auto -> OFF. No active component "
+            f"expects posterior-suppressed modes, so hot-rung draws are not "
+            f"kept and NO search for suppressed modes will run. Set "
+            f"`store_hot_chains: true` to enable it (adds roughly "
+            f"{100 * hot_chain_trace_share(n_temps, DEFAULT_HOT_THIN, n_raw_elements, n_out_elements):.0f}% "
+            f"to the trace file)."
+        )
+    elif hot_thin:
+        log.info(
+            f"{label}: store_hot_chains set explicitly -> ON (thin "
+            f"{hot_thin}), roughly {100 * share:.0f}% of the trace file."
+        )
+    else:
+        log.info(
+            f"{label}: store_hot_chains set explicitly -> OFF; no search "
+            f"for posterior-suppressed modes will run."
+        )
+    return hot_thin
+
+
 def de_proposal(rng, pop, i, gamma, keys, jitter=DE_JITTER):
     """One ter Braak DE-MC proposal for population member `i`:
     x_i + gamma * (x_j1 - x_j2) + jitter * N(0, 1), j1 != j2 != i.

--- a/src/exozippy/samplers/convergence.py
+++ b/src/exozippy/samplers/convergence.py
@@ -270,6 +270,88 @@ def find_burnin(posterior, lp=None, var_names=None):
     return diag
 
 
+# Groups the burn-in / stuck-chain trim is allowed to slice.  ALLOW-LIST,
+# not "every group that happens to have chain/draw dims": the trim's indices
+# mean "T=1 chain k" and "T=1 draw n", so they are only meaningful for groups
+# indexed by the SAME axes as `posterior`.
+#
+# `posterior_hot` (ptde_async store_hot_chains) is the counter-example that
+# motivated this (notes/code_review_20260808.txt 2.9.2): its chain axis is
+# (n_temps-1) x n_chains hot-rung chains, and its draw axis is its own thinned
+# one, so slicing it by T=1 good-chain indices and a T=1 burn-in silently
+# returned a handful of arbitrary hot chains with their heads cut off.  It is
+# a live input -- outputs.ledger.discover_hot_modes clusters it to record
+# posterior-suppressed modes as "considered and rejected" -- and today that
+# consumer only escapes because it runs BEFORE this call in run.py.  An
+# allow-list makes the invariant hold by construction instead of by statement
+# ordering.
+#
+# Why an allow-list and not a deny-list naming `posterior_hot`: a deny-list
+# has to be extended for every future group or that group is silently
+# mangled, which is exactly the failure being fixed.  The allow-list fails
+# the other way -- a new group is left untrimmed, which is visible in the
+# data rather than a silent corruption -- and _warn_untrimmed_groups makes
+# even that loud for any group that does carry chain/draw dims.
+_TRIMMED_GROUPS = (
+    "posterior",
+    "sample_stats",
+    "log_likelihood",
+    "posterior_predictive",
+)
+
+# Groups known NOT to share the T=1 draw axes; excluded silently.
+_UNTRIMMED_GROUPS = ("posterior_hot",)
+
+
+def _group_names(idata):
+    """Group names present on an InferenceData/DataTree, root excluded."""
+    try:
+        names = [str(g).strip("/") for g in idata.groups]
+    except TypeError:  # legacy arviz: groups() is a method
+        names = [str(g).strip("/") for g in idata.groups()]
+    return [n for n in names if n]
+
+
+def _warn_untrimmed_groups(idata, names):
+    """Loudly surface any unrecognized group carrying chain/draw dims."""
+    for name in names:
+        if name in _TRIMMED_GROUPS or name in _UNTRIMMED_GROUPS:
+            continue
+        dims = getattr(idata[name], "sizes", {})
+        if "chain" in dims or "draw" in dims:
+            logger.warning(
+                "Convergence trim: group '%s' has chain/draw dims but is not "
+                "in _TRIMMED_GROUPS; it is being carried across UNTRIMMED "
+                "(still holds burn-in and stuck chains). Add it to "
+                "samplers/convergence._TRIMMED_GROUPS if it shares the T=1 "
+                "draw axes, or to _UNTRIMMED_GROUPS if it does not.",
+                name,
+            )
+
+
+def trim_groups(idata, good_idx, burnin):
+    """Drop stuck chains + burn-in draws from the T=1 groups only.
+
+    Returns a new InferenceData in which every group named in
+    ``_TRIMMED_GROUPS`` is sliced to ``good_idx`` chains and draws from
+    ``burnin`` on, and EVERY other group -- ``posterior_hot`` above all -- is
+    carried across byte-for-byte.
+    """
+    names = _group_names(idata)
+    _warn_untrimmed_groups(idata, names)
+    trimmed = idata.copy()
+    idx = list(good_idx)
+    for name in names:
+        if name not in _TRIMMED_GROUPS:
+            continue
+        group = idata[name]
+        ds = group.to_dataset() if hasattr(group, "to_dataset") else group
+        trimmed[name] = ds.isel(
+            chain=idx, draw=slice(burnin, None), missing_dims="ignore"
+        )
+    return trimmed
+
+
 def analyze_idata(idata, min_ess=None, max_rhat=None, var_names=None):
     """Find burn-in + stuck chains on an InferenceData and return a trimmed view.
 
@@ -278,7 +360,9 @@ def analyze_idata(idata, min_ess=None, max_rhat=None, var_names=None):
     :func:`find_burnin`, tags the diagnostics with a ``converged`` verdict
     against the thresholds (informational only -- nothing is discarded), and
     returns ``(trimmed_idata, diag)`` where ``trimmed_idata`` has the stuck
-    chains and the burn-in draws removed from every group that has those dims.
+    chains and the burn-in draws removed from the T=1 groups
+    (``_TRIMMED_GROUPS``).  Every other group is carried across untouched --
+    see that constant for why this is an allow-list.
     """
     posterior = idata.posterior
     var_names = var_names or default_var_names(posterior)
@@ -300,13 +384,7 @@ def analyze_idata(idata, min_ess=None, max_rhat=None, var_names=None):
     diag["min_ess_threshold"] = min_ess
 
     good_idx = np.nonzero(diag["good_mask"])[0]
-    # isel across the whole InferenceData; missing_dims="ignore" leaves groups
-    # without chain/draw (e.g. observed_data) untouched.
-    trimmed = idata.isel(
-        chain=good_idx.tolist(),
-        draw=slice(diag["burnin"], None),
-        missing_dims="ignore",
-    )
+    trimmed = trim_groups(idata, good_idx, diag["burnin"])
     return trimmed, diag
 
 

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -335,12 +335,41 @@ def _update_ladder_barrier(temperatures, swap_accept, swap_propose):
     Only valid to call DURING the tuning phase -- re-spacing the ladder after
     tuning would break invariance, the same rule the DE gamma adaptation
     follows.
+
+    Pairs with ZERO proposals in the window carry no measurement and are
+    filled in from their measured neighbours, never scored.  The old
+    `1 - accept/max(propose, 1)` read a never-proposed pair as 0/1 = fully
+    REJECTING, r_k = 1, the largest barrier a link can have -- so an
+    unmeasured link stole ladder resolution from the links that had actually
+    been measured.  Zero proposals are routine: the DEO schedule alternates
+    even and odd pairs by round, the counters are reset every adaptation
+    window, and rung thinning lengthens the windows in which a given parity
+    never came up.  Scoring the gap 0 instead is equally wrong in the other
+    direction (it claims perfect mixing, collapsing those two rungs
+    together) and, because the gap then drops out of the total, silently
+    rescales every other pair's share.  Linear interpolation over the pair
+    index keeps the total honest and preserves the barrier PROFILE, which
+    varies smoothly along a smooth ladder; np.interp clamps at the ends, so
+    an unmeasured end pair inherits its nearest measured neighbour.  With a
+    single measured pair every r_k is that one value, the ladder is already
+    equal-share, and the update is exactly a no-op -- the right answer from
+    one datum.
     """
     n_temps = len(temperatures)
     if n_temps < 3:
         return np.asarray(temperatures, dtype=float)
-    r = 1.0 - swap_accept / np.maximum(swap_propose, 1)
-    r = np.clip(r, 0.0, 1.0)
+    prop = np.asarray(swap_propose, dtype=float)
+    acc = np.asarray(swap_accept, dtype=float)
+    measured = prop > 0
+    if not measured.any():
+        return np.asarray(temperatures, dtype=float)
+    r = np.zeros(prop.shape, dtype=float)
+    r[measured] = np.clip(1.0 - acc[measured] / prop[measured], 0.0, 1.0)
+    if not measured.all():
+        pair_idx = np.arange(prop.size)
+        r[~measured] = np.interp(
+            pair_idx[~measured], pair_idx[measured], r[measured]
+        )
     # Cumulative barrier at each rung; Lambda[0] = 0, length n_temps.
     Lambda = np.concatenate([[0.0], np.cumsum(r)])
     total = float(Lambda[-1])

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -146,26 +146,38 @@ def ladder_health_report(temperatures, n_swap_accept, n_swap_propose):
     return lam
 
 
-# Gradient-free polish stopping rule: stop when the best point found has
-# gained less than POLISH_TOL_NATS over the last POLISH_TOL_WINDOW sweeps.
+# OPT-IN improvement tolerance for the gradient-free polish: stop when the
+# best point found has gained less than `tol` nats over the last `tol_window`
+# sweeps.  DEFAULT OFF (tol=None), and that default is measured, not timid.
 #
+# The L-BFGS engine stops on its GRADIENT NORM by default (polish.py
+# _LBFGS_GTOL) -- an actual statement about the local surface.  No such
+# quantity exists here; this engine is gradient-free by construction.  The
+# only observable is the best-lp history, and on a real binary-lens surface
+# that history is a STAIRCASE: exactly-flat plateaus punctuated by jumps,
+# because best_lp is the running maximum of a T=1 Metropolis population that
+# spends many sweeps before one member escapes to a better region.  Measured
+# on examples/DC2018_128 (2 seeds, 300 sweeps, pop 38):
+#
+#   window  seed 0 stops at   nats missed    seed 1 stops at   nats missed
+#     10        sweep 11          73.2          sweep 20          136.5
+#     20        sweep 36          38.8          sweep 30          136.5
+#     30        sweep 46          38.8          sweep 40          136.5
+#     50        sweep 66          38.8          sweep 158          11.3
+#
+# and the shortfall is IDENTICAL for tol = 0.05, 0.5 and 2.0 nats, which is
+# the proof: the plateaus are exactly flat, so no threshold separates "has
+# converged" from "has not jumped yet".  Widening the window only delays the
+# same mistake.  A rule that costs 38-137 nats of start quality to save
+# sweeps is the opposite of the point -- the polish exists because a start
+# far below its basin optimum poisons the whitening probe (polish.py).
+#
+# So this engine's default stopping criterion stays the step CAP.  These
+# constants are the values used when a caller does opt in (tol=..., e.g. for
+# a surface known to be smooth, or a re-polish of an already-polished point).
 # ABSOLUTE nats, never relative to |lp|: logp carries an arbitrary additive
 # normalization, so a relative threshold means something different for every
-# model -- the exact trap documented on polish._LBFGS_FTOL, where scipy's
-# relative ftol quit whenever an iteration gained < 1e-3*|lp| (~2 nats at
-# lp ~ 1900) and stranded ob140939's seeds ~15 nats below their peaks.
-#
-# 0.05 nats: the polish exists to put the start inside its basin, close
-# enough that the whitening probe measures honest curvature.  That probe
-# works in 0.5-nat steps, so a tenth of one probe step is already far below
-# anything downstream can resolve, and the remaining climb to the exact MAP
-# is not wanted anyway (polish.py: the exact MAP of a scale-like parameter
-# is not in the typical set).
-#
-# Over a WINDOW of sweeps, never per sweep: best_lp is a running maximum of a
-# stochastic search, so single quiet sweeps are routine even while the search
-# is still climbing.  10 sweeps is >= 80 proposals (pop_size >= 8), enough
-# that a genuinely climbing search cannot look flat across all of them.
+# model -- the trap documented on polish._LBFGS_FTOL.
 POLISH_TOL_NATS = 0.05
 POLISH_TOL_WINDOW = 10
 
@@ -178,7 +190,7 @@ def polish_seed_starts(
     n_steps=150,
     pop_size=None,
     gamma=None,
-    tol=POLISH_TOL_NATS,
+    tol=None,
     tol_window=POLISH_TOL_WINDOW,
 ):
     """T=1 differential-evolution polish of each seed's raw start.
@@ -189,10 +201,10 @@ def polish_seed_starts(
     difference-vector proposals, the same move the sampler itself uses), and
     return the best-lp point visited as the new seed.
 
-    Stopping is by TOLERANCE, with ``n_steps`` as the safety cap: the sweeps
-    end as soon as the best point has gained less than ``tol`` nats over the
-    last ``tol_window`` sweeps (see POLISH_TOL_NATS).  ``tol=None`` restores
-    the old fixed ``n_steps`` sweeps.
+    Stopping: ``n_steps`` sweeps.  An improvement tolerance is available
+    (``tol`` nats over the last ``tol_window`` sweeps) but is OFF by default
+    -- see the POLISH_TOL_NATS comment for the measurement that says why a
+    best-lp window cannot be trusted on this engine.
 
     Rationale: an unpolished solution-estimate seed (e.g. a raw MMEXOFAST
     fit) can start hundreds of nats below its own basin's optimum, and

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -146,6 +146,30 @@ def ladder_health_report(temperatures, n_swap_accept, n_swap_propose):
     return lam
 
 
+# Gradient-free polish stopping rule: stop when the best point found has
+# gained less than POLISH_TOL_NATS over the last POLISH_TOL_WINDOW sweeps.
+#
+# ABSOLUTE nats, never relative to |lp|: logp carries an arbitrary additive
+# normalization, so a relative threshold means something different for every
+# model -- the exact trap documented on polish._LBFGS_FTOL, where scipy's
+# relative ftol quit whenever an iteration gained < 1e-3*|lp| (~2 nats at
+# lp ~ 1900) and stranded ob140939's seeds ~15 nats below their peaks.
+#
+# 0.05 nats: the polish exists to put the start inside its basin, close
+# enough that the whitening probe measures honest curvature.  That probe
+# works in 0.5-nat steps, so a tenth of one probe step is already far below
+# anything downstream can resolve, and the remaining climb to the exact MAP
+# is not wanted anyway (polish.py: the exact MAP of a scale-like parameter
+# is not in the typical set).
+#
+# Over a WINDOW of sweeps, never per sweep: best_lp is a running maximum of a
+# stochastic search, so single quiet sweeps are routine even while the search
+# is still climbing.  10 sweeps is >= 80 proposals (pop_size >= 8), enough
+# that a genuinely climbing search cannot look flat across all of them.
+POLISH_TOL_NATS = 0.05
+POLISH_TOL_WINDOW = 10
+
+
 def polish_seed_starts(
     raw_starts,
     logp_fn,
@@ -154,14 +178,21 @@ def polish_seed_starts(
     n_steps=150,
     pop_size=None,
     gamma=None,
+    tol=POLISH_TOL_NATS,
+    tol_window=POLISH_TOL_WINDOW,
 ):
     """T=1 differential-evolution polish of each seed's raw start.
 
     For each seed: spawn a small population jittered at ONE scale unit
     around the seed (staying inside its own basin -- this is a local
-    refiner, not a search), run ``n_steps`` of DE-MC at T=1 (Metropolis
-    acceptance on difference-vector proposals, the same move the sampler
-    itself uses), and return the best-lp point visited as the new seed.
+    refiner, not a search), run DE-MC at T=1 (Metropolis acceptance on
+    difference-vector proposals, the same move the sampler itself uses), and
+    return the best-lp point visited as the new seed.
+
+    Stopping is by TOLERANCE, with ``n_steps`` as the safety cap: the sweeps
+    end as soon as the best point has gained less than ``tol`` nats over the
+    last ``tol_window`` sweeps (see POLISH_TOL_NATS).  ``tol=None`` restores
+    the old fixed ``n_steps`` sweeps.
 
     Rationale: an unpolished solution-estimate seed (e.g. a raw MMEXOFAST
     fit) can start hundreds of nats below its own basin's optimum, and
@@ -207,6 +238,10 @@ def polish_seed_starts(
         best_lp = float(lps[best_i])
         lp0 = float(lps[0])  # the seed's own lp (member 0 = exact center)
 
+        # best_lp after each completed sweep; the tolerance test reads it
+        # tol_window sweeps back.
+        history = []
+        steps_taken, stop = 0, "cap"
         for _ in range(int(n_steps)):
             for i in range(pop_size):
                 j1, j2 = _pick_two(rng, pop_size, i)
@@ -224,11 +259,27 @@ def polish_seed_starts(
                     if lp > best_lp:
                         best_lp = lp
                         best = {k: v.copy() for k, v in prop.items()}
+            steps_taken += 1
+            if tol is None or not tol_window:
+                continue
+            history.append(best_lp)
+            if (
+                len(history) > tol_window
+                and history[-1] - history[-1 - tol_window] < tol
+            ):
+                stop = "tol"
+                break
         polished.append(best)
         dlps.append(best_lp - lp0)
+        reason = (
+            f"converged: < {tol} nats over {tol_window} sweeps"
+            if stop == "tol"
+            else f"hit the {int(n_steps)}-step cap"
+        )
         logger.info(
             f"PTDE seed polish: seed {s} lp {lp0:.1f} -> {best_lp:.1f} "
-            f"(dlp=+{best_lp - lp0:.1f}, {n_steps} steps x {pop_size} pop)"
+            f"(dlp=+{best_lp - lp0:.1f}, {steps_taken} steps x {pop_size} "
+            f"pop, {reason})"
         )
     return polished, dlps
 

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -617,14 +617,14 @@ def ptde_sample(
         _common.compile_conversions(model)
     )
 
-    if n_chains is None:
-        n_chains = 2 * n_params  # standard DE minimum for good mixing
+    # 2 * n_params is the standard DE population for good mixing; the floor
+    # and the warning both live in _common.resolve_n_chains.
+    n_chains = _common.resolve_n_chains(n_chains, n_params, "PTDE", logger)
     if gamma is None:
         gamma = 2.38 / np.sqrt(2 * n_params)
     logger.info(
         f"PTDE: {n_params} params, {n_chains} chains/rung, γ={gamma:.4f}"
     )
-    _common.warn_if_population_degenerate(n_chains, n_params, "PTDE", logger)
 
     # initialize populations
     t1_starts, chain_seed_index = _common.resolve_start_population(

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -117,7 +117,7 @@ def ptde_async_sample(
     lp_plausibility_ceiling=None,
     collect_rung_timing=False,
     progress_callback=None,
-    store_hot_chains=False,
+    store_hot_chains="auto",
 ):
     """
     Asynchronous Parallel Tempering + Differential Evolution sampler.
@@ -153,11 +153,16 @@ def ptde_async_sample(
                the knob means the same thing for both samplers. None -> 5%.
     lp_plausibility_ceiling : float | None -- same runaway-lp warning as
                ptde.py (None -> outputs.modes.DEFAULT_LP_ABS_MAX).
-    store_hot_chains : False | True | int -- keep THINNED draws from the
-               hot rungs (T > 1) as an extra ``posterior_hot`` group on the
-               returned InferenceData: every int-th post-tune iteration of
+    store_hot_chains : "auto" | False | True | int -- keep THINNED draws from
+               the hot rungs (T > 1) as an extra ``posterior_hot`` group on
+               the returned InferenceData: every int-th post-tune iteration of
                each hot chain (True -> 20), with its UNtempered logp and a
-               per-chain ``temperature`` coordinate. Hot draws are not
+               per-chain ``temperature`` coordinate. "auto" (the default)
+               decides from the TOPOLOGY -- on when any active component
+               declares ``expects_suppressed_modes`` (today the microlensing
+               lens), off otherwise; see
+               _common.resolve_store_hot_chains, which also logs the decision
+               and the resulting trace-size cost. Hot draws are not
                posterior draws -- a T-tempered mode is ~sqrt(T) too wide --
                but they visit posterior-suppressed basins (occupancy
                ~exp(-dlp/T)) that the T=1 chains abandon, so they are the
@@ -198,6 +203,15 @@ def ptde_async_sample(
     # see _common.compile_conversions for the rationale).
     raw_to_phys, raw_to_phys_batched, raw_var_names, out_var_names = (
         _common.compile_conversions(model)
+    )
+    # Element count of the PHYSICAL side (sampled + Deterministic), the
+    # denominator of the hot-group trace share below.  One transform
+    # evaluation at the start point; the graph is compiled either way.
+    _n_out_elements = sum(
+        int(np.asarray(v).size)
+        for v in raw_to_phys(
+            *[np.asarray(raw_start[k]) for k in raw_var_names]
+        )
     )
 
     n_chains = _common.resolve_n_chains(
@@ -297,11 +311,15 @@ def ptde_async_sample(
     # parameter docstring. UNtempered logp is stored (current_lp holds the
     # raw logp; tempering happens in the acceptance rule), so hot lp values
     # are directly comparable to T=1.
-    hot_thin = 0
-    if store_hot_chains and n_temps > 1:
-        hot_thin = (
-            20 if store_hot_chains is True else max(1, int(store_hot_chains))
-        )
+    hot_thin = _common.resolve_store_hot_chains(
+        store_hot_chains,
+        system,
+        n_temps,
+        n_params,
+        _n_out_elements,
+        "PTDE-async",
+        logger,
+    )
     hot_cap = max(1, draws // hot_thin) if hot_thin else 0
     if hot_thin:
         stored_hot_raw = {

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -200,15 +200,13 @@ def ptde_async_sample(
         _common.compile_conversions(model)
     )
 
-    if n_chains is None:
-        n_chains = 2 * n_params
+    n_chains = _common.resolve_n_chains(
+        n_chains, n_params, "PTDE-async", logger
+    )
     if gamma is None:
         gamma = 2.38 / np.sqrt(2 * n_params)
     logger.info(
         f"PTDE-async: {n_params} params, {n_chains} chains/rung, gamma={gamma:.4f}"
-    )
-    _common.warn_if_population_degenerate(
-        n_chains, n_params, "PTDE-async", logger
     )
 
     t1_starts, chain_seed_index = _common.resolve_start_population(

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -163,3 +163,101 @@ def test_analyze_idata_trims_and_flags(monkeypatch):
     assert trimmed.sample_stats.sizes["draw"] == 2000 - diag["burnin"]
     assert isinstance(diag["converged"], bool)
     assert diag["max_rhat"] < 1.02
+
+
+# --- review 2.9.2: the trim must never touch posterior_hot ----------------
+
+
+def _idata_with_hot(n_hot_chains=14, n_hot=40):
+    """A transient-bearing T=1 posterior plus a posterior_hot group whose
+    chain axis (rungs x chains) and draw axis (thinned) are BOTH unrelated
+    to the T=1 ones -- exactly what ptde_async's store_hot_chains writes."""
+    az = pytest.importorskip("arviz")
+    xr = pytest.importorskip("xarray")
+    raw = _transient(6, 2000, frac=0.3, seed=5)
+    idata = az.from_dict(
+        {
+            "posterior": {"p.x": raw * 2.0 + 10.0, "p.x_raw": raw},
+            "sample_stats": {"lp": -0.5 * raw**2},
+        }
+    )
+    rng = np.random.default_rng(0)
+    idata["posterior_hot"] = xr.Dataset(
+        {
+            "p.x_raw": (
+                ("chain", "draw"),
+                rng.standard_normal((n_hot_chains, n_hot)),
+            ),
+            "lp": (
+                ("chain", "draw"),
+                rng.standard_normal((n_hot_chains, n_hot)),
+            ),
+        },
+        coords={
+            "chain": np.arange(n_hot_chains),
+            "draw": np.arange(n_hot),
+            "temperature": (
+                "chain",
+                np.repeat(np.geomspace(2.0, 128.0, n_hot_chains // 2), 2),
+            ),
+        },
+    )
+    return idata
+
+
+def test_analyze_idata_leaves_posterior_hot_bit_identical():
+    """
+    Given an InferenceData carrying a posterior_hot group,
+    When analyze_idata trims stuck chains and burn-in,
+    Then posterior_hot comes out IDENTICAL to what went in.
+
+    Regression (notes/code_review_20260808.txt 2.9.2): the trim isel'd
+    EVERY group with chain/draw dims, so posterior_hot -- whose chain axis
+    is (n_temps-1) x n_chains hot-rung chains and whose draw axis is its own
+    thinned one -- was sliced by T=1 good-chain indices and a T=1 burn-in.
+    It survived only because outputs.ledger.discover_hot_modes happens to
+    run BEFORE this call in run.py; this pins the invariant instead of the
+    ordering.
+    """
+    # ARRANGE
+    idata = _idata_with_hot()
+    before = idata.posterior_hot.to_dataset().copy(deep=True)
+
+    # ACT
+    trimmed, diag = C.analyze_idata(idata, min_ess=100, max_rhat=1.01)
+
+    # ASSERT: the T=1 groups WERE trimmed ...
+    assert diag["burnin"] > 0
+    assert trimmed.posterior.sizes["draw"] == 2000 - diag["burnin"]
+    # ... and the hot group was not touched at all.
+    assert trimmed.posterior_hot.to_dataset().identical(before)
+    # nor was the caller's original object mutated
+    assert idata.posterior_hot.to_dataset().identical(before)
+
+
+def test_analyze_idata_warns_about_an_unknown_chain_draw_group(caplog):
+    """
+    Given an InferenceData carrying a group that is neither a known T=1
+      group nor a known exempt one, but does have chain/draw dims,
+    When analyze_idata trims,
+    Then the group is carried across untrimmed and a warning names it --
+      the allow-list fails loudly rather than silently mangling a group
+      whose axes it does not understand.
+    """
+    # ARRANGE
+    import logging
+
+    xr = pytest.importorskip("xarray")
+    idata = _idata_with_hot()
+    rng = np.random.default_rng(1)
+    idata["mystery"] = xr.Dataset(
+        {"z": (("chain", "draw"), rng.standard_normal((6, 2000)))}
+    )
+
+    # ACT
+    with caplog.at_level(logging.WARNING):
+        trimmed, _diag = C.analyze_idata(idata)
+
+    # ASSERT
+    assert "mystery" in caplog.text
+    assert trimmed.mystery.sizes["draw"] == 2000

--- a/tests/test_hot_chains.py
+++ b/tests/test_hot_chains.py
@@ -377,3 +377,233 @@ def test_an_empty_hot_group_reports_failed_not_none_found():
 
     assert status["state"] == L.HOT_FAILED
     assert "0 draws" in status["detail"]
+
+
+# ---------------------------------------------------------------------------
+# store_hot_chains: 'auto' resolves from the TOPOLOGY -- on where suppressed
+# modes are the norm (microlensing), off otherwise.
+# ---------------------------------------------------------------------------
+
+
+class _FakeComponent:
+    def __init__(self, expects):
+        self.expects_suppressed_modes = expects
+
+
+class _TopologySystem:
+    """Duck-typed System exposing only what the resolver reads."""
+
+    def __init__(self, **components):
+        self.active_components = {
+            k: _FakeComponent(v) for k, v in components.items()
+        }
+
+
+def _resolve(spec, system, caplog=None, n_temps=8, n_raw=10, n_out=20):
+    import logging
+
+    from exozippy.samplers._common import resolve_store_hot_chains
+
+    log = logging.getLogger("exozippy.test.hot")
+    return resolve_store_hot_chains(
+        spec, system, n_temps, n_raw, n_out, "PTDE-async", log
+    )
+
+
+def test_auto_stores_hot_chains_for_a_microlensing_topology():
+    """
+    Given a system whose lens component declares expects_suppressed_modes,
+    When store_hot_chains is left at its 'auto' default,
+    Then hot-rung retention turns ON at the default thinning.
+
+    Microlensing degeneracies (u_0 sign, close/wide s, parallax families)
+    are structural, so a solution the T=1 posterior abandons still has to be
+    reported -- and hot draws are the only detector for it.
+    """
+    from exozippy.samplers._common import DEFAULT_HOT_THIN
+
+    system = _TopologySystem(lens=True, mulensinstrument=False, star=False)
+
+    assert _resolve("auto", system) == DEFAULT_HOT_THIN
+
+
+def test_auto_skips_hot_chains_for_a_transit_or_rv_topology():
+    """
+    Given a system of components that expect no suppressed modes,
+    When store_hot_chains is left at 'auto',
+    Then hot-rung retention stays OFF -- the alternative-mode question
+      rarely arises there and the storage is not worth it.
+    """
+    system = _TopologySystem(
+        star=False, planet=False, transit=False, rvinstrument=False
+    )
+
+    assert _resolve("auto", system) == 0
+
+
+def test_explicit_false_beats_the_microlensing_default():
+    """
+    Given a microlensing topology,
+    When the user sets store_hot_chains false (or 'off'),
+    Then the explicit value wins -- only the UNSET case is topology-driven.
+    """
+    system = _TopologySystem(lens=True)
+
+    assert _resolve(False, system) == 0
+    assert _resolve("off", system) == 0
+
+
+def test_explicit_integer_thinning_is_honored_in_both_topologies():
+    """
+    Given an explicit integer thinning factor,
+    When it is resolved under either topology,
+    Then that exact factor is used -- and in particular the integer 1 means
+      "keep every hot draw", not the default thinning (the 1 == True
+      collision that cost seed_polish a whole value, review 2.9.1).
+    """
+    lensy = _TopologySystem(lens=True)
+    planar = _TopologySystem(transit=False)
+
+    assert _resolve(5, lensy) == 5
+    assert _resolve(5, planar) == 5
+    assert _resolve(1, lensy) == 1
+    assert _resolve(1, planar) == 1
+    # ... while the BOOLEAN True still means the default thinning
+    from exozippy.samplers._common import DEFAULT_HOT_THIN
+
+    assert _resolve(True, planar) == DEFAULT_HOT_THIN
+
+
+def test_the_auto_decision_and_its_cost_are_logged(caplog):
+    """
+    Given either topology,
+    When 'auto' resolves,
+    Then the decision, the reason and the trace-size cost are logged -- a
+      silent topology-dependent default is what makes behavior feel
+      unpredictable.
+    """
+    import logging
+
+    # ON: names the component that asked for it and quotes the cost
+    with caplog.at_level(logging.INFO, logger="exozippy.test.hot"):
+        _resolve("auto", _TopologySystem(lens=True))
+    assert "auto -> ON" in caplog.text
+    assert "lens" in caplog.text
+    assert "% of the trace file" in caplog.text
+
+    # OFF: says no search will run, and what enabling it would cost
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="exozippy.test.hot"):
+        _resolve("auto", _TopologySystem(transit=False))
+    assert "auto -> OFF" in caplog.text
+    assert "NO search for suppressed modes will run" in caplog.text
+    assert "store_hot_chains: true" in caplog.text
+
+
+def test_trace_share_matches_the_ob140939_arithmetic():
+    """
+    Given ob140939's shape -- 24 rungs, thin 20, 19 raw and 39 output
+      elements,
+    When the predicted hot-group share is computed,
+    Then it is ~37% of the trace, matching the measured file.
+
+    n_chains and draws cancel exactly (both groups scale with them), so the
+    share is set by the ladder height, the thinning, and the DERIVED-variable
+    count -- not by n_temps alone.
+    """
+    from exozippy.samplers._common import hot_chain_trace_share
+
+    share = hot_chain_trace_share(
+        n_temps=24, hot_thin=20, n_raw_elements=19, n_out_elements=39
+    )
+
+    assert share == pytest.approx(23.0 / 63.0, rel=1e-9)
+    assert 0.36 < share < 0.37
+    # a two-rung ladder or no thinning at all degrade sensibly
+    assert hot_chain_trace_share(1, 20, 19, 39) == 0.0
+    assert hot_chain_trace_share(24, 0, 19, 39) == 0.0
+
+
+def test_an_unrecognized_store_hot_chains_string_raises():
+    """
+    Given a typo in the sampler block,
+    When it is resolved,
+    Then it raises rather than silently meaning "off" -- a misspelled
+      opt-in that quietly does nothing is how a search stops running
+      without anyone noticing.
+    """
+    with pytest.raises(ValueError, match="not recognized"):
+        _resolve("yes-please", _TopologySystem(lens=True))
+
+
+def test_lens_component_declares_that_it_expects_suppressed_modes():
+    """
+    Given the shipped Lens component,
+    When its capability flag is read,
+    Then it declares expects_suppressed_modes, and the base Component does
+      not -- this is the whole topology signal, so pin it here rather than
+      only through a duck-typed stand-in.
+    """
+    from exozippy.components.component import Component
+    from exozippy.components.mulensing.lens import Lens
+
+    assert Lens.expects_suppressed_modes is True
+    assert Component.expects_suppressed_modes is False
+
+
+def test_default_store_hot_chains_is_auto_end_to_end():
+    """
+    Given a model with no microlensing component and no explicit setting,
+    When the async sampler runs,
+    Then no posterior_hot group is written -- the 'auto' default resolves
+      to off for a non-microlensing topology all the way through the
+      sampler, not just in the resolver.
+    """
+    with pm.Model() as model:
+        pm.Normal("x", mu=0.0, sigma=1.0)
+
+    idata = ptde_async_sample(
+        model,
+        _MinimalSystem(),
+        draws=30,
+        tune=10,
+        n_temps=3,
+        T_max=8.0,
+        n_chains=4,
+        cores=1,
+        seed=3,
+        log_interval=10000,
+    )
+
+    assert not hasattr(idata, "posterior_hot")
+
+
+def test_auto_stores_hot_chains_end_to_end_for_a_lensy_system():
+    """
+    Given a system whose components declare expects_suppressed_modes and no
+      explicit store_hot_chains,
+    When the async sampler runs,
+    Then the posterior_hot group IS written -- the microlensing default
+      reaches the sampler, which is the behavior change users will see.
+    """
+    with pm.Model() as model:
+        pm.Normal("x", mu=0.0, sigma=1.0)
+
+    class _LensySystem(_MinimalSystem):
+        active_components = {"lens": _FakeComponent(True)}
+
+    idata = ptde_async_sample(
+        model,
+        _LensySystem(),
+        draws=60,
+        tune=20,
+        n_temps=3,
+        T_max=8.0,
+        n_chains=4,
+        cores=1,
+        seed=7,
+        log_interval=10000,
+    )
+
+    assert hasattr(idata, "posterior_hot")
+    assert idata.posterior_hot.sizes["chain"] == (3 - 1) * 4

--- a/tests/test_hot_chains.py
+++ b/tests/test_hot_chains.py
@@ -185,3 +185,195 @@ def test_hot_record_reports_as_hot_chain_in_the_ledger_text():
 
     text = ledger_to_text(ledger)
     assert "(hot-chain): REJECTED" in text
+
+
+# ---------------------------------------------------------------------------
+# Hot-chain search OUTCOME reporting: "never searched", "searched and found
+# nothing", "the search crashed" and "found N" must be distinguishable in the
+# report a user reads, not only in a log file.
+# ---------------------------------------------------------------------------
+
+
+def _idata_with(hot=None):
+    """Minimal InferenceData, optionally carrying a posterior_hot group."""
+    import arviz as az
+
+    idata = az.from_dict(
+        {"posterior": {"toy.x_raw": np.zeros((2, 5))}},
+    )
+    if hot is not None:
+        idata["posterior_hot"] = hot
+    return idata
+
+
+def test_four_hot_search_outcomes_render_differently():
+    """
+    Given the four possible outcomes of the hot-chain suppressed-mode
+      search,
+    When each is rendered for the report,
+    Then all four texts are distinct and each names its own state, so a
+      reader can never mistake "never searched" or "the search failed" for
+      the reassurance "searched, nothing found".
+    """
+    # ARRANGE
+    from exozippy.outputs.ledger import (
+        HOT_FAILED,
+        HOT_FOUND,
+        HOT_NONE_FOUND,
+        HOT_NOT_SEARCHED,
+        hot_status_to_text,
+    )
+
+    states = {
+        HOT_NOT_SEARCHED: "NOT PERFORMED",
+        HOT_NONE_FOUND: "PERFORMED",
+        HOT_FAILED: "FAILED",
+        HOT_FOUND: "PERFORMED",
+    }
+
+    # ACT
+    texts = {s: hot_status_to_text({"state": s, "n_new": 2}) for s in states}
+
+    # ASSERT
+    assert len(set(texts.values())) == 4
+    for state, marker in states.items():
+        assert marker in texts[state]
+    # the two "did not happen" states must not read as a clean negative
+    assert "no additional mode was found" not in texts[HOT_NOT_SEARCHED]
+    assert "no additional mode was found" not in texts[HOT_FAILED]
+    assert "not the" in texts[HOT_FAILED].lower()
+    # and an empty status renders nothing at all
+    assert hot_status_to_text({}) == ""
+
+
+def test_missing_hot_group_reports_not_searched():
+    """
+    Given a trace with no posterior_hot group (store_hot_chains defaults
+      to off, so this is the common case),
+    When run_hot_mode_discovery runs,
+    Then the status says the search never happened -- NOT that nothing was
+      found.
+    """
+    from exozippy.outputs.ledger import (
+        HOT_NOT_SEARCHED,
+        run_hot_mode_discovery,
+    )
+
+    ledger, status = run_hot_mode_discovery(None, None, _idata_with(None), [])
+
+    assert status["state"] == HOT_NOT_SEARCHED
+    assert ledger == []
+
+
+def test_a_crashing_search_reports_failed_not_none_found(monkeypatch):
+    """
+    Given hot draws present but the discovery raising,
+    When run_hot_mode_discovery runs,
+    Then the ledger is returned unchanged (non-fatal, a wrap-up diagnostic
+      must not kill a finished fit) AND the status is 'failed' carrying the
+      exception type and message -- distinguishable from a clean
+      no-candidates run, which is the confusion being fixed.
+    """
+    # ARRANGE
+    from exozippy.outputs import ledger as L
+
+    model, p = _two_basin_model()
+    stub = _StubSystem([p])
+    hot = _fake_hot_group(model, p, np.random.default_rng(11))
+
+    def _boom(*a, **k):
+        raise RuntimeError("clustering blew up")
+
+    monkeypatch.setattr(L, "discover_hot_modes", _boom)
+
+    # ACT
+    out_ledger, status = L.run_hot_mode_discovery(
+        stub, model, _idata_with(hot), ["sentinel"]
+    )
+
+    # ASSERT
+    assert out_ledger == ["sentinel"]
+    assert status["state"] == L.HOT_FAILED
+    assert "RuntimeError" in status["detail"]
+    assert "clustering blew up" in status["detail"]
+    text = L.hot_status_to_text(status)
+    assert "FAILED" in text
+    assert text != L.hot_status_to_text({"state": L.HOT_NONE_FOUND})
+
+
+def test_a_clean_search_that_finds_a_basin_reports_found():
+    """
+    Given hot draws visiting a basin the ledger does not hold,
+    When run_hot_mode_discovery runs,
+    Then the status is 'found' with the new-record count.
+    """
+    from exozippy.outputs import ledger as L
+
+    model, p = _two_basin_model()
+    stub = _StubSystem([p])
+    raw2 = np.asarray(p.raw_from_initval(np.array([2.0])))
+    ledger0 = build_seed_ledger(stub, model, [{"toy.x_raw": raw2}], [0])
+    hot = _fake_hot_group(model, p, np.random.default_rng(11))
+
+    out_ledger, status = L.run_hot_mode_discovery(
+        stub, model, _idata_with(hot), ledger0, min_points=20
+    )
+
+    assert status["state"] == L.HOT_FOUND
+    assert status["n_new"] == 1
+    assert len(out_ledger) == 2
+
+
+def test_a_search_finding_only_rediscoveries_reports_none_found():
+    """
+    Given hot draws whose every cluster is a basin the ledger already
+      holds,
+    When run_hot_mode_discovery runs,
+    Then the status is 'none-found' -- the reassurance the user wants,
+      earned by an actual search.
+    """
+    from exozippy.outputs import ledger as L
+
+    model, p = _two_basin_model()
+    stub = _StubSystem([p])
+    hot = _fake_hot_group(model, p, np.random.default_rng(11))
+    # seed the ledger with BOTH basins so every cluster dedups
+    starts = [
+        {"toy.x_raw": np.asarray(p.raw_from_initval(np.array([v])))}
+        for v in (2.0, 7.0)
+    ]
+    ledger0 = build_seed_ledger(stub, model, starts, [0, 1])
+
+    out_ledger, status = L.run_hot_mode_discovery(
+        stub, model, _idata_with(hot), ledger0, min_points=20
+    )
+
+    assert status["state"] == L.HOT_NONE_FOUND
+    assert status["n_new"] == 0
+    assert len(out_ledger) == 2
+
+
+def test_an_empty_hot_group_reports_failed_not_none_found():
+    """
+    Given a posterior_hot group that reached discovery with zero draws --
+      what a mis-sliced group looks like (review 2.9.2),
+    When discovery runs,
+    Then it is reported as a FAILED search, never as "searched and found
+      nothing".
+    """
+    import xarray as xr
+
+    from exozippy.outputs import ledger as L
+
+    empty = xr.Dataset(
+        {
+            "toy.x_raw": (("chain", "draw"), np.zeros((0, 0))),
+            "lp": (("chain", "draw"), np.zeros((0, 0))),
+        }
+    )
+    _ledger, status = L.run_hot_mode_discovery(
+        None, None, _idata_with(empty), []
+    )
+
+    assert status["state"] == L.HOT_FAILED
+    assert "0 draws" in status["detail"]

--- a/tests/test_polish.py
+++ b/tests/test_polish.py
@@ -316,3 +316,213 @@ def test_polish_reaches_the_peak_when_lp_is_large_in_magnitude():
     assert method == "lbfgs"
     lp_fn = model.compile_logp()
     assert float(lp_fn(polished[0])) == pytest.approx(-2000.0, abs=1.0)
+
+
+# ---------------------------------------------------------------------------
+# review 2.9.1: `seed_polish: 1` is one step, and stopping is by TOLERANCE
+# with the step count as a safety cap.
+# ---------------------------------------------------------------------------
+
+
+def test_integer_one_is_one_step_not_the_default():
+    """
+    Given `seed_polish: 1` -- the integer 1, not the boolean True,
+    When resolve_polish_steps maps it,
+    Then the cap is 1 step.
+
+    Regression (notes/code_review_20260808.txt 2.9.1): the old
+    `spec in (True, "on")` test matched the integer 1, because 1 == True in
+    Python, so asking for a single step silently got DEFAULT_POLISH_STEPS
+    (150).  Every small integer 2..N was honored, which is what made the
+    one-value hole invisible.
+    """
+    assert resolve_polish_steps(1, n_seeds=1, has_seed_hints=False) == 1
+    assert resolve_polish_steps(2, n_seeds=1, has_seed_hints=False) == 2
+    # True must still mean "the default cap", not "1 step".
+    assert (
+        resolve_polish_steps(True, n_seeds=1, has_seed_hints=False)
+        == DEFAULT_POLISH_STEPS
+    )
+
+
+def test_integer_zero_is_off_and_stays_off():
+    """
+    Given `seed_polish: 0`,
+    When resolve_polish_steps maps it,
+    Then it is 0 -- the symmetric `0 == False` collision was harmless
+      (0 steps IS off) and must stay harmless after the bool fix.
+    """
+    assert resolve_polish_steps(0, n_seeds=1, has_seed_hints=False) == 0
+    assert resolve_polish_steps(False, n_seeds=1, has_seed_hints=False) == 0
+    assert resolve_polish_steps(None, n_seeds=1, has_seed_hints=False) == 0
+
+
+def test_de_polish_step_count_is_a_cap_honored_exactly_at_one():
+    """
+    Given the gradient-free DE engine with n_steps=1,
+    When polish_seed_starts runs,
+    Then exactly ONE sweep of pop_size proposals happens (plus the
+      pop_size population-seeding evaluations) -- the cap is honored
+      literally and the tolerance window (10 sweeps) cannot pre-empt it.
+    """
+    # ARRANGE
+    from exozippy.samplers.ptde import polish_seed_starts
+
+    calls = []
+
+    def logp(p):
+        calls.append(1)
+        return float(-0.5 * np.sum((p["x"] - 3.0) ** 2))
+
+    seed = {"x": np.array([0.0])}
+    scales = {"x": np.ones(1)}
+
+    # ACT
+    polish_seed_starts(
+        [seed],
+        logp,
+        np.random.default_rng(0),
+        scales,
+        n_steps=1,
+        pop_size=8,
+    )
+
+    # ASSERT: 8 seeding evaluations + 8 proposals in the single sweep
+    assert len(calls) == 16
+
+
+def test_de_polish_stops_on_tolerance_well_before_the_cap():
+    """
+    Given a start already sitting at its basin optimum and a 150-step cap,
+    When the DE polish runs,
+    Then it stops on its tolerance after ~tol_window sweeps instead of
+      burning all 150 -- "polish" is a stopping criterion, not a step count.
+
+    Also pins that the tolerance cannot be reached before tol_window+1
+    sweeps (the window is what keeps a single quiet sweep of a stochastic
+    search from ending it).
+    """
+    # ARRANGE
+    from exozippy.samplers.ptde import (
+        POLISH_TOL_WINDOW,
+        polish_seed_starts,
+    )
+
+    calls = []
+
+    def logp(p):
+        calls.append(1)
+        return float(-0.5 * np.sum((p["x"] - 3.0) ** 2))
+
+    seed = {"x": np.array([3.0])}
+    scales = {"x": np.ones(1)}
+    pop = 8
+
+    # ACT
+    _polished, dlps = polish_seed_starts(
+        [seed],
+        logp,
+        np.random.default_rng(0),
+        scales,
+        n_steps=150,
+        pop_size=pop,
+    )
+
+    # ASSERT
+    sweeps = (len(calls) - pop) / pop
+    assert sweeps == POLISH_TOL_WINDOW + 1
+    assert sweeps < 150
+    assert dlps[0] >= 0.0
+
+
+def test_de_polish_tolerance_does_not_stop_a_climbing_search_early():
+    """
+    Given a start far below its basin optimum,
+    When the DE polish runs with the default tolerance,
+    Then it keeps going past the tolerance window (the search is still
+      gaining more than the tolerance per window) and reaches the optimum.
+    """
+    # ARRANGE
+    from exozippy.samplers.ptde import (
+        POLISH_TOL_WINDOW,
+        polish_seed_starts,
+    )
+
+    calls = []
+
+    def logp(p):
+        calls.append(1)
+        return float(-0.5 * np.sum((p["x"] - 40.0) ** 2))
+
+    seed = {"x": np.array([0.0])}
+    scales = {"x": np.ones(1)}
+    pop = 8
+
+    # ACT
+    polished, dlps = polish_seed_starts(
+        [seed],
+        logp,
+        np.random.default_rng(1),
+        scales,
+        n_steps=150,
+        pop_size=pop,
+    )
+
+    # ASSERT
+    sweeps = (len(calls) - pop) / pop
+    assert sweeps > POLISH_TOL_WINDOW + 1
+    assert dlps[0] > 0.0
+    assert abs(float(polished[0]["x"][0]) - 40.0) < 5.0
+
+
+def test_de_polish_tolerance_can_be_disabled_for_a_fixed_step_count():
+    """
+    Given tol=None (the pre-tolerance behavior),
+    When the DE polish runs from a start already at its optimum,
+    Then all n_steps sweeps run -- the old fixed-step contract is still
+      reachable for anything that depends on it.
+    """
+    from exozippy.samplers.ptde import polish_seed_starts
+
+    calls = []
+
+    def logp(p):
+        calls.append(1)
+        return float(-0.5 * np.sum((p["x"] - 3.0) ** 2))
+
+    polish_seed_starts(
+        [{"x": np.array([3.0])}],
+        logp,
+        np.random.default_rng(0),
+        {"x": np.ones(1)},
+        n_steps=25,
+        pop_size=8,
+        tol=None,
+    )
+
+    assert len(calls) == 8 + 25 * 8
+
+
+def test_lbfgs_polish_stops_on_the_gradient_not_the_cap():
+    """
+    Given a smooth quadratic basin and the default 150-iteration cap,
+    When the L-BFGS engine polishes,
+    Then it converges on the gradient tolerance in a handful of iterations
+      -- the cap is a safety net, never the stopping criterion -- and
+      capping at 1 iteration measurably under-polishes the same problem.
+    """
+    # ARRANGE: a curved valley, so one iteration is demonstrably not enough
+    with pm.Model() as model:
+        x = pm.Flat("x")
+        y = pm.Flat("y")
+        pm.Potential("like", -0.5 * ((y - x**2) ** 2 / 0.01 + (x - 1.0) ** 2))
+    start = {"x": np.array(-1.0), "y": np.array(1.0)}
+    lp_fn = model.compile_logp()
+
+    # ACT
+    _cap1, dlp_1, _m1 = polish_raw_starts(model, [start], n_steps=1)
+    full, dlp_full, _m2 = polish_raw_starts(model, [start], n_steps=150)
+
+    # ASSERT
+    assert dlp_1[0] < dlp_full[0]
+    assert float(lp_fn(full[0])) == pytest.approx(0.0, abs=1.0)

--- a/tests/test_polish.py
+++ b/tests/test_polish.py
@@ -362,8 +362,8 @@ def test_de_polish_step_count_is_a_cap_honored_exactly_at_one():
     Given the gradient-free DE engine with n_steps=1,
     When polish_seed_starts runs,
     Then exactly ONE sweep of pop_size proposals happens (plus the
-      pop_size population-seeding evaluations) -- the cap is honored
-      literally and the tolerance window (10 sweeps) cannot pre-empt it.
+      pop_size population-seeding evaluations) -- `seed_polish: 1` really
+      is one step of work, which is what 2.9.1 was about.
     """
     # ARRANGE
     from exozippy.samplers.ptde import polish_seed_starts
@@ -391,97 +391,23 @@ def test_de_polish_step_count_is_a_cap_honored_exactly_at_one():
     assert len(calls) == 16
 
 
-def test_de_polish_stops_on_tolerance_well_before_the_cap():
+def test_de_polish_default_is_the_step_cap_not_an_improvement_window():
     """
-    Given a start already sitting at its basin optimum and a 150-step cap,
-    When the DE polish runs,
-    Then it stops on its tolerance after ~tol_window sweeps instead of
-      burning all 150 -- "polish" is a stopping criterion, not a step count.
+    Given a start already sitting at its basin optimum,
+    When the gradient-free DE polish runs with the DEFAULT settings,
+    Then all n_steps sweeps run: this engine's default stopping criterion
+      is the cap, deliberately.
 
-    Also pins that the tolerance cannot be reached before tol_window+1
-    sweeps (the window is what keeps a single quiet sweep of a stochastic
-    search from ending it).
-    """
-    # ARRANGE
-    from exozippy.samplers.ptde import (
-        POLISH_TOL_WINDOW,
-        polish_seed_starts,
-    )
-
-    calls = []
-
-    def logp(p):
-        calls.append(1)
-        return float(-0.5 * np.sum((p["x"] - 3.0) ** 2))
-
-    seed = {"x": np.array([3.0])}
-    scales = {"x": np.ones(1)}
-    pop = 8
-
-    # ACT
-    _polished, dlps = polish_seed_starts(
-        [seed],
-        logp,
-        np.random.default_rng(0),
-        scales,
-        n_steps=150,
-        pop_size=pop,
-    )
-
-    # ASSERT
-    sweeps = (len(calls) - pop) / pop
-    assert sweeps == POLISH_TOL_WINDOW + 1
-    assert sweeps < 150
-    assert dlps[0] >= 0.0
-
-
-def test_de_polish_tolerance_does_not_stop_a_climbing_search_early():
-    """
-    Given a start far below its basin optimum,
-    When the DE polish runs with the default tolerance,
-    Then it keeps going past the tolerance window (the search is still
-      gaining more than the tolerance per window) and reaches the optimum.
+    Why (measured on examples/DC2018_128, tabulated on
+    ptde.POLISH_TOL_NATS): the best-lp history of a T=1 Metropolis
+    population is a STAIRCASE of exactly-flat plateaus, so a best-lp
+    improvement window fires on a plateau and misses the next jump -- 38 to
+    137 nats short there, by the SAME amount at tol = 0.05, 0.5 and 2.0,
+    which proves no threshold separates the two cases.  A start left tens
+    of nats below its basin optimum is exactly what poisons the whitening
+    probe, i.e. the thing the polish exists to prevent.
     """
     # ARRANGE
-    from exozippy.samplers.ptde import (
-        POLISH_TOL_WINDOW,
-        polish_seed_starts,
-    )
-
-    calls = []
-
-    def logp(p):
-        calls.append(1)
-        return float(-0.5 * np.sum((p["x"] - 40.0) ** 2))
-
-    seed = {"x": np.array([0.0])}
-    scales = {"x": np.ones(1)}
-    pop = 8
-
-    # ACT
-    polished, dlps = polish_seed_starts(
-        [seed],
-        logp,
-        np.random.default_rng(1),
-        scales,
-        n_steps=150,
-        pop_size=pop,
-    )
-
-    # ASSERT
-    sweeps = (len(calls) - pop) / pop
-    assert sweeps > POLISH_TOL_WINDOW + 1
-    assert dlps[0] > 0.0
-    assert abs(float(polished[0]["x"][0]) - 40.0) < 5.0
-
-
-def test_de_polish_tolerance_can_be_disabled_for_a_fixed_step_count():
-    """
-    Given tol=None (the pre-tolerance behavior),
-    When the DE polish runs from a start already at its optimum,
-    Then all n_steps sweeps run -- the old fixed-step contract is still
-      reachable for anything that depends on it.
-    """
     from exozippy.samplers.ptde import polish_seed_starts
 
     calls = []
@@ -490,17 +416,88 @@ def test_de_polish_tolerance_can_be_disabled_for_a_fixed_step_count():
         calls.append(1)
         return float(-0.5 * np.sum((p["x"] - 3.0) ** 2))
 
+    pop = 8
+
+    # ACT
     polish_seed_starts(
         [{"x": np.array([3.0])}],
         logp,
         np.random.default_rng(0),
         {"x": np.ones(1)},
         n_steps=25,
-        pop_size=8,
-        tol=None,
+        pop_size=pop,
     )
 
-    assert len(calls) == 8 + 25 * 8
+    # ASSERT
+    assert len(calls) == pop + 25 * pop
+
+
+def test_de_polish_improvement_window_is_available_as_an_opt_in():
+    """
+    Given a caller who opts in with tol/tol_window on a smooth surface,
+    When the DE polish runs from a start already at its optimum,
+    Then it stops one window past the window length instead of burning the
+      whole cap -- the machinery works; only the DEFAULT is off.
+    """
+    # ARRANGE
+    from exozippy.samplers.ptde import (
+        POLISH_TOL_NATS,
+        POLISH_TOL_WINDOW,
+        polish_seed_starts,
+    )
+
+    calls = []
+
+    def logp(p):
+        calls.append(1)
+        return float(-0.5 * np.sum((p["x"] - 3.0) ** 2))
+
+    pop = 8
+
+    # ACT
+    _polished, dlps = polish_seed_starts(
+        [{"x": np.array([3.0])}],
+        logp,
+        np.random.default_rng(0),
+        {"x": np.ones(1)},
+        n_steps=150,
+        pop_size=pop,
+        tol=POLISH_TOL_NATS,
+    )
+
+    # ASSERT
+    sweeps = (len(calls) - pop) / pop
+    assert sweeps == POLISH_TOL_WINDOW + 1
+    assert dlps[0] >= 0.0
+
+
+def test_an_improvement_window_would_quit_on_a_staircase_plateau():
+    """
+    Given a best-lp history shaped like the DE polish's real one -- flat
+      plateaus punctuated by jumps (examples/DC2018_128),
+    When an improvement window of any tolerance is applied to it,
+    Then it stops on the first plateau and misses every later jump.
+
+    This is the measurement that keeps the DE tolerance OFF by default,
+    kept as an executable statement so nobody turns it on by analogy with
+    the L-BFGS path's gradient tolerance.  Note the verdict does not move
+    with the tolerance: the plateaus are EXACTLY flat.
+    """
+    # ARRANGE: a plateau, a jump, a longer plateau, a bigger jump
+    history = [100.0] * 15 + [140.0] * 40 + [180.0] * 30 + [220.0] * 15
+
+    def first_stop(window, tol):
+        for t in range(window, len(history)):
+            if history[t] - history[t - window] < tol:
+                return t + 1
+        return len(history)
+
+    # ACT + ASSERT
+    for window in (10, 20, 30):
+        stops = {tol: first_stop(window, tol) for tol in (0.05, 0.5, 2.0)}
+        assert len(set(stops.values())) == 1, stops
+        stop = stops[0.05]
+        assert history[stop - 1] < history[-1]
 
 
 def test_lbfgs_polish_stops_on_the_gradient_not_the_cap():

--- a/tests/test_ptde.py
+++ b/tests/test_ptde.py
@@ -806,3 +806,89 @@ def test_make_starts_caps_exact_seed_chains():
     assert n_exact <= n_chains // 2
     # every seed still contributes a chain (round-robin unchanged)
     assert set(chain_seed_index) == set(range(K))
+
+
+# ---------------------------------------------------------------------------
+# review 2.9.3: a pair with ZERO swap proposals carries no measurement and
+# must not be scored as fully rejecting.
+# ---------------------------------------------------------------------------
+
+
+def test_unmeasured_swap_pair_does_not_inflate_the_barrier():
+    """
+    Given a 5-rung ladder in which every MEASURED adjacent pair rejects at
+      the same rate, and the other pairs were never proposed (the DEO
+      schedule alternates even/odd pairs and the counters reset every
+      adaptation window, so this is routine),
+    When the barrier-equalizing ladder update runs,
+    Then the ladder is unchanged -- a uniform barrier is already
+      equal-share, so the only honest update is none.
+
+    Regression (notes/code_review_20260808.txt 2.9.3): the old
+    `1 - accept/max(propose, 1)` read a never-proposed pair as 0/1 = fully
+    REJECTING, r = 1, the largest barrier a link can carry, so an
+    unmeasured link stole ladder resolution from the links that had
+    actually been measured.
+    """
+    # ARRANGE: pairs 0 and 2 measured at 20% rejection; pairs 1 and 3 never
+    # proposed.
+    from exozippy.samplers.ptde import _update_ladder_barrier
+
+    temps = np.array([1.0, 2.0, 4.0, 8.0, 16.0])
+    accept = np.array([8.0, 0.0, 8.0, 0.0])
+    propose = np.array([10.0, 0.0, 10.0, 0.0])
+
+    # ACT
+    new_T = _update_ladder_barrier(temps, accept, propose)
+
+    # ASSERT
+    np.testing.assert_allclose(new_T, temps, rtol=1e-9)
+
+
+def test_unmeasured_pair_is_interpolated_from_its_measured_neighbours():
+    """
+    Given a ladder whose measured pairs have very different rejection rates
+      and an unmeasured pair between them,
+    When the ladder update runs,
+    Then the result matches what the same ladder would give if the gap had
+      been measured at the interpolated rate -- the gap inherits the local
+      barrier PROFILE rather than a global constant, and the total barrier
+      stays honest.
+    """
+    # ARRANGE
+    from exozippy.samplers.ptde import _update_ladder_barrier
+
+    temps = np.array([1.0, 2.0, 4.0, 8.0, 16.0])
+    # measured: pair0 r=0.1, pair2 r=0.5 -> pair1 should read r=0.3, and
+    # pair3 (past the last measurement) clamps to 0.5.
+    accept = np.array([9.0, 0.0, 5.0, 0.0])
+    propose = np.array([10.0, 0.0, 10.0, 0.0])
+    equivalent_accept = np.array([9.0, 7.0, 5.0, 5.0])
+    equivalent_propose = np.full(4, 10.0)
+
+    # ACT
+    got = _update_ladder_barrier(temps, accept, propose)
+    want = _update_ladder_barrier(temps, equivalent_accept, equivalent_propose)
+
+    # ASSERT
+    np.testing.assert_allclose(got, want, rtol=1e-9)
+    # and it is NOT what scoring the gaps as fully-rejecting would give
+    old_style = _update_ladder_barrier(temps, accept, np.maximum(propose, 1.0))
+    assert not np.allclose(got, old_style)
+
+
+def test_ladder_update_is_a_noop_when_nothing_was_proposed():
+    """
+    Given an adaptation window in which no swap at all was proposed,
+    When the ladder update runs,
+    Then the ladder is returned unchanged rather than re-spaced against
+      four fabricated full-rejection links.
+    """
+    from exozippy.samplers.ptde import _update_ladder_barrier
+
+    temps = np.array([1.0, 2.0, 4.0, 8.0, 16.0])
+    zeros = np.zeros(4)
+
+    np.testing.assert_allclose(
+        _update_ladder_barrier(temps, zeros, zeros), temps
+    )

--- a/tests/test_ptde_async.py
+++ b/tests/test_ptde_async.py
@@ -344,3 +344,91 @@ def test_ptde_async_freezes_gamma_when_first_chain_starts_recording(caplog):
     assert len(freeze_msgs) == 1, (
         f"expected exactly one gamma-freeze message, got {freeze_msgs}"
     )
+
+
+# ---------------------------------------------------------------------------
+# review 2.9.4: n_chains = 2 (reachable at n_params = 1 with the default
+# 2 * n_params) has no valid DE move.
+# ---------------------------------------------------------------------------
+
+
+def test_pick_two_raises_a_clear_error_below_three_chains():
+    """
+    Given a population of 2,
+    When a DE proposal tries to pick two OTHER members,
+    Then it raises with a message naming n_chains and the minimum.
+
+    Regression (notes/code_review_20260808.txt 2.9.4): this died inside
+    numpy as "Cannot take a larger sample than population when replace is
+    False", which says nothing about n_chains.
+    """
+    from exozippy.samplers._common import _pick_two
+
+    with pytest.raises(ValueError, match="two other population members"):
+        _pick_two(np.random.default_rng(0), 2, 0)
+    # three is enough to form a difference vector (degenerately: the two
+    # others are forced) and must still work
+    assert _pick_two(np.random.default_rng(0), 3, 0) in [(1, 2), (2, 1)]
+
+
+def test_default_n_chains_is_floored_above_the_de_minimum():
+    """
+    Given a one-parameter model, where the default n_chains = 2 * n_params
+      would be 2,
+    When the population size is resolved,
+    Then it is floored at MIN_DE_CHAINS so the DEFAULT can never land on a
+      population too small to make a DE move.
+    """
+    import logging
+
+    from exozippy.samplers._common import MIN_DE_CHAINS, resolve_n_chains
+
+    log = logging.getLogger("test")
+    assert resolve_n_chains(None, 1, "PTDE", log) == MIN_DE_CHAINS
+    # the default is untouched wherever it is already large enough
+    assert resolve_n_chains(None, 6, "PTDE", log) == 12
+
+
+def test_explicitly_requesting_two_chains_raises_rather_than_being_bumped():
+    """
+    Given a user explicitly asking for n_chains = 2,
+    When the population size is resolved,
+    Then it RAISES with a message explaining why -- quietly running a
+      different sampler than the one requested is worse than stopping, and
+      unlike the default case there is a human to tell.
+    """
+    import logging
+
+    from exozippy.samplers._common import resolve_n_chains
+
+    log = logging.getLogger("test")
+    with pytest.raises(ValueError, match="two OTHER population members"):
+        resolve_n_chains(2, 1, "PTDE-async", log)
+
+
+def test_one_parameter_model_samples_end_to_end_on_the_default_population():
+    """
+    Given a one-parameter model and no explicit n_chains -- exactly the
+      configuration that used to crash inside numpy,
+    When the async sampler runs,
+    Then it completes and returns MIN_DE_CHAINS chains of draws.
+    """
+    from exozippy.samplers._common import MIN_DE_CHAINS
+
+    with pm.Model() as model:
+        pm.Normal("x", mu=0.0, sigma=1.0)
+
+    idata = ptde_async_sample(
+        model,
+        _MinimalSystem(),
+        draws=30,
+        tune=10,
+        n_temps=2,
+        T_max=4.0,
+        cores=1,
+        seed=5,
+        log_interval=10000,
+    )
+
+    assert idata.posterior.sizes["chain"] == MIN_DE_CHAINS
+    assert idata.posterior.sizes["draw"] == 30


### PR DESCRIPTION
## 2.9.1 -- `seed_polish: 1` returned 150

`spec in (True, "on")` compares with `==`, and `1 == True`. Every other small int was honored (2 -> 2), which is what kept the one-value hole invisible. Fixed with `isinstance(spec, bool)` first. `0 == False` also matched; confirmed harmless (0 steps *is* off) and still returns 0 via the int path.

### The tolerance-by-default design change: shipped, measured, half reversed

The request was to make the default stopping criterion a tolerance rather than a step count. I implemented it, measured it on real examples, and reversed the DE half (commit `e8487d6`). The measure was **absolute** logp gain over a window of sweeps -- never relative to `|lp|`, the trap already documented on `_LBFGS_FTOL`.

**L-BFGS path: tolerance-by-default already held.** It stops on `|grad| < 0.01` nats/raw-unit with `maxiter` as a net. On `examples/ob140939` (4 literature seeds), 2 of 4 converge on the gradient at **432** and **655** iterations. The other 2 never do -- still crawling a flat direction at **5000** iterations, where 33x the default cap buys **9 nats of a 547-nat climb (1.6%)** and doubles wall time. The 150 cap is doing its documented job (bounding hierarchical-MAP drift), not standing in for a missing tolerance. Left at 150; the log line now says which criterion ended it.

**DE path: an improvement window is not a safe stopping rule.** On `examples/DC2018_128` (binary lens, 2 seeds, 300 sweeps, pop 38) the best-lp history is a *staircase of exactly-flat plateaus*:

| window | seed 0 stops | nats missed | seed 1 stops | nats missed |
|---|---|---|---|---|
| 10 | sweep 11 | 73.2 | sweep 20 | 136.5 |
| 20 | sweep 36 | 38.8 | sweep 30 | 136.5 |
| 30 | sweep 46 | 38.8 | sweep 40 | 136.5 |
| 50 | sweep 66 | 38.8 | sweep 158 | 11.3 |

The shortfall is **identical at tol = 0.05, 0.5 and 2.0 nats** -- that is the proof. The plateaus are exactly flat, so no threshold separates "converged" from "has not jumped yet", and widening the window only delays the same mistake. Leaving a start 38-137 nats low is precisely what poisons the whitening probe -- the pathology the polish exists to prevent.

So `polish_seed_starts` defaults to `tol=None` (the cap is the criterion), with `tol`/`tol_window` as a documented opt-in. The table is in the code and a synthetic-staircase test pins the reason executably.

**Net: `seed_polish: N` now honestly means "at most N".**

## 2.9.2 -- `posterior_hot` mangled by the trim

Reproduced: 14 hot chains x 40 draws in, 3 chains out, temperature coord scrambled to `[2, 2, 4]`; with burn-in exceeding the thinned hot draws it comes out empty.

**Allow-list, not deny-list.** `_TRIMMED_GROUPS = (posterior, sample_stats, log_likelihood, posterior_predictive)` -- the groups indexed by the *same* T=1 axes. A deny-list naming `posterior_hot` would need extending for every future group or that group is silently mangled, which is the defect itself; the allow-list fails the other way (visibly untrimmed), and `_warn_untrimmed_groups` names any unknown chain/draw group loudly. The test asserts the hot group is `.identical()` to what went in **and** that the T=1 groups were trimmed -- pinning the invariant rather than the current statement ordering.

**`discover_hot_modes` would not have coped, and validated nothing.** It reshapes `(chain, draw, ...)` without consulting the temperature coord or checking the chain count against `(n_temps-1) x n_chains`. Handed a mangled group it would cluster it and report "0 new basins" -- indistinguishable from a real negative. Three paths that used to `return ledger` silently now report FAILED: empty group, missing raw vars/`lp`, all-non-finite.

Storage context: no trace here carries the group, so computed from ob140939's shapes (19 raw / 39 output elements, `n_temps=24`, `n_chains=38`, 50000 draws, `hot_thin=20`) the hot group is **~36.5% of the trace**. It is read, so it stays.

## Four-state hot-search reporting

**`store_hot_chains` defaults to False** -- only `examples/ob140939` enables it -- so **most fits have been in state 1**, silently saying nothing about a search that never ran.

`discover_hot_modes` fills an optional `status` dict; a new `run_hot_mode_discovery` (in `ledger.py`, so it is testable without a live fit) owns the state machine `run.py` held inline; `hot_status_to_text` renders it into `<prefix>_modes.txt` **independently of `seed_ledger`** -- states 1 and 3 are exactly the ones that produce no ledger records. `write_rejected_latex` adds a *rendered* caption sentence (not a `%` comment) in states 1 and 3, so a table going into a paper cannot be read as a complete list of alternatives considered.

The catch stays broad and non-fatal (nothing established what it was guarding), but the exception type and message now travel into the report.

## 2.9.3 -- zero-proposal swap pairs

Reproduced: pairs 0 and 2 measured at r = 0.2/0.4, pairs 1 and 3 never proposed -> `r = [0.2, 1.0, 0.4, 1.0]`, total barrier **2.6 against a true 1.2**. Routine cause: DEO alternates even/odd pairs by round and the counters reset every adaptation window.

Unmeasured pairs are filled by **linear interpolation over the pair index** from measured neighbours. On why not simply excluding them: scoring 0 claims *perfect* mixing, collapses those rungs together, and -- because the gap drops out of the total -- silently rescales every other pair's share. Interpolation keeps the total honest and preserves the profile. With a single measured pair every `r_k` equals it, the ladder is already equal-share, and the update is an exact no-op; an all-zero window returns the ladder unchanged. `ladder_health_report`'s separate `max(prop, 1)` is reporting-only and left alone.

## 2.9.4 -- `n_chains = 2` crashed

`_pick_two(rng, 2, 0)` raised numpy's "Cannot take a larger sample than population when replace is False", which never mentions `n_chains`.

**Both, split by who asked.** The *default* `2 * n_params` is floored at `MIN_DE_CHAINS = 4` (new `_common.resolve_n_chains`, now the single owner of the resolve+warn step both samplers ran inline) -- nobody chose 2 there, the formula produced it. An *explicit* `n_chains < 3` **raises**: there is a human to tell, and quietly running a different sampler than the one requested is worse than stopping. 4 rather than 3 because at exactly 3 the two others are forced, so every proposal lies along one direction. `warn_if_population_degenerate` is untouched and still owns the stronger `n_params + 2` advice. Includes an end-to-end test: a 1-parameter model now samples on the default population.

## Verification

**182 tests pass** across `test_polish`, `test_convergence`, `test_hot_chains`, `test_ptde`, `test_ptde_async`, `test_ptde_deo`, `test_multiseed_ptde`, `test_mode_ledger`, `test_whitening`, `test_multiseed_mmexofast`, `test_mode_report`, `test_mode_report_cli`, `test_run_endpoints`, `test_multimode_outputs`, `test_runaway_logp_regression`. With `src/` stashed, **18 of the new tests fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)