### PR TITLE
star: replace the implicit uniform-in-distance prior with a d^2 volume prior, deferring to galacticmodel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,25 @@ Planet-as-lens was **not** implemented, deliberately. A planet body has no `dist
 
 Tests: `tests/test_galactic_model.py`, `tests/test_ffp_mass_function.py`.
 
+### The stellar distance prior (`components/star/star.py`)
+
+`star.distance` carries finite `lower`/`upper` (1 mpc to 100 kpc) and no sigma, so `parameter.py`'s logit transform gave it a **uniform-in-distance** prior -- a default that fell out of the machinery, not a choice anyone made. `Star.build_likelihood` now adds the constant-space-density (volume) prior instead: `+2*log(d)`, normalized over the parameter's own hard support (`log Z = log((upper^3 - lower^3)/3)`), i.e. `p(d) ~ d^2`, `p(plx) ~ plx^-4`. Uniform-in-d is `p(plx) ~ plx^-2`; the two disagree by exactly `d^2`, negligible for a well-measured parallax and dominant below `plx/sigma ~ 10` (the Lutz-Kelker regime). One or the other always applies -- there is no config key, because there is a right answer.
+
+**Where a `galacticmodel` block exists the star component stands down entirely.** Its `kinematic_prior` already carries `volume_element = 2*log(d)`, and it applies to `system.star.distance.value` -- the **whole** vector, one `pt.sum`, no mask, lens and source and every other star alike -- so the two coverage sets are identical and a second copy would make the prior `d^4`. A galactic model is also strictly stronger than constant space density (real disk/bulge profiles along the actual sight line), so where one exists it wins outright. If galacticmodel's coverage ever narrows to a subset, star must cover the **complement** rather than stand down; `tests/test_distance_volume_prior.py` pins the coverage claim so that change cannot pass silently. Topology detection is `Star._galactic_imf` (component attr, then raw config), the same helper the Salpeter floor uses.
+
+Details worth not rediscovering:
+
+- **Normalized, deliberately**, even though the choice here is topology-driven rather than user-selected and so does not need PR #82/#86's "make two user-selectable IMFs comparable" argument. Three other reasons do: the prior it replaces *is* a normalized density (the logit reparameterization implies exactly `U(lower, upper)`), so dropping the constant would quietly demote `star.distance`'s prior to an unnormalized reweighting; the bounds are user-settable even though the prior is not, and today tightening `upper:` moves logp by exactly the `-log(span)` it is worth rather than by an arbitrary offset; and it is one closed-form constant with no gradient and no runtime cost. A **dynamic (linked)** `lower`/`upper` is normalized over the STATIC bounds and warns -- `build_pymc` re-maps that element's real support, so the constant does not normalize it.
+- The term covers **every** element, pinned and hard-linked ones included, exactly as the galacticmodel priors do. For a pinned element it is a constant and cannot move a posterior.
+- It applies **on top of** a user's Gaussian `sigma` on distance, and that is right: such an entry is a parallax *measurement*, and multiplying it by the volume prior is the standard treatment. The shift is `~2*(sigma/d)^2` in fractional distance -- 2e-4 for a 1% parallax, 18% for a 30% one, i.e. it only bites exactly where the volume prior is what you want.
+- **Nothing else carries a distance Jacobian or volume term.** SED (`calc_appmag`'s distance modulus), mann (`calc_absmag`), and astrometry (parallax scaling) use distance only in forward models; `lens.event_rate_prior`'s `log(mu_rel * theta_E)` is a rate *selection* factor, not a volume element, and it is applied whether or not a galacticmodel exists.
+- Reading a Parameter's hard support has one owner, `parameter.sampled_bounds` (galacticmodel's IMF normalizers call it too). Unreadable/non-finite bounds fall back to unnormalized with a warning rather than failing a fit.
+- Like `star.logmass` under the IMF, the LaTeX prior macro still reports `star.distance` as Uniform: a component-level `pm.Potential` is invisible to `Parameter`'s own prior description. Pre-existing behavior, not introduced here.
+
+Every pinned logp for a topology with a star and no galacticmodel moves by exactly `2*sum(log d) - n_star*log Z` (`log Z = 33.44017` at the defaults.yaml bounds, so `-28.835` nats per star at the 10 pc default start). `tests/test_runaway_logp_regression.py` has a galacticmodel and is therefore the unchanged control.
+
+Tests: `tests/test_distance_volume_prior.py`.
+
 ### Gaussian-process noise (`components/gp.py`)
 
 Optional, per data file, off by default. A file gets correlated noise by naming a celerite2 kernel on its config entry — `gp: rotation` (`RotationTerm`, spot modulation), `gp: sho` (`SHOTerm`, granulation/generic red noise), or `gp: [rotation, sho]` for their sum. Absent or `gp: none` keeps the independent-Gaussian likelihood, byte for byte.

--- a/src/exozippy/components/galacticmodel/galacticmodel.py
+++ b/src/exozippy/components/galacticmodel/galacticmodel.py
@@ -6,6 +6,11 @@ import pytensor.tensor as pt
 from scipy.special import erf, erfc
 
 from exozippy.components.component import Component
+
+# One owner for "read a Parameter's hard support" -- star.py's volume prior
+# normalizes over star.distance's bounds exactly the way the IMF branches
+# below normalize over star.logmass's.
+from exozippy.components.parameter import sampled_bounds as _sampled_bounds
 from exozippy.constants import (
     BULGE_BAR_ANGLE,
     BULGE_CENTRAL_NUMBER_DENSITY,
@@ -66,30 +71,11 @@ logger = logging.getLogger(__name__)
 # mulensing/lens.py use exactly the code this likelihood uses.
 from .physics import (  # noqa: E402
     GALACTOCENTRIC_FRAME,
-    galactic_xyz as _galactic_xyz_np,
     line_of_sight_basis,
 )
-
-
-def _sampled_bounds(param):
-    """(lower, upper) of a Parameter's hard support as float arrays.
-
-    Returns None when the bounds are missing, non-finite, or symbolic, which
-    the IMF normalizers treat as "leave this prior unnormalized" -- a
-    constant offset never changes the sampling, so a bound the component
-    cannot read is not worth failing a fit over.
-    """
-    try:
-        # atleast_1d: a scalar bound must still broadcast against the
-        # (n_star,) logmass vector, and np.select wants real arrays.
-        lower = np.atleast_1d(np.asarray(param.lower, dtype=float))
-        upper = np.atleast_1d(np.asarray(param.upper, dtype=float))
-    except (AttributeError, TypeError, ValueError):
-        return None
-
-    if not (np.all(np.isfinite(lower)) and np.all(np.isfinite(upper))):
-        return None
-    return lower, upper
+from .physics import (  # noqa: E402
+    galactic_xyz as _galactic_xyz_np,
+)
 
 
 def _unnormalized_warning():

--- a/src/exozippy/components/parameter.py
+++ b/src/exozippy/components/parameter.py
@@ -207,6 +207,34 @@ def to_vec(val, n_elements, fill=np.nan):
     return res
 
 
+def sampled_bounds(param):
+    """(lower, upper) of a Parameter's hard support as float arrays.
+
+    Returns ``None`` when the bounds are missing, non-finite, or symbolic.
+    Every caller so far is a prior NORMALIZER (the galacticmodel IMF
+    branches, ``star``'s volume prior), and all of them treat ``None`` as
+    "leave this prior unnormalized" -- a constant offset never changes the
+    sampling, so a bound the component cannot read is not worth failing a
+    fit over.
+
+    NOTE this reads the STATIC bounds.  An element carrying a dynamic
+    (linked) ``lower``/``upper`` -- ``element_links`` -- has its real
+    support re-mapped inside ``build_pymc``; callers that care must check
+    ``param.element_links`` themselves.
+    """
+    try:
+        # atleast_1d: a scalar bound must still broadcast against the
+        # (n_elements,) sampled vector, and np.select wants real arrays.
+        lower = np.atleast_1d(np.asarray(param.lower, dtype=float))
+        upper = np.atleast_1d(np.asarray(param.upper, dtype=float))
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+    if not (np.all(np.isfinite(lower)) and np.all(np.isfinite(upper))):
+        return None
+    return lower, upper
+
+
 class UnitTranslator:
     # Essential "Pretty" Mapping
     SOLAR_DENSITY_UNIT = u.def_unit(

--- a/src/exozippy/components/star/star.py
+++ b/src/exozippy/components/star/star.py
@@ -1,8 +1,11 @@
 import logging
 
 import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
 
 from exozippy.components.component import Component
+from exozippy.components.parameter import sampled_bounds
 from exozippy.constants import (
     FFP_MASS_FUNCTION_MIN_MEARTH,
     FFP_MASS_FUNCTION_SLOPE,
@@ -658,6 +661,138 @@ class Star(Component):
             _pin_sigma("ra", abs_astrom_idx)
             _pin_sigma("dec", abs_astrom_idx)
 
+    # Floor inside the volume prior's log, in pc.  The same clip
+    # galacticmodel applies before its own volume element
+    # (``pt.maximum(stars.distance.value, 1e-3)``), and equal to
+    # defaults.yaml's lower bound on star.distance, so it is inert for any
+    # ordinary fit: the logit transform already keeps a sampled element
+    # strictly inside its bounds.  It only matters if a hard link ever
+    # drives an element to zero, where a bare log(0) would be a -inf wall
+    # with no gradient for the sampler to follow.
+    DISTANCE_FLOOR_PC = 1.0e-3
+
+    def _volume_prior_log_norm(self):
+        """log Z of p(d) ~ d^2 over star.distance's hard support.
+
+        Z = int_lower^upper d^2 dd = (upper^3 - lower^3) / 3, per element,
+        which is finite (and positive) for any finite bounds.  Evaluated as
+        ``3 log(upper) + log1p(-(lower/upper)^3) - log 3`` so the cube never
+        has to be formed at the far end of a wide support.
+
+        WHY NORMALIZE, when the galacticmodel-or-not choice is topology-
+        driven rather than user-selected (so the PR #82/#86 argument -- make
+        two user-selectable IMFs comparable -- does not apply)?  Three
+        reasons, none of which is comparability across topologies:
+
+        1. The prior this REPLACES is normalized.  A bounded, no-sigma
+           element's logit reparameterization gives exactly U(lower, upper),
+           an honest density integrating to 1 (see parameter.py section 5b's
+           note on why no extra -log(span) belongs there).  Dropping the
+           normalizer here would quietly demote star.distance's prior from a
+           density to an unnormalized reweighting -- a regression in a
+           property the code currently has.
+        2. The bounds ARE user-settable even though the prior choice is not.
+           Today, tightening `star.distance: {upper: ...}` moves logp by
+           exactly the -log(span) that the tightening is worth; unnormalized,
+           it would move it by an arbitrary offset instead.
+        3. It is one closed-form constant with no runtime cost and no
+           gradient.
+
+        Returns 0.0 (unnormalized, with a warning) when the bounds cannot be
+        read as finite floats, matching the IMF normalizers: a constant can
+        never change the sampling, so it is not worth failing a fit over.
+        """
+        bounds = sampled_bounds(self.distance)
+        if bounds is None:
+            logger.warning(
+                f"[{self.prefix}] Cannot read finite bounds on "
+                f"{self.prefix}.distance; the d^2 volume prior is left "
+                f"unnormalized (harmless for sampling, but its logp is "
+                f"offset by an unknown constant)."
+            )
+            return 0.0
+        lower, upper = bounds
+
+        # Bounds may only be tightened and defaults.yaml's are (1e-3, 1e5)
+        # pc, so this is belt and braces.
+        bad = (upper <= 0.0) | (lower < 0.0) | (upper <= lower)
+        if np.any(bad):
+            logger.warning(
+                f"[{self.prefix}] Non-positive or inverted bounds on "
+                f"{self.prefix}.distance; the d^2 volume prior is left "
+                f"unnormalized."
+            )
+            return 0.0
+
+        # A dynamic (linked) bound is re-mapped inside build_pymc, so the
+        # static bounds read above are not that element's real support and
+        # this constant does not normalize it.  Say so rather than pretend.
+        links = getattr(self.distance, "element_links", None) or {}
+        if links.get("lower") or links.get("upper"):
+            logger.warning(
+                f"[{self.prefix}] {self.prefix}.distance carries a linked "
+                f"lower/upper bound, so its support is dynamic; the d^2 "
+                f"volume prior is normalized over the STATIC bounds and is "
+                f"therefore an unnormalized reweighting inside the dynamic "
+                f"interval."
+            )
+
+        return (
+            3.0 * np.log(upper)
+            + np.log1p(-((lower / upper) ** 3))
+            - np.log(3.0)
+        )
+
     def build_likelihood(self, model, system):
-        # Explicit pass-through!
-        pass
+        """Stage 6: the constant-space-density (volume) prior on distance.
+
+        A bounded element with no sigma is sampled UNIFORM in its own
+        coordinate -- parameter.py's logit transform implies exactly
+        U(lower, upper) -- so ``star.distance`` defaulted to uniform in d
+        over defaults.yaml's [1e-3, 1e5] pc.  Nobody chose that: it is what
+        fell out of the default machinery.  Transformed, it is
+        p(plx) ~ plx^-2, whereas an object drawn from a locally constant
+        space density gives p(d) ~ d^2, i.e. p(plx) ~ plx^-4 -- the volume
+        of the shell it could have come from.  The two disagree by exactly
+        d^2, which is negligible for a well-measured parallax and dominant
+        for a poor one (plx/sigma below ~10), the Lutz-Kelker regime.
+
+        DEFER TO galacticmodel WHERE ONE EXISTS.  Its ``kinematic_prior``
+        already carries ``volume_element = 2*log(d)`` over the SAME full
+        ``star.distance`` vector this covers -- it reads ``system.star`` and
+        sums with no mask, lens and source and every other star alike -- so
+        adding a second copy would apply d^4.  A galactic model is also a
+        strictly stronger statement than constant space density (it has the
+        disk/bulge density profiles along the actual sight line), so where
+        one exists it wins outright and this term stays out of the way.
+
+        The term applies to every element of the vector, including pinned
+        and hard-linked ones, exactly as the galacticmodel priors do.  For a
+        pinned element it is a constant and cannot change the posterior.
+
+        Note this applies on top of a user's Gaussian ``sigma`` on distance,
+        and that is deliberate: such a constraint is a parallax MEASUREMENT,
+        and multiplying it by the volume prior is the standard treatment.
+        The shift is ~2*(sigma/d)^2 in fractional distance -- 2e-4 for a
+        1% parallax, 18% for a 30% one, which is precisely the regime where
+        the volume prior is the correct thing to do.
+        """
+        if "distance" not in self.manifest:
+            # No distance parameter in this topology at all (no sed, mann,
+            # lens, galacticmodel or astrometry) -- nothing to weight.
+            return
+
+        has_galacticmodel, _ = self._galactic_imf(system)
+        if has_galacticmodel:
+            logger.debug(
+                f"[{self.prefix}] galacticmodel present -- deferring the "
+                f"distance prior to its density/kinematic mixture, which "
+                f"already carries the d^2 volume element."
+            )
+            return
+
+        distance = pt.maximum(self.distance.value, self.DISTANCE_FLOOR_PC)
+        pm.Potential(
+            f"{self.prefix}.volume_prior",
+            pt.sum(2.0 * pt.log(distance) - self._volume_prior_log_norm()),
+        )

--- a/tests/test_distance_volume_prior.py
+++ b/tests/test_distance_volume_prior.py
@@ -1,0 +1,305 @@
+"""Tests for the constant-space-density (volume) prior on star.distance.
+
+``star.distance`` is declared with finite ``lower``/``upper`` and no sigma, so
+parameter.py's logit transform gives it a UNIFORM-in-distance prior -- a
+default nobody chose, and one that implies p(plx) ~ plx^-2.  ``Star.build_
+likelihood`` now adds ``2*log(d)`` (normalized) so the prior is p(d) ~ d^2,
+the volume of the shell the object could have come from.
+
+Where a ``galacticmodel`` block exists it already carries exactly that term
+(``volume_element`` inside its ``kinematic_prior``, over the same full
+``star.distance`` vector), so the star component defers entirely and no
+second copy is applied.
+"""
+
+import types
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import pytest
+
+from exozippy.components.star.star import Star
+from exozippy.config import ConfigManager
+
+# star/defaults.yaml hard bounds on distance (pc).  They are the support the
+# volume prior normalizes over.
+_D_LOWER = 0.001
+_D_UPPER = 100000.0
+
+
+def _build_star(config=None, params=("distance",), user_params=None):
+    """Build Star parameters through the full config -> model pipeline.
+
+    Returns (star, model, system) with ``system`` a stub carrying only the
+    topology dict ``_galactic_imf`` consults.
+    """
+    config = config or {"star": [{"name": "A"}]}
+    cm = ConfigManager(dict(user_params or {}), system_config=config)
+    cm.finalize_user_params()
+
+    star = Star(config["star"], cm)
+    star.manifest = {p: None for p in params}
+
+    with pm.Model() as model:
+        for p in params:
+            star.add_parameter(model, p, system=None)
+
+    return star, model, types.SimpleNamespace(config=config)
+
+
+def _expected_log_norm(lower=_D_LOWER, upper=_D_UPPER):
+    """log int_lower^upper d^2 dd, written the obvious way."""
+    return float(np.log((upper**3 - lower**3) / 3.0))
+
+
+def _logp_at(model, point):
+    return float(model.compile_logp()(point))
+
+
+def _eval(model, tensor, point):
+    import pytensor
+
+    fn = pytensor.function(model.free_RVs, tensor, on_unused_input="ignore")
+    return np.asarray(fn(*[point[rv.name] for rv in model.free_RVs]))
+
+
+def _potential_names(model):
+    return [p.name for p in model.potentials]
+
+
+# ----------------------------------------------------------------------
+# The prior itself
+# ----------------------------------------------------------------------
+
+
+def test_volume_prior_adds_exactly_two_log_d_minus_the_normalizer():
+    """
+    Given a star with a distance and no galacticmodel,
+    When the star's likelihood is built,
+    Then the model logp gains exactly 2*log(d) - log(Z) relative to the old
+      uniform-in-distance behaviour, at every raw point.
+
+    The assertion is the ANALYTIC difference, not "a number changed": the
+    baseline model is the same graph with build_likelihood skipped, which is
+    byte-for-byte the pre-fix model.
+    """
+    # ARRANGE: the same parameter built twice, once with the new potential
+    base_star, base_model, _ = _build_star()
+    star, model, system = _build_star()
+    with model:
+        star.build_likelihood(model, system)
+
+    log_z = _expected_log_norm()
+
+    # ACT / ASSERT at several raw points (the term is d-dependent, so one
+    # point could not distinguish it from a constant offset).
+    for raw in (-2.0, 0.0, 1.5):
+        point = base_model.initial_point()
+        point["star.distance_raw"] = np.array([raw])
+        d = float(_eval(base_model, base_star.distance.value, point)[0])
+
+        delta = _logp_at(model, point) - _logp_at(base_model, point)
+        assert delta == pytest.approx(2.0 * np.log(d) - log_z, rel=1e-12)
+
+
+def test_volume_prior_covers_every_star():
+    """
+    Given two stars and no galacticmodel,
+    When the star's likelihood is built,
+    Then the added term is the SUM over both distances -- galacticmodel's
+      volume element is a plain pt.sum over the whole vector too, so the
+      replacement has to cover the same set.
+    """
+    # ARRANGE
+    config = {"star": [{"name": "A"}, {"name": "B"}]}
+    base_star, base_model, _ = _build_star(config=config)
+    star, model, system = _build_star(config=config)
+    with model:
+        star.build_likelihood(model, system)
+
+    point = base_model.initial_point()
+    point["star.distance_raw"] = np.array([-1.0, 2.0])
+    d = _eval(base_model, base_star.distance.value, point)
+    assert d.shape == (2,)
+
+    # ACT
+    delta = _logp_at(model, point) - _logp_at(base_model, point)
+
+    # ASSERT
+    expected = np.sum(2.0 * np.log(d)) - 2.0 * _expected_log_norm()
+    assert delta == pytest.approx(expected, rel=1e-12)
+
+
+def test_volume_prior_is_a_normalized_density_over_the_support():
+    """
+    Given star.distance's hard support [1e-3, 1e5] pc,
+    When exp(2*log d - log Z) is integrated over it,
+    Then it integrates to 1 -- the term is a proper prior density, exactly
+      as the uniform prior it replaces was.
+    """
+    # ARRANGE
+    star, model, system = _build_star()
+    with model:
+        star.build_likelihood(model, system)
+
+    log_z = star._volume_prior_log_norm()
+    assert float(np.atleast_1d(log_z)[0]) == pytest.approx(
+        _expected_log_norm(), rel=1e-12
+    )
+
+    # ACT: a d^2 integrand is dominated by the upper end, so a linear grid
+    # is the right one (and trapezoid on a quadratic converges as h^2).
+    d = np.linspace(_D_LOWER, _D_UPPER, 400001)
+    integral = np.trapezoid(np.exp(2.0 * np.log(d) - log_z), d)
+
+    # ASSERT
+    assert float(integral) == pytest.approx(1.0, rel=1e-9)
+
+
+def test_volume_prior_gradient_is_finite():
+    """
+    Given the volume prior on a sampled distance,
+    When its gradient with respect to the raw sampling coordinate is taken,
+    Then it is finite at the start and far out in the raw coordinate.
+    """
+    # ARRANGE
+    star, model, system = _build_star()
+    with model:
+        star.build_likelihood(model, system)
+    raw = model["star.distance_raw"]
+    node = model["star.volume_prior"]
+
+    # ACT
+    grad_fn = pt.grad(pt.sum(node), raw)
+
+    # ASSERT
+    for value in (-20.0, 0.0, 20.0):
+        got = grad_fn.eval({raw: np.array([value])})
+        assert np.all(np.isfinite(got)), f"non-finite gradient at raw={value}"
+
+
+def test_volume_prior_beats_uniform_at_large_distance():
+    """
+    Given the prior densities implied by the two choices,
+    When they are compared across the support,
+    Then the volume prior favours larger distances by exactly d^2 -- the
+      whole point, and the difference that matters in the plx/sigma < 10
+      regime.
+    """
+    # ARRANGE
+    star, model, system = _build_star()
+    with model:
+        star.build_likelihood(model, system)
+    log_z = float(np.atleast_1d(star._volume_prior_log_norm())[0])
+
+    # ACT: log p(d) for both, up to the shared uniform reference
+    d1, d2 = 100.0, 1000.0
+    volume = (2.0 * np.log(d2) - log_z) - (2.0 * np.log(d1) - log_z)
+
+    # ASSERT
+    assert volume == pytest.approx(2.0 * np.log(d2 / d1), rel=1e-12)
+
+
+# ----------------------------------------------------------------------
+# Deferring to the galactic model
+# ----------------------------------------------------------------------
+
+
+def test_galacticmodel_suppresses_the_star_volume_prior():
+    """
+    Given a config that carries a galacticmodel block,
+    When the star's likelihood is built,
+    Then NO star volume prior is added and the model logp is untouched --
+      galacticmodel.kinematic_prior already supplies 2*log(d), and a second
+      copy would make the prior d^4.
+    """
+    # ARRANGE
+    config = {
+        "star": [{"name": "Lens"}, {"name": "Source"}],
+        "galacticmodel": [{}],
+    }
+    base_star, base_model, _ = _build_star(config=config)
+    star, model, system = _build_star(config=config)
+
+    # ACT
+    with model:
+        star.build_likelihood(model, system)
+
+    # ASSERT
+    assert "star.volume_prior" not in _potential_names(model)
+    point = base_model.initial_point()
+    point["star.distance_raw"] = np.array([0.7, -1.3])
+    assert _logp_at(model, point) == pytest.approx(
+        _logp_at(base_model, point), rel=1e-12
+    )
+
+
+def test_galacticmodel_covers_the_same_stars_the_volume_prior_would():
+    """
+    Given galacticmodel's kinematic prior,
+    When its distance coverage is read,
+    Then it is the WHOLE star.distance vector with no mask -- which is what
+      makes deferring to it (rather than covering the stars it misses)
+      correct.  If this ever becomes a subset, the star component must
+      cover the complement instead of standing down entirely.
+    """
+    # ARRANGE
+    import inspect
+
+    from exozippy.components.galacticmodel.galacticmodel import GalacticModel
+
+    src = inspect.getsource(GalacticModel.build_likelihood)
+
+    # ASSERT: the distance it weights is the unmasked vector, and the volume
+    # element is applied inside the summed kinematic potential.
+    assert "distance = pt.maximum(stars.distance.value, 1e-3) / 1e3" in src
+    assert "volume_element = 2.0 * pt.log(distance * 1000.0)" in src
+    assert "+ volume_element" in src
+
+
+# ----------------------------------------------------------------------
+# Topologies with no distance at all
+# ----------------------------------------------------------------------
+
+
+def test_no_distance_in_the_manifest_adds_nothing():
+    """
+    Given a topology with no sed/mann/lens/galacticmodel/astrometry, so the
+      star has no distance parameter at all,
+    When the star's likelihood is built,
+    Then nothing is added -- there is no distance to weight.
+    """
+    # ARRANGE
+    star, model, system = _build_star(params=("radius",))
+
+    # ACT
+    with model:
+        star.build_likelihood(model, system)
+
+    # ASSERT: only the logit transform's own uniform-prior correction, which
+    # every bounded element carries; no volume prior.
+    assert _potential_names(model) == ["logit_uniform_prior.star.radius"]
+
+
+def test_pinned_distance_contributes_only_a_constant():
+    """
+    Given a distance pinned with sigma: 0,
+    When the volume prior is built,
+    Then the element is still covered (as galacticmodel covers pinned
+      elements) but contributes a constant, so no posterior can move.
+    """
+    # ARRANGE
+    user_params = {"star.A.distance": {"initval": 250.0, "sigma": 0}}
+    star, model, system = _build_star(user_params=user_params)
+    with model:
+        star.build_likelihood(model, system)
+
+    # ACT
+    value = float(model["star.volume_prior"].eval())
+
+    # ASSERT
+    assert list(star.distance.is_sampled) == [False]
+    assert value == pytest.approx(
+        2.0 * np.log(250.0) - _expected_log_norm(), rel=1e-12
+    )


### PR DESCRIPTION
`star.distance` was declared with `lower: 0.001`, `upper: 100000.0` and no sigma, so it was sampled **uniform in distance** over 1 mpc to 100 kpc. Nobody chose that -- it is what falls out of the default machinery. Transformed, it implies `p(plx) ~ 1/plx^2`; the standard constant-space-density prior is `p(d) ~ d^2`, implying `p(plx) ~ plx^-4`. The two disagree by `d^2`, which matters exactly where a parallax is poorly measured.

Per the user's decision, no config key: **defer to galacticmodel where one exists, otherwise apply the volume prior, and drop the uniform behaviour.**

## Star coverage -- galacticmodel covers every star, so "defer entirely" is correct

Checked rather than assumed, because if the kinematic prior covered only lens/source, deferring would have left other stars with **no** distance prior at all -- worse than the uniform it replaces.

`GalacticModel.build_likelihood` reads `stars = system.star` and computes over the **whole** `star.distance` vector; `volume_element = 2.0*pt.log(distance*1000.0)` enters `kinematic_penalty = pt.sum(logsumexp(...) + volume_element + velocity_jacobian)` -- one `pt.sum`, no mask, no lens/source selection. And `in_system("galacticmodel")` puts `distance` in the manifest for *all* stars, so the vector really is every modeled star. The sets are identical; there is no complement to cover.

`test_galacticmodel_covers_the_same_stars_the_volume_prior_would` pins that against the source, so a future narrowing cannot pass silently.

## Normalized: `log Z = log((upper^3 - lower^3)/3)` = 33.44017

The PR #82/#86 argument (a constant differing between user-selectable choices) does not apply here, so a different one:

1. **The prior it replaces is normalized.** The logit reparameterization implies exactly `U(lower, upper)`. Dropping the constant would demote `star.distance`'s prior from a density to an unnormalized reweighting -- losing a property the code has today.
2. **The bounds are user-settable even though the prior is not.** Today tightening `upper:` moves logp by exactly the `-log(span)` it is worth; unnormalized it would move by an arbitrary offset.
3. One closed-form constant, no gradient, no runtime cost.

A **dynamic (linked) bound** is re-mapped inside `build_pymc`, so the static constant does not normalize it -- that case warns explicitly rather than pretending. Unreadable or non-finite bounds fall back to unnormalized with a warning, matching the IMF normalizers.

Also decided: the term covers **every** element including pinned/hard-linked ones (constant for those), exactly as galacticmodel's priors do; and it applies **on top of** a user Gaussian `sigma` on distance (kelt4 is exactly this case) -- a parallax measurement times a volume prior is the standard treatment, and the shift is `~2*(sigma/d)^2` fractionally, so it only bites where the volume prior is what you want.

## Every pinned value recomputed, every delta matches analytically

No test pins an absolute logp for an affected topology, so real examples were measured at the raw start, pre- and post-fix:

| example | old lp | new lp | delta | `2*sum(log d) - n*log Z` |
|---|---|---|---|---|
| kelt4 (3 stars @ 218.055 pc, sed) | 83018.98586862905 | 82950.97386025761 | **-68.01200837144** | -68.01200837144934 |
| GaiaBH1 (1 star @ 478.5 pc) | -259.087538492679 | -280.18639017713554 | **-21.098851684457** | -21.09885168445656 |
| astrometry_sim (1 star @ 20 pc) | -224.08465917784542 | -251.53335873698006 | **-27.448699559135** | -27.448699559134596 |
| **ob08092 (galacticmodel)** | 1260.3007061236497 | 1260.3007061236497 | **0** | deferred |

Every delta matches to float64, and `test_runaway_logp_regression.py` (DC2018_128, galacticmodel) reproduces its pinned lp exactly -- the control holds, so the deferral is neither double-counting nor mis-scoped.

## Other distance-dependent terms, checked and left alone

`sed/physics.py:calc_appmag` (distance modulus), `mann.py:calc_absmag`, and `astrometryinstrument`'s parallax scaling are all forward-model uses -- no prior or Jacobian. `lens.event_rate_prior` = `log(mu_rel_geo * theta_E)` is a rate *selection* factor (Batista+2011 decomposition), not a volume element, and applies whether or not a galacticmodel exists. No double-counting.

Pre-existing reporting gap, not introduced here: the LaTeX prior macro still calls `star.distance` "Uniform", because a component-level `pm.Potential` is invisible to `Parameter`'s own prior description -- the same as `star.logmass` under the IMF.

## Tests

New `tests/test_distance_volume_prior.py` (9 tests): the analytic `2*log(d) - log Z` delta at three raw points; the sum over both stars of a 2-star system; numeric integration of the density to 1.0 (rel 1e-9); finite gradient at raw -20/0/+20; the d^2 preference; galacticmodel suppression (no potential, logp identical); the coverage pin; no-distance-in-manifest; and the pinned-element constant.

**Pre-fix: 6 of 9 fail**, 3 pass -- the 3 are controls that must pass either way.

**602 passed, 0 failed** across 39 suites including `test_galactic_model`, `test_ffp_mass_function`, `test_runaway_logp_regression`, `test_mann`, `test_torres`, `test_chen`, `test_sed_flux_constraints`, `test_examples_prepare`, `test_integration_kelt4`, `test_whitening`. No existing assertion weakened.

One incidental refactor: `galacticmodel._sampled_bounds` moved to `parameter.sampled_bounds`, so "read a Parameter's hard support" has one owner (both normalizers use it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)