### PR TITLE
transit: plots substituted 1.0 for a pinned baseline (last of the point.get family)

### DIFF
--- a/src/exozippy/components/transit/transit.py
+++ b/src/exozippy/components/transit/transit.py
@@ -740,9 +740,27 @@ class Transit(Instrument):
     # always draw the exact same arrays (see plotspec.PlotSpec).
     # ------------------------------------------------------------------
     def _baseline_for(self, point, i):
-        """Baseline flux for instrument i from a point (default 1.0)."""
-        base_vals = np.atleast_1d(point.get(self.baseline.label, 1.0))
-        return float(base_vals[i])
+        """Baseline flux for instrument i, in internal units.
+
+        The value comes from the point when it is there, else from the
+        baseline Parameter's own initval -- the same fallback
+        _point_to_plot_params uses for every other plotted parameter.
+
+        A ``point.get(label, 1.0)`` here silently substituted UNITY for any
+        parameter absent from the draws, and pinned (``sigma: 0``)
+        parameters are always absent (an all-fixed vector never becomes a
+        pm.Deterministic, so it is in neither model.deterministics nor the
+        posterior).  Unity is not a neutral default: load_data seeds each
+        baseline with the light curve's own median flux, so on an
+        un-normalized light curve (raw counts) a pinned baseline plotted
+        the model curve and the phased panel's cleaned flux off by the
+        entire flux scale.
+        """
+        vals = point.get(self.baseline.label)
+        if vals is None:
+            vals = self.baseline.initval
+        base_vals = np.atleast_1d(vals)
+        return float(base_vals[i] if i < len(base_vals) else base_vals[0])
 
     def _eval_unphased_lc(self, system, point, i):
         """Full model light curve for instrument i: baseline + transit + GP.

--- a/tests/test_plot_data.py
+++ b/tests/test_plot_data.py
@@ -573,3 +573,147 @@ def test_phased_rv_data_uses_the_pinned_gamma(pinned_gamma_rv_system):
     np.testing.assert_allclose(
         np.sort(data_trace.y), np.sort(expected), atol=1e-6
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: a PINNED baseline must reach the transit plots (not plot as 1.0)
+# ---------------------------------------------------------------------------
+
+# An UN-NORMALIZED light curve: raw counts, so the baseline the likelihood
+# uses is nowhere near the old 1.0 default and any leak of it shifts both
+# panels by the entire flux scale.
+_LC = dict(baseline=20000.0, depth=0.01, P=3.0, tc=2459000.0, err=20.0)
+
+
+@pytest.fixture(scope="module")
+def pinned_baseline_transit_system(tmp_path_factory):
+    """One-instrument transit system on raw counts whose baseline is PINNED.
+
+    A baseline vector with no free element never becomes a
+    pm.Deterministic, so its label is absent from both
+    model.deterministics and the posterior -- the condition the bug needed.
+    """
+    tmp_dir = tmp_path_factory.mktemp("pinned_baseline")
+    path = tmp_dir / "pinned.TESS.dat"
+
+    # One transit, sampled densely enough that the median flux is still the
+    # out-of-transit level (so baseline_init is the pinned value too).
+    t = np.linspace(_LC["tc"] - 0.25, _LC["tc"] + 0.25, 200)
+    flux = np.full_like(t, _LC["baseline"])
+    in_transit = np.abs(t - _LC["tc"]) < 0.05
+    flux[in_transit] -= _LC["baseline"] * _LC["depth"]
+    np.savetxt(path, np.column_stack([t, flux, np.full_like(t, _LC["err"])]))
+
+    config = {
+        "run": {"name": "pinned_baseline"},
+        "star": [{"name": "A", "mist": False}],
+        "planet": [{"name": "b"}],
+        "orbit": [{"name": "b", "primary": ["A"], "companion": ["b"]}],
+        "band": [{"name": "TESS", "filter": "TESS"}],
+        "transit": [{"name": "TESS_S48", "file": str(path), "band": "TESS"}],
+    }
+    user_params = {
+        "star.A.radius": {"initval": 1.0, "sigma": 0.05},
+        "star.A.mass": {"initval": 1.0, "sigma": 0.05},
+        "star.A.teff": {"initval": 5800, "sigma": 100},
+        "star.A.feh": {"initval": 0.0, "sigma": 0.08},
+        "orbit.b.period": {"initval": _LC["P"]},
+        "orbit.b.tc": {"initval": _LC["tc"]},
+        "orbit.b.cosi": {"initval": 0.0},
+        "planet.b.radius": {"initval": 1.0},
+        "transit.TESS_S48.baseline": {
+            "initval": _LC["baseline"],
+            "sigma": 0,
+        },
+    }
+
+    system = System(config, user_params=user_params)
+    system.prepare()
+    model = system.build_model()
+    with model:
+        point = system.get_internal_point(model, system.get_raw_start(model))
+    return system, model, point, t, flux
+
+
+def test_pinned_baseline_is_absent_from_the_point(
+    pinned_baseline_transit_system,
+):
+    """
+    Given a transit fit whose baseline is pinned with sigma: 0,
+    When the plotting point is built from the model,
+    Then the baseline is not in it -- so any plot helper reading the point
+    needs a real fallback, and this fixture exercises that path.
+    """
+    system, _, point, _, _ = pinned_baseline_transit_system
+
+    label = system.transit.baseline.label
+
+    assert label not in point
+
+
+def test_baseline_helper_returns_the_pinned_value(
+    pinned_baseline_transit_system,
+):
+    """
+    Given the same pinned-baseline fit,
+    When _baseline_for is asked for the instrument's baseline,
+    Then it returns the pinned raw-count value, not 1.0.
+    """
+    system, _, point, _, _ = pinned_baseline_transit_system
+
+    base = system.transit._baseline_for(point, 0)
+
+    assert base == pytest.approx(_LC["baseline"], rel=1e-9)
+
+
+def test_unphased_transit_model_uses_the_pinned_baseline(
+    pinned_baseline_transit_system,
+):
+    """
+    Given a transit fit on RAW COUNTS whose baseline is PINNED,
+    When plot_data builds the unphased chart,
+    Then the plotted model curve sits at that baseline, not at 1.0.
+
+    Regression: _baseline_for read the point with
+    point.get(label, 1.0), and a pinned parameter is always absent from the
+    draws, so the model curve plotted at unity -- 20000 counts below the
+    data the likelihood actually fit.
+    """
+    system, _, point, _, flux = pinned_baseline_transit_system
+    comp = system.transit
+
+    specs = comp.plot_data(system, point)
+    unphased = [s for s in specs if not s.meta["phase_folded"]][0]
+    model_trace = [t for t in unphased.traces if t.role == "model"][0]
+
+    # out-of-transit the curve is the baseline itself; in transit it dips by
+    # at most the depth, so the whole curve lives within a percent of it
+    assert np.max(model_trace.y) == pytest.approx(_LC["baseline"], rel=1e-9)
+    assert np.min(model_trace.y) > 0.9 * _LC["baseline"]
+    # the pre-fix value, explicitly excluded: the data are 20000x above it
+    assert np.max(model_trace.y) > 0.5 * np.median(flux)
+
+
+def test_phased_transit_data_uses_the_pinned_baseline(
+    pinned_baseline_transit_system,
+):
+    """
+    Given the same pinned-baseline fit,
+    When plot_data builds the phased chart for the single planet,
+    Then the cleaned flux is the data minus that baseline (one planet and
+    no GP, so nothing else is removed) rather than the data minus 1.0.
+    """
+    system, _, point, _, flux = pinned_baseline_transit_system
+    comp = system.transit
+
+    specs = comp.plot_data(system, point)
+    phased = [s for s in specs if s.meta["phase_folded"]]
+    assert len(phased) == 1
+    data_trace = [t for t in phased[0].traces if t.role == "data"][0]
+
+    expected = flux - _LC["baseline"]
+    np.testing.assert_allclose(
+        np.sort(data_trace.y), np.sort(expected), atol=1e-6
+    )
+    # the pre-fix cleaned flux (data - 1.0) is off by the whole flux scale
+    assert not np.allclose(data_trace.y, flux - 1.0, atol=1.0)


### PR DESCRIPTION
The third and final instance of the `point.get(label, <literal>)` defect -- after `astrometryinstrument` (PR #101, review 2.6.2) and `rvinstrument` (PR #107).

`point.get` returns its default for any parameter **absent from the draws**, and pinned (`sigma: 0`) parameters are absent (`parameter.py:958`: `track_node = any(is_sampled) or force_node or links`, so an all-pinned vector never becomes a `pm.Deterministic`).

**The `1.0` default is not neutral, which makes this the worst of the three.** `Transit.load_data` sets `baseline_init[i] = np.median(df.iloc[:, 1].values)` -- the data's own median flux. On an un-normalized light curve a pinned baseline is nowhere near 1.0.

## Reproduced

Synthetic un-normalized light curve: 200 points, out-of-transit level **20000 counts**, 1% dip, with `transit.TESS_S48.baseline: {initval: 20000, sigma: 0}`. The baseline label is confirmed absent from the point, so the fallback path is genuinely exercised.

| quantity | pre-fix | post-fix | truth |
|---|---|---|---|
| `_baseline_for(point, 0)` | 1.0 | 20000.0 | 20000.0 |
| unphased model curve (max) | 1.0 | 20000.0 | 20000.0 |
| phased cleaned flux (in-transit) | 19799.0 | -200.0 | -200.0 |

The phased panel was off by 19999 counts -- max relative difference **99.995**, the entire flux scale.

## Fix

`_baseline_for` reads the point with no default and falls back to `self.baseline.initval`, byte-for-byte the shape of #107's `_instrument_gamma` (including the `i < len(...)` guard, since `Parameter.initval` may be a scalar). The docstring records the mechanism and why `1.0` was not neutral.

## Audit

Three other `point.get` calls remain in `transit.py`, all correct as written:

- **`transit.py:992`** reads `t14` with no default, guarded by `if t14_raw is not None`, degrading to "no x-axis zoom" -- the safe pattern #107 identified, still intact.
- **`transit.py:796/798`** read orbit `period`/`tc` with no default; on absence `float(np.atleast_1d(None)[p_idx])` raises and the caller's `try/except` skips the phased panel with a warning. Loud degradation, not a silent wrong number -- the same shape as `rvinstrument.py:530/532`, which #107 deliberately left alone. Attempting to trigger it (pinning both with `sigma: 0`) failed: `orbit.period` is derived so it is always a Deterministic, and `orbit.tc` survived pinning too. Worth knowing that if it ever does go absent, the symptom is a *missing* phased panel plus a warning, not a mis-plotted one.

## This is the last instance

Grepping `src/exozippy/` for point reads with a literal default returns nothing outside the three now-fixed sites. The remaining accessors are all correct: `component.py:487` and `astrometryinstrument.py:848` use the canonical `point.get(p.label, p.initval)`; `astrometryinstrument.py:899` falls back to `1000/distance` deliberately; `parameter.py:558 get_value` implements the full point -> expression -> initval -> raise chain; `outputs/ledger.py:761` uses a NaN sentinel for a dedup comparison guarded by `np.all(np.isfinite(b))`, not a plot path.

## Tests

Four added to `tests/test_plot_data.py` immediately after the RV set and following its shape: the absent-from-point precondition, the helper's return, the unphased curve, and the phased cleaned flux (compared against an independent `flux - 20000`, with an explicit exclusion of the pre-fix `flux - 1.0`). **3 of 4 fail pre-fix**; the precondition passes by design. `tests/test_plot_data.py`: **19 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)