### PR TITLE
config/mkparam/evidence: in-memory params passthrough, probe state leak, init_scale KeyError, warp docstring (review 3.2, 3.10, 3.11, 3.13)

### DIFF
--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -1743,6 +1743,22 @@ class ConfigManager:
 
         return result
 
+    # Every mutable ConfigManager attribute the relaxation engine writes to.
+    # probe_derivable deep-copies each one before running the engine and puts
+    # the copy back in a finally block, which is what makes a probe genuinely
+    # read-only.  If the engine ever starts writing somewhere new, it belongs
+    # in this tuple -- a mutation missing from it silently survives the probe.
+    _PROBE_SNAPSHOT_ATTRS = (
+        "user_params",  # _execute_solve syncs solved init_scale back
+        "diagnostics",  # _record_diagnostic appends contradictions
+        "propagated_scales",  # refreshed at the end of every solve
+        "symbolic_blacklist",  # a 2 s sp.solve timeout adds the target
+        "_last_provenance",
+        "_last_scale_provenance",
+        "_last_resolved",
+        "_last_solved_by",
+    )
+
     def probe_derivable(self, paths, tolerance=1e-3):
         """Which of `paths` the relaxation engine can pin down from what is
         known now, as opposed to falling back on a bare defaults.yaml value.
@@ -1782,17 +1798,17 @@ class ConfigManager:
             flat[str(sym)] = float(val) * factor
 
         # The engine writes back init_scale into user_params, appends
-        # diagnostics, and refreshes the export snapshots.  None of that may
-        # leak out of a probe.
-        saved = (
-            copy.deepcopy(self.user_params),
-            list(self.diagnostics),
-            dict(self.propagated_scales),
-            dict(self._last_provenance),
-            dict(self._last_scale_provenance),
-            dict(self._last_resolved),
-            dict(self._last_solved_by),
-        )
+        # diagnostics, blacklists any inversion whose sp.solve hits the 2 s
+        # alarm, and refreshes the export snapshots.  None of that may leak
+        # out of a probe -- least of all the blacklist, which is consulted
+        # for the rest of the process: one slow inversion during this
+        # throwaway stage-1a probe would otherwise disable that relation for
+        # the real stage-3 solve, which has different inputs and might well
+        # have solved it in time.
+        saved = {
+            attr: copy.deepcopy(getattr(self, attr))
+            for attr in self._PROBE_SNAPSHOT_ATTRS
+        }
         prev_level = logger.level
         try:
             logger.setLevel(logging.WARNING)
@@ -1805,23 +1821,8 @@ class ConfigManager:
             ranks = {}
         finally:
             logger.setLevel(prev_level)
-            (
-                self.user_params,
-                self.diagnostics,
-                self.propagated_scales,
-                self._last_provenance,
-                self._last_scale_provenance,
-                self._last_resolved,
-                self._last_solved_by,
-            ) = (
-                saved[0],
-                saved[1],
-                saved[2],
-                saved[3],
-                saved[4],
-                saved[5],
-                saved[6],
-            )
+            for attr, value in saved.items():
+                setattr(self, attr, value)
 
         return {p for p in paths if ranks.get(p, 0) > RANK_DEFAULT}
 

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -2629,8 +2629,23 @@ class ConfigManager:
                         resolved_scales[target_str] = new_scale
                         scale_provenance[target_str] = new_scale_rank
 
-                    if target_str in self.user_params and isinstance(
-                        self.user_params[target_str], dict
+                    # Sync the solved scale back into user_params -- but only
+                    # when there IS one.  init_scale is optional at every
+                    # source (defaults.yaml, component hints, user sigmas), so
+                    # a target whose parents are ALL scale-less scores
+                    # new_scale_rank == 0, fails the guard above, and has no
+                    # entry from the default-armor pass either: reading
+                    # resolved_scales[target_str] here used to raise KeyError
+                    # straight out of prepare().  (Reproduced by naming
+                    # `orbit.<name>.arsun` in a params file -- it is solved
+                    # from m_total and period, and none of the three carries
+                    # an init_scale default.)  Skipping leaves the parameter
+                    # with no preliminary scale, which is the documented and
+                    # handled state: build_pymc falls back to a fraction of
+                    # the bound span, and the startup whitening probe measures
+                    # the real scale from the data regardless.
+                    if target_str in resolved_scales and isinstance(
+                        self.user_params.get(target_str), dict
                     ):
                         factor = self.get_conversion_factor(
                             parts[0], parts[-1], full_path=target_str

--- a/src/exozippy/mkparam.py
+++ b/src/exozippy/mkparam.py
@@ -1,5 +1,6 @@
 """mkparam - Seed a params.yaml from the MAP of a previous trace."""
 
+import copy
 import logging
 import re
 from pathlib import Path
@@ -224,7 +225,12 @@ def _sample_seed_draws(idata, n, exclude, rng_seed=0):
 
 
 def mkprior(
-    config, base_dir=None, trace_path=None, output_path=None, n_seeds=None
+    config,
+    base_dir=None,
+    trace_path=None,
+    output_path=None,
+    n_seeds=None,
+    user_params=None,
 ):
     """
     Write a params.yaml seeded from a previous trace.
