### PR TITLE
rvinstrument: plots substituted zero for a pinned gamma (same bug as review 2.6.2)

### DIFF
--- a/src/exozippy/components/rvinstrument/rvinstrument.py
+++ b/src/exozippy/components/rvinstrument/rvinstrument.py
@@ -499,8 +499,24 @@ class RVInstrument(Instrument):
         return out
 
     def _instrument_gamma(self, point, i):
-        """The reference-point gamma for instrument i, in internal units."""
-        gamma_vals = np.atleast_1d(point.get(self.gamma.label, 0.0))
+        """The reference-point gamma for instrument i, in internal units.
+
+        The value comes from the point when it is there, else from the
+        gamma Parameter's own initval -- the same fallback
+        _point_to_plot_params uses for every other plotted parameter.
+
+        A ``point.get(label, 0.0)`` here silently substituted ZERO for any
+        parameter absent from the draws, and pinned (``sigma: 0``)
+        parameters are always absent (an all-fixed vector never becomes a
+        pm.Deterministic, so it is in neither model.deterministics nor the
+        posterior).  A fit with a pinned nonzero offset therefore plotted
+        every point of that instrument shifted by the whole gamma away
+        from the model curve the likelihood actually fit.
+        """
+        vals = point.get(self.gamma.label)
+        if vals is None:
+            vals = self.gamma.initval
+        gamma_vals = np.atleast_1d(vals)
         return gamma_vals[i] if i < len(gamma_vals) else gamma_vals[0]
 
     def _phased_arrays(self, system, point, col, o_idx):

--- a/tests/test_plot_data.py
+++ b/tests/test_plot_data.py
@@ -441,3 +441,135 @@ def test_legacy_plot_still_renders_at_start(rvonly_built, tmp_path):
 
     produced = list(Path(tmp_path).glob("kelt4_start*.pdf"))
     assert len(produced) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Regression: a PINNED gamma must reach the RV plots (not plot as zero)