@@ -253,6 +259,16 @@ def mkprior(
     n_seeds : int, optional
         Number of multi-seed start points to emit. When None, read from
         ``config['mkprior']['n_seeds']`` (default 1 = legacy scalar behavior).
+    user_params : dict, optional
+        The parameter overrides the fit actually ran with, for the in-memory
+        entry point ``run_fit(config, user_params=<dict>)``. When omitted,
+        ``config['parameter_file']`` is read from disk -- which is right for a
+        file-driven run and WRONG for a dict-driven one: the restart file
+        merges the trace MAP into these entries, so priors and bounds would
+        come from whatever stale file happened to sit at that path (or be
+        silently dropped when no such file exists). It is also the fingerprint
+        this function checks the trace against, so the mismatch surfaces as a
+        StaleTraceError rather than a quietly wrong restart file.
 
     Returns
     -------
@@ -282,7 +298,15 @@ def mkprior(
 
     param_file = config.get("parameter_file")
     existing_params = {}
-    if param_file:
+    if user_params is not None:
+        # In-memory run: these ARE the fit's parameter overrides, and the file
+        # at config['parameter_file'] (if any) is not.  Copied so nothing here
+        # can write back into the caller's dict.
+        existing_params = copy.deepcopy(user_params)
+        validate_sigma_has_center(
+            existing_params, source="the in-memory user_params"
+        )
+    elif param_file:
         param_path = base_dir / param_file
         if param_path.exists():
             existing_params = _load_yaml(str(param_path))

--- a/src/exozippy/outputs/evidence.py
+++ b/src/exozippy/outputs/evidence.py
@@ -1,4 +1,11 @@
-"""Per-mode local evidence estimation via warp bridge sampling.
+"""Per-mode local evidence estimation by bridge sampling.
+
+The estimator is the plain Meng & Wong (1996) optimal bridge against a
+Gaussian proposal fitted to the mode's own raw draws.  It is NOT warp bridge
+sampling: no warp transformation of the target is applied anywhere in this
+module (see the note under step 4 for the one place a warp would earn its
+keep).  The module was titled "warp bridge sampling" until 2026-08-11, which
+described an implementation that never existed.
 
 This is the *fallback* multimodal-weighting path in EXOZIPPy.  The primary
 paths (declared-degeneracy jump proposals / folded likelihoods) weight known
@@ -14,10 +21,12 @@ outputs.modes already clusters on):
   1. Membership.  Draws are assigned to modes by the integer ``mode`` label
      that identify_modes attaches to idata.posterior (or by ModeReport.labels).
 
-  2. Proposal.  A normalized multivariate Gaussian (default) or Student-t is
-     fit to the mode's raw draws over the *full* free-RV vector.  Raw space is
-     the non-centered N(0, 1) space, so a Gaussian is a natural, bound-free
-     reference with an analytic normalizing constant.
+  2. Proposal.  A normalized multivariate Gaussian -- the only proposal family
+     implemented -- is fit to the mode's raw draws over the *full* free-RV
+     vector (``_fit_gaussian``, shrunk toward its diagonal and eigenvalue-
+     floored so the density is always proper).  Raw space is the non-centered
+     N(0, 1) space, so a Gaussian is a natural, bound-free reference with an
+     analytic normalizing constant.
 
   3. Bridge estimator (Meng & Wong 1996, optimal bridge).  Using the mode's
      posterior draws and fresh draws from the proposal, the iterative optimal
@@ -31,6 +40,13 @@ outputs.modes already clusters on):
      refused: no number is reported, the reason is logged, and the caller
      falls back to occupancy for the whole report (softmax evidence weights
      need every mode's lnZ, so a single refusal invalidates the set).
+
+     That bound-pileup case is exactly what a warp would fix, and is the
+     obvious next step if refusals prove common: Warp-III (Meng & Schilling
+     2002) symmetrizes the target about its mode by mixing x with 2*mu - x,
+     turning the one-sided tail the Gaussian proposal cannot cover into a
+     symmetric one it can.  Not implemented -- recorded here so the option is
+     not rediscovered from scratch.
 
   5. Weights.  Accepted lnZ_k -> softmax weights w_k; lnZ error bars propagate
      to softmax weight uncertainties dw_k by linearization.
@@ -445,7 +461,10 @@ def estimate_mode_evidences(
     re2_max=DEFAULT_RE2_MAX,
     seed=20260712,
 ):
-    """Estimate each mode's local evidence by warp bridge sampling.
+    """Estimate each mode's local evidence by bridge sampling.
+
+    Meng & Wong (1996) optimal bridge against a Gaussian proposal fitted to
+    each mode's own raw draws; no warp is applied (see the module docstring).
 
     Parameters
     ----------

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -766,9 +766,15 @@ def _run_fit(config, gui, user_params=None):
 
     try:
         # mkprior re-derives the structural fingerprint from this config and
-        # the parameter_file itself; measured to reproduce the System
-        # snapshot exactly (see the note at mkparam.mkprior's check).
-        mkprior(config, trace_path=trace_path)
+        # the params, not from the live System; measured to reproduce the
+        # System snapshot exactly (see the note at mkparam.mkprior's check).
+        # The params half has to be handed over when run_fit was called with
+        # an in-memory dict: the file at config['parameter_file'] is then not
+        # what was fitted (it may be stale, or absent), and mkprior would
+        # merge ITS priors and bounds into the restart file.  Left None for a
+        # file-driven run, so that path still reads the file itself and its
+        # error messages still name it.
+        mkprior(config, trace_path=trace_path, user_params=user_params)
     except Exception:
         logger.exception("mkprior failed (non-fatal)")
 

--- a/tests/test_mkparam.py
+++ b/tests/test_mkparam.py
@@ -1,5 +1,7 @@
 """Tests for mkparam MAP-seeding logic."""
 
+import copy
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -667,3 +669,107 @@ def test_standardize_param_names_flat_dict_component_no_crash(tmp_path):
 
     # The key should pass through unchanged (no list to look up names in)
     assert "sed.0.errscale" in result
+
+
+# ---------------------------------------------------------------------------
+# In-memory user_params (run_fit(config, user_params=<dict>))
+# ---------------------------------------------------------------------------
+
+
+def test_in_memory_user_params_beat_the_file_on_disk(tmp_path):
+    """
+    Given a fit driven by an in-memory user_params dict while a DIFFERENT
+    params file happens to sit at config['parameter_file'],
+    When mkprior is given those in-memory params,
+    Then the restart file carries the priors that were actually fitted and
+    none of the on-disk file's.
+
+    The two differ only in the magnitudes of mu/sigma, which
+    evaluator.structural_hash deliberately does not cover -- so nothing else
+    in the pipeline would have caught the substitution.
+    """
+    import yaml
+
+    stale_on_disk = {"star.Host.teff": {"mu": 4000.0, "sigma": 500.0}}
+    param_file = tmp_path / "star.params.yaml"
+    with open(param_file, "w") as f:
+        yaml.dump(stale_on_disk, f)
+
+    fitted = {"star.Host.teff": {"mu": 5800.0, "sigma": 100.0}}
+
+    trace = _make_idata({"star.teff": 5750.0}, tmpdir=tmp_path)
+    config = {
+        "prefix": "fitresults/model",
+        "parameter_file": "star.params.yaml",
+        "star": [{"name": "Host"}],
+    }
+
+    out = mkprior(
+        config,
+        base_dir=tmp_path,
+        trace_path=trace,
+        output_path=tmp_path / "out.yaml",
+        user_params=fitted,
+    )
+
+    entry = yaml.safe_load(open(out))["star.Host.teff"]
+    assert entry["mu"] == pytest.approx(5800.0), (
+        "prior center must be the one fitted"
+    )
+    assert entry["sigma"] == pytest.approx(100.0)
+    assert entry["initval"] == pytest.approx(5750.0, abs=1e-6)
+
+
+def test_in_memory_user_params_are_not_mutated(tmp_path):
+    """
+    Given an in-memory user_params dict,
+    When mkprior consumes it,
+    Then the caller's dict is untouched -- run_fit hands over the same object
+    the live System was built from.
+    """
+    fitted = {"star.Host.teff": {"mu": 5800.0, "sigma": 100.0}}
+    before = copy.deepcopy(fitted)
+
+    trace = _make_idata({"star.teff": 5750.0}, tmpdir=tmp_path)
+    config = {
+        "prefix": "fitresults/model",
+        "parameter_file": None,
+        "star": [{"name": "Host"}],
+    }
+
+    mkprior(
+        config,
+        base_dir=tmp_path,
+        trace_path=trace,
+        output_path=tmp_path / "out.yaml",
+        user_params=fitted,
+    )
+
+    assert fitted == before
+
+
+def test_in_memory_user_params_still_validated(tmp_path):
+    """
+    Given in-memory params with a centerless Gaussian prior (sigma, no
+    mu/initval),
+    When mkprior consumes them,
+    Then the same fatal check the on-disk path runs fires, naming the source.
+    """
+    trace = _make_idata({"star.mass": 1.0}, tmpdir=tmp_path)
+    config = {
+        "prefix": "fitresults/model",
+        "parameter_file": None,
+        "star": [{"name": "Host"}],
+    }
+
+    with pytest.raises(ValueError) as exc:
+        mkprior(
+            config,
+            base_dir=tmp_path,
+            trace_path=trace,
+            output_path=tmp_path / "out.yaml",
+            user_params={"star.Host.teff": {"sigma": 100.0}},
+        )
+
+    assert "star.Host.teff" in str(exc.value)
+    assert "in-memory" in str(exc.value)

--- a/tests/test_mkprior_in_memory.py
+++ b/tests/test_mkprior_in_memory.py
@@ -1,0 +1,111 @@
+"""End-to-end: run_fit driven by an IN-MEMORY user_params dict must produce a
+restart file built from those params, not from whatever file happens to sit at
+``config['parameter_file']``.
+
+``run_fit(config, user_params=<dict>)`` is a documented entry point (no YAML
+files needed), but mkprior used to re-read the parameter_file from disk to get
+the constraints it merges the trace MAP into.  A dict-driven run therefore
+emitted a restart file carrying priors and bounds that were never part of the
+fit -- and silently, because the two inputs here differ only in the magnitudes
+of mu/sigma, which ``evaluator.structural_hash`` deliberately does not cover,
+so the trace-freshness check cannot see the substitution either.
+
+Marked 'slow': it runs the whole pipeline once (kelt4 RV-only, 1 draw).
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from exozippy.run import run_fit
+
+pytestmark = pytest.mark.slow
+
+EXAMPLE_DIR = Path(__file__).parent.parent / "examples" / "kelt4"
+
+# The value the fit actually ran with, and the decoy that sits on disk at
+# config['parameter_file'].  Same parameter, same structure -- only the prior
+# numbers differ, which is precisely the case nothing else in the pipeline
+# catches.
+FITTED_TEFF = {"initval": 6207.0, "mu": 6207.0, "sigma": 100.0}
+STALE_TEFF = {"initval": 6207.0, "mu": 4000.0, "sigma": 900.0}
+
+
+@pytest.fixture(scope="module")
+def in_memory_result(tmp_path_factory):
+    """Run the kelt4 RV-only example once through run_fit with an in-memory
+    user_params dict, leaving a decoy params file on disk."""
+    work_dir = tmp_path_factory.mktemp("mkprior_mem_work") / "kelt4"
+    out_dir = tmp_path_factory.mktemp("mkprior_mem_out")
+
+    shutil.copytree(
+        EXAMPLE_DIR,
+        work_dir,
+        ignore=shutil.ignore_patterns("fitresults", ".#*", "#*#"),
+    )
+
+    orig_cwd = os.getcwd()
+    os.chdir(work_dir)
+    try:
+        with open("kelt4_rvonly.yaml") as f:
+            config = yaml.safe_load(f)
+
+        user_params = yaml.safe_load(open(config["parameter_file"]))
+        user_params["star.A.teff"] = dict(FITTED_TEFF)
+        user_params.pop("star.0.teff", None)
+
+        # The decoy: same file the config still points at, different priors.
+        stale = dict(user_params)
+        stale["star.A.teff"] = dict(STALE_TEFF)
+        with open(config["parameter_file"], "w") as f:
+            yaml.dump(stale, f)
+
+        config["prefix"] = str(out_dir / "KELT-4A")
+        config["sampler"] = {
+            "method": "nuts",
+            "tune": 2,
+            "draws": 1,
+            "chains": 1,
+            "cores": 1,
+            "measure_scales": False,
+            "recompute_trace": True,
+        }
+
+        run_fit(config, user_params=user_params)
+    finally:
+        os.chdir(orig_cwd)
+
+    return out_dir, work_dir
+
+
+def test_restart_file_is_written_for_an_in_memory_run(in_memory_result):
+    """
+    Given run_fit called with an in-memory user_params dict,
+    When the run completes,
+    Then mkprior still writes the next versioned restart file.
+    """
+    _, work_dir = in_memory_result
+    assert (work_dir / "kelt4.params.2.yaml").exists(), (
+        "mkprior wrote nothing; yaml files present: "
+        f"{[f.name for f in work_dir.glob('*.yaml')]}"
+    )
+
+
+def test_restart_file_carries_the_in_memory_priors(in_memory_result):
+    """
+    Given a decoy params file on disk whose priors differ from the in-memory
+    dict the fit ran with,
+    When run_fit completes and mkprior writes the restart file,
+    Then the restart file carries the FITTED prior, not the decoy's.
+    """
+    _, work_dir = in_memory_result
+    result = yaml.safe_load(open(work_dir / "kelt4.params.2.yaml"))
+
+    entry = result["star.A.teff"]
+    assert entry["mu"] == pytest.approx(FITTED_TEFF["mu"])
+    assert entry["sigma"] == pytest.approx(FITTED_TEFF["sigma"])
+    assert entry["mu"] != pytest.approx(STALE_TEFF["mu"])
+    assert entry["sigma"] != pytest.approx(STALE_TEFF["sigma"])

--- a/tests/test_mmexofast_support.py
+++ b/tests/test_mmexofast_support.py
@@ -217,12 +217,51 @@ def test_probe_derivable_leaves_no_trace():
         list(cm.diagnostics),
         dict(cm._last_resolved),
     )
+    # Every attribute the engine is declared to write, not just the three
+    # spelled out above: "rolls every mutation back" is the contract, so the
+    # sweep is what actually pins it.
+    all_before = {
+        attr: copy.deepcopy(getattr(cm, attr))
+        for attr in cm._PROBE_SNAPSHOT_ATTRS
+    }
 
     cm.probe_derivable(["lens.0.t_E"])
 
     assert cm.user_params == before[0]
     assert cm.diagnostics == before[1]
     assert cm._last_resolved == before[2]
+    for attr, value in all_before.items():
+        assert getattr(cm, attr) == value, f"probe leaked {attr}"
+
+
+def test_probe_derivable_rolls_back_a_solver_timeout_blacklist(monkeypatch):
+    """
+    Given every sympy inversion times out while the derivability probe runs,
+    When probe_derivable returns,
+    Then symbolic_blacklist is unchanged.
+
+    The blacklist is consulted for the rest of the process, so a 2 s timeout
+    inside this throwaway stage-1a probe would otherwise permanently disable
+    that inversion for the real stage-3 solve -- which runs against different
+    inputs and might well have solved it in time.
+    """
+    import exozippy.config as cfgmod
+
+    def _always_times_out(*args, **kwargs):
+        raise TimeoutError("Symbolic solver timed out!")
+
+    cm = _cm(_full_pspl_params(), _BINARY_CONFIG)
+    monkeypatch.setattr(cfgmod.sp, "solve", _always_times_out)
+
+    cm.probe_derivable(["lens.0.t_E"])
+
+    assert cm.symbolic_blacklist == set()
+
+    # The blacklisting itself still works; it is only the probe that must not
+    # keep it.  This also proves the timeout path was reached at all, so the
+    # assertion above cannot pass vacuously.
+    cm.resolve_and_validate_parameters({})
+    assert cm.symbolic_blacklist
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mode_evidence.py
+++ b/tests/test_mode_evidence.py
@@ -1,6 +1,7 @@
 """
-Tests for per-mode local evidence estimation via warp bridge sampling
-(outputs/evidence.py).
+Tests for per-mode local evidence estimation by bridge sampling
+(outputs/evidence.py) -- the plain Meng & Wong optimal bridge against a fitted
+Gaussian proposal; no warp is involved.
 
 The bridge estimator returns each mode's local log-evidence relative to a
 Gaussian proposal fit in raw (unconstrained) space; softmax of the lnZ values

--- a/tests/test_scale_propagation.py
+++ b/tests/test_scale_propagation.py
@@ -105,3 +105,54 @@ def test_user_sigma_still_seeds_the_scale():
     assert cm.propagated_scales.get("star.0.logmass") == pytest.approx(
         0.02, rel=0.01
     )
+
+
+# ---------------------------------------------------------------------------
+# The scale sync back into user_params when there is no scale to sync
+# ---------------------------------------------------------------------------
+
+# star + planet + orbit is the smallest topology carrying Kepler's third law,
+# arsun**3 = C * m_total * period**2.  None of arsun, m_total or period has an
+# init_scale in defaults.yaml -- init_scale is optional -- so the forward
+# Jacobian pass scores the solved arsun scale at rank 0, which loses to arsun's
+# own (absent) rank-0 scale and is therefore never stored.  Naming arsun in a
+# params file then used to send the sync step reading a key that was never
+# written: KeyError straight out of prepare().
+_ORBIT_CONFIG = {
+    "star": [{"name": "A"}],
+    "planet": [{"name": "b"}],
+    "orbit": [{"name": "b", "primary": ["A"], "companion": ["b"]}],
+}
+
+
+def test_scaleless_solved_target_does_not_crash_the_engine():
+    """
+    Given a params entry on a derived parameter (orbit arsun) whose relation
+    parents carry no init_scale from any source,
+    When the relaxation engine solves it (stage 3 of prepare),
+    Then the solve completes and the entry simply gets no init_scale.
+
+    The user period entry is load-bearing: an initval with no sigma pins the
+    VALUE at RANK_USER while leaving period scale-less, which is what drives
+    the propagated scale rank to zero.
+    """
+    # Arrange
+    cm = ConfigManager(
+        {
+            "orbit.b.period": {"initval": 2.9895933},
+            "orbit.b.arsun": {"lower": 0.0, "upper": 1000.0},
+        },
+        system_config=_ORBIT_CONFIG,
+    )
+
+    # Act
+    cm.finalize_user_params()
+
+    # Assert: the solve ran and arsun got a start value ...
+    entry = cm.user_params["orbit.0.arsun"]
+    assert entry["initval"] is not None
+    # ... but no preliminary scale, which is the handled state: build_pymc
+    # falls back to a fraction of the bound span and the whitening probe
+    # measures the real scale from the data.
+    assert "init_scale" not in entry
+    assert cm.propagated_scales.get("orbit.0.arsun") is None


### PR DESCRIPTION
Four items from section 3, one commit each.

## 3.2 -- mkprior ignored in-memory user_params

`mkprior` read `config["parameter_file"]` from disk unconditionally, so a run driven by `run_fit(config, user_params=<dict>)` merged the trace MAP into whatever file happened to sit at that path.

It is silent because the one guard here cannot catch it: the structural fingerprint mkprior checks the trace against is computed from the *same* wrong params, and `evaluator._param_structure` deliberately omits numeric mu/sigma magnitudes -- exactly what a params file differs by.

Verified end to end with a decoy `kelt4.params.yaml` differing only in `mu`/`sigma`: pre-fix the restart file carries `mu=4000, sigma=900` instead of the fitted `6207/100`.

`mkprior(..., user_params=None)`: when given, those entries are both the constraint source and the fingerprint input, deep-copied on entry and run through the same `validate_sigma_has_center` check. `run.py` passes `_run_fit`'s own `user_params`, so a file-driven run stays `None` and that path is byte-identical, error messages naming the file included. Other callers checked: `scripts/mkprior.py` is a config-path CLI with no in-memory params; `cli.py` calls `run_fit(config)` only.

## 3.10 -- probe_derivable leaked the symbolic blacklist

`probe_derivable` is documented as running the engine on a snapshot and rolling **every** mutation back. With every `sp.solve` forced to raise `TimeoutError`, a probe on `examples/ob140939` left **13** entries in `symbolic_blacklist` (`lens.0.pi_rel`, `lens.0.mu_ra_rel`/`mu_dec_rel`, `lens.0.alpha`, `star.N.mass`/`parallax`/`logg`/`luminosity`, ...) -- permanently disabling those inversions for the real stage-3 solve.

The save/restore is now driven by a `_PROBE_SNAPSHOT_ATTRS` tuple naming every mutable attribute the engine writes, deep-copied in and `setattr` back in the `finally`.

**Does it leak anything else? No -- answered empirically rather than by inspection.** The whole `ConfigManager.__dict__` was diffed across a probe (deepcopy-compare of every dict/set/list, identity check on the rest), both with forced timeouts and without. `symbolic_blacklist` was the only attribute that changed; `master_symbol_map`, `all_relations`, `hints`, `scale_hints`, `links`, `dependencies`, `custom_solvers` and the `seed_*` attributes were untouched. The static read agrees -- the engine's only other writes are the seven attributes already saved.

The existing `test_probe_derivable_leaves_no_trace` now sweeps every declared attribute instead of three hand-picked ones, so the docstring's claim is enforced rather than merely repaired for one case.

## 3.11 -- init_scale sync could KeyError out of prepare()

In `_execute_solve` the write-back sits *outside* the guard that populates `resolved_scales`. When every relation parent is scale-less, `new_scale_rank == 0` fails the `> scale_provenance.get(target, 0)` test, nothing is stored, and the read raises.

**A real trigger exists in a shipped example**, found by instrumenting the site and scanning: naming `orbit.<name>.arsun` in a params file next to a plain `orbit.<name>.period` initval. `arsun` comes from Kepler's third law and none of `arsun`/`m_total`/`period` carries an `init_scale` default, so `prepare()` dies with `KeyError: 'orbit.0.arsun'` on the kelt4 RV-only example plus that one entry.

Guarded on `target_str in resolved_scales`. Chosen over moving the block inside the rank test so that the case where a higher-ranked scale already exists still syncs exactly as before. Skipping leaves no preliminary scale, which is what CLAUDE.md documents as fine: `build_pymc` falls back to a fraction of the bound span and the whitening probe measures the real scale from the data. The sibling pass in `_solve_and_update` needs no change -- its sync is already inside the branch that writes the scale.

## 3.13 -- "warp bridge sampling" implements no warp

Documentation only, no test, since nothing behavioural changed. The module implements the plain Meng & Wong (1996) optimal bridge against a Gaussian fitted to each mode's raw draws.

**A second false claim turned up in the same paragraph**: "a normalized multivariate Gaussian (default) or Student-t" -- there is no Student-t path (`_fit_gaussian`/`_mvn_logpdf`/`_sample_gaussian` are the only proposal code). Both corrected; PR #88's accurate passages left alone. Warp-III is recorded under the refusal step as the thing that would rescue the bound-pileup case, explicitly marked not implemented. `tests/test_mode_evidence.py`'s header updated to match.

## Tests

`tests/test_mkprior_in_memory.py` (new, slow -- a real `run_fit` on kelt4 RV-only), three unit tests in `test_mkparam.py` (file-beaten, caller dict not mutated, validation still fires), a forced-timeout probe test in `test_mmexofast_support.py`, and `test_scaleless_solved_target_does_not_crash_the_engine` in `test_scale_propagation.py`.

Post-fix: `test_mmexofast_support` + `test_scale_propagation` + `test_mkparam` + `test_mode_evidence` -> 70 passed; `test_mkprior_multiseed` + `test_trace_staleness` + `test_mode_evidence` -> 55 passed; `test_mkprior_in_memory` -> 2 passed. Pre-fix (src stashed): the 6 fast new/strengthened tests all fail, and the end-to-end prior-content test fails. No existing assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