+# ---------------------------------------------------------------------------
+
+# A large, unmistakable offset: nothing else in the model can produce it, so
+# any leak of the old 0.0 default shows up as the whole instrument sitting
+# _GAMMA_PINNED m/s away from the model curve.
+_PIN = dict(gamma=-12345.0, K=100.0, P=10.0, tc=2450005.0)
+
+
+@pytest.fixture(scope="module")
+def pinned_gamma_rv_system(tmp_path_factory):
+    """One-instrument RV system whose gamma is PINNED (sigma: 0).
+
+    A gamma vector with no free element never becomes a pm.Deterministic,
+    so its label is absent from both model.deterministics and the
+    posterior -- which is exactly the condition the bug needed.
+    """
+    tmp_dir = tmp_path_factory.mktemp("pinned_gamma")
+    path = tmp_dir / "pinned.rv"
+
+    t = np.linspace(2450000.0, 2450100.0, 40)
+    rv = _PIN["gamma"] + _PIN["K"] * np.sin(
+        2 * np.pi * (t - _PIN["tc"]) / _PIN["P"]
+    )
+    np.savetxt(path, np.column_stack([t, rv, np.full_like(t, 5.0)]))
+
+    config = {
+        "run": {"name": "pinned_gamma"},
+        "star": [{"name": "A", "mist": False}],
+        "planet": [{"name": "b"}],
+        "orbit": [{"name": "b", "primary": ["A"], "companion": ["b"]}],
+        "rvinstrument": [{"name": "HIRES", "file": str(path)}],
+    }
+    user_params = {
+        "star.A.mass": {"initval": 1.0, "sigma": 0.05},
+        "star.A.radius": {"initval": 1.0, "sigma": 0.1},
+        "star.A.teff": {"initval": 5800, "sigma": 100},
+        "star.A.feh": {"initval": 0.0, "sigma": 0.1},
+        "orbit.b.period": {"initval": _PIN["P"]},
+        "orbit.b.tc": {"initval": _PIN["tc"]},
+        "rvinstrument.HIRES.gamma": {"initval": _PIN["gamma"], "sigma": 0},
+    }
+
+    system = System(config, user_params=user_params)
+    system.prepare()
+    model = system.build_model()
+    with model:
+        point = system.get_internal_point(model, system.get_raw_start(model))
+    system.compile_plotter_functions(model)
+    return system, model, point, t, rv
+
+
+def test_pinned_gamma_is_absent_from_the_point(pinned_gamma_rv_system):
+    """
+    Given an RV fit whose gamma is pinned with sigma: 0,
+    When the plotting point is built from the model,
+    Then gamma is not in it -- so any plot helper reading the point needs a
+    real fallback, and this fixture genuinely exercises that path.
+    """
+    system, _, point, _, _ = pinned_gamma_rv_system
+
+    label = system.rvinstrument.gamma.label
+
+    assert label not in point
+
+
+def test_unphased_rv_data_uses_the_pinned_gamma(pinned_gamma_rv_system):
+    """
+    Given an RV fit whose gamma is PINNED at a large nonzero value,
+    When plot_data builds the unphased chart,
+    Then the plotted (gamma-subtracted) data carry that pinned offset.
+
+    Regression: _instrument_gamma read the point with
+    point.get(label, 0.0), and a pinned parameter is always absent from the
+    draws, so the whole instrument plotted -12345 m/s away from the model
+    curve while the likelihood used the real offset.
+    """
+    system, _, point, _, rv_ms = pinned_gamma_rv_system
+    comp = system.rvinstrument
+
+    specs = comp.plot_data(system, point)
+    unphased = [s for s in specs if not s.meta["phase_folded"]][0]
+    data_trace = [t for t in unphased.traces if t.role == "data"][0]
+
+    # independent reference: the file's own RVs minus the pinned gamma
+    expected = rv_ms - _PIN["gamma"]
+    np.testing.assert_allclose(data_trace.y, expected, atol=1e-6)
+    # and the offset dominates the signal, so plotting gamma as 0 is not a
+    # rounding-level difference: it is a 123x shift of the whole series
+    assert abs(_PIN["gamma"]) > 100 * np.ptp(expected) / 2.0
+    # the pre-fix value, explicitly excluded
+    assert not np.allclose(data_trace.y, rv_ms, atol=1.0)
+
+
+def test_gamma_helper_returns_the_pinned_value(pinned_gamma_rv_system):
+    """
+    Given the same pinned-gamma fit,
+    When _instrument_gamma is asked for the instrument's offset,
+    Then it returns the pinned value (in internal units), not zero.
+    """
+    system, _, point, _, _ = pinned_gamma_rv_system
+    comp = system.rvinstrument
+
+    g_ms = comp._instrument_gamma(point, 0) * comp._rv_factor()
+
+    assert g_ms == pytest.approx(_PIN["gamma"], rel=1e-9)
+
+
+def test_phased_rv_data_uses_the_pinned_gamma(pinned_gamma_rv_system):
+    """
+    Given the same pinned-gamma fit,
+    When plot_data builds the phased chart for the single orbit,
+    Then its cleaned data are gamma-subtracted with the pinned value too
+    (the phased panel calls the same helper, one orbit -> no other signal).
+    """
+    system, _, point, _, rv_ms = pinned_gamma_rv_system
+    comp = system.rvinstrument
+
+    specs = comp.plot_data(system, point)
+    phased = [s for s in specs if s.meta["phase_folded"]]
+    assert len(phased) == 1
+    data_trace = [t for t in phased[0].traces if t.role == "data"][0]
+
+    expected = rv_ms - _PIN["gamma"]
+    # the phase fold reorders nothing here (traces keep data order), so
+    # compare the sorted values -- the offset is what is under test
+    np.testing.assert_allclose(
+        np.sort(data_trace.y), np.sort(expected), atol=1e-6
+    )


### PR DESCRIPTION
The same `point.get(label, <literal>)` defect PR #101 fixed in `astrometryinstrument.py` (review 2.6.2), in `rvinstrument._instrument_gamma`.

`point.get` returns its default for any parameter **absent from the draws**, and pinned (`sigma: 0`) parameters are absent. Confirmed the mechanism at `parameter.py:958`: `track_node = any(is_sampled) or force_node or links`, so a gamma vector with every element pinned never becomes a `pm.Deterministic` and appears in neither `model.deterministics` nor the posterior.

## Reproduced

One-instrument RV fit, 40 epochs, `K = 100 m/s`, `P = 10 d`, `rvinstrument.HIRES.gamma: {initval: -12345.0, sigma: 0}`:

| | pre-fix | post-fix | truth |
|---|---|---|---|
| `_instrument_gamma(point, 0)` | **0.0** | -12345.0 | -12345.0 |
| plotted unphased data, mean | **-12345.0** | 4.3e-14 | ~0 |
| plotted unphased data, range | **-12445 to -12245** | -100 to +100 | -100 to +100 |
| plotted phased data, mean | **-12345.0** | 4.3e-14 | ~0 |

The RV model trace is gamma-free by construction (gamma is subtracted from the *data* in numpy), so the visible symptom is the instrument's data drawn 12345 m/s away from a model curve oscillating about zero -- an offset **123x the signal's own semi-amplitude**, so the two shared no visible axis at all. Unphased and every phased panel were affected.

## Fix

`_instrument_gamma` now reads `point.get(self.gamma.label)` with **no literal default** and falls back to `self.gamma.initval` when it is `None` -- structurally identical to #101's `_linear_terms` helper and to the fallback `Component._point_to_plot_params` already uses. No third convention.

## Audit of the rest of the file

Three `point.get` calls exist in `rvinstrument.py`; the other two are **safe, and deliberately so**. `_phased_arrays` reads `orbit.period` and `orbit.tc` with **no default**, and both carry `force_node: True` in `Orbit.register_parameters`, so they are unconditional `pm.Deterministic`s. Verified empirically by building the fit three ways (nothing pinned, `orbit.tc` pinned, `orbit.logP` pinned) -- both present in all three. Note `orbit.logP` *does* drop out when pinned, but nothing here reads it; and with no default a future absence would raise a `TypeError` rather than silently plotting a wrong number, so that shape is already correct.

## `transit.py:744` -- same bug, NOT touched (out of scope)

Confirmed and potentially worse. `_baseline_for` does `point.get(self.baseline.label, 1.0)`, and `baseline` is a free parameter, so an all-pinned vector is absent for the same reason. The literal `1.0` looks like a harmless neutral default, but `Transit.load_data` sets `baseline_init[i] = np.median(df.iloc[:, 1].values)` -- **the data's own median flux**. On an un-normalized light curve (raw counts) the pinned baseline is nowhere near 1.0, and both `_eval_unphased_lc` and the phased panels' cleaned flux would be off by the whole flux scale.

Also in that file and **not** the same bug: `transit.py:974` reads `t14` with no default and is explicitly guarded by `if t14_raw is not None`, degrading to "no x-axis zoom". Correct as written.

## Tests

Four appended to `tests/test_plot_data.py` (module-scoped fixture, no example-data dependency):

- `test_pinned_gamma_is_absent_from_the_point` -- the precondition, passing before and after **by design**, so the other three are known to exercise the fallback rather than a point that happens to carry gamma;
- `test_unphased_rv_data_uses_the_pinned_gamma` -- asserts plotted **y values** against an independent reference (the file's RVs minus the pinned gamma), plus that the offset dominates the signal and that the pre-fix array is explicitly excluded;
- `test_gamma_helper_returns_the_pinned_value`;
- `test_phased_rv_data_uses_the_pinned_gamma`.

Pre-fix (src stashed): **3 failed, 1 passed** (the precondition), e.g. `-12444.92 (ACTUAL) vs -99.92 (DESIRED)` across all 40 epochs. Post-fix: `test_plot_data`+`test_rv_model`+`test_rv_integration` **32 passed**; `test_plotrender`+`test_evaluator`+`test_gp` **69 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)