### PR TITLE
mmexofast: a corrupt seed cache must not silently disable all seeding

### DIFF
--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -606,6 +606,10 @@ class Lens(Component):
         if not isinstance(mmx_file, str) or mmx_file == "auto":
             return
 
+        # None means the file is ABSENT (warn and run unseeded, as before);
+        # a file that exists but cannot be parsed raises out of load_json.
+        # exozippy did not write a user-named file and so cannot regenerate
+        # it -- only run_or_load's own cache has that recovery.
         data = mmexofast_support.load_json(mmx_file)
         if data is None:
             logger.warning(f"No seeds loaded from '{mmx_file}'.")
@@ -898,7 +902,9 @@ class Lens(Component):
         blockers = [
             k
             for k in up
-            if k.endswith((".pi_E_N", ".pi_E_E")) or ".pm_ra" in k or ".pm_dec" in k
+            if k.endswith((".pi_E_N", ".pi_E_E"))
+            or ".pm_ra" in k
+            or ".pm_dec" in k
         ]
         if blockers:
             logger.info(

--- a/src/exozippy/components/mulensing/mmexofast_support.py
+++ b/src/exozippy/components/mulensing/mmexofast_support.py
@@ -29,6 +29,23 @@ Only ``run_or_load`` touches the mmexofast package, and imports it lazily:
 exozippy must stay importable (and publishable) without it, since mmexofast
 is installable only from git (see the microlensing group in pyproject.toml).
 
+Failure policy: seeding that cannot happen must SAY so. Starting a raw
+light-curve fit from defaults.yaml is hopeless, and on a cluster expensively
+so, which is why the missing-package case raises rather than continuing (see
+``run_or_load``). A JSON that exists but cannot be parsed is the same failure
+wearing a quieter coat, so ``load_json`` distinguishes three cases and never
+collapses them:
+
+- ABSENT: ``None`` plus a warning; the caller decides (an explicit
+  ``mmexofast: <file>`` warns and skips, the auto path generates the file).
+- PRESENT and well-formed: the dict.
+- PRESENT and unreadable / unparseable / structurally wrong: raises
+  ``CorruptMMEXOFASTFileError``. ``run_or_load`` catches it for its OWN
+  cache -- a derived artifact with an unambiguous recovery (regenerate),
+  the same call ``utilities/zenodo.py`` makes for a corrupt download -- and
+  moves the bad file aside first so nothing is overwritten silently. A
+  user-named file is not ours to rebuild, so there the exception propagates.
+
 Time systems: newer MMEXOFAST adds ``jd_offset`` to every epoch parameter so
 the JSON is always full JD. EXOZIPPy's t_0 must live in the DATA's own time
 system (the initval is compared against raw file times), so seed extraction
@@ -48,14 +65,72 @@ from ...config import RANK_DERIVED_DATA
 logger = logging.getLogger(__name__)
 
 
+class CorruptMMEXOFASTFileError(ValueError):
+    """An MMEXOFAST JSON exists but cannot be used.
+
+    Distinct from "absent" on purpose. Absent is a normal state with a
+    normal recovery (generate it, or run without seeds because the user said
+    so); present-but-broken is a state nobody chose, and the observed cause
+    -- a job killed while ``run_or_load`` was writing the cache -- leaves a
+    file whose only visible symptom, before this exception existed, was a
+    fit that quietly started from defaults.yaml.
+    """
+
+
+# The one key every MMEXOFAST exozippy-init JSON carries. Its absence means
+# the file is not one (wrong path, half-written, hand-edited), which is
+# worth catching here: `push_seed_hints` would only log "no 'fits'" and let
+# the run continue seedless.
+_REQUIRED_KEY = "fits"
+
+
 def load_json(path):
-    """Read an MMEXOFAST JSON; return the dict, or None with a warning."""
+    """Read an MMEXOFAST JSON.
+
+    Returns
+    -------
+    dict or None
+        The parsed JSON object, or None when ``path`` does not exist (logged
+        as a warning; absence is the caller's decision to make).
+
+    Raises
+    ------
+    CorruptMMEXOFASTFileError
+        The file exists but could not be opened, is not valid JSON, is not a
+        JSON object, or lacks the ``fits`` key. Every one of those means the
+        seeds this file was supposed to supply will not be applied, and the
+        module's contract (see the module docstring) is that seeding which
+        cannot happen is reported, not absorbed. ``fits: []`` is legal -- an
+        MMEXOFAST run that found no solutions is a real answer, and
+        ``push_seed_hints`` already warns about it.
+    """
+    path = Path(path)
+    if not path.exists():
+        logger.warning(f"mmexofast file '{path}' does not exist.")
+        return None
+
     try:
         with open(path) as f:
-            return json.load(f)
+            data = json.load(f)
     except (OSError, ValueError) as e:
-        logger.warning(f"Could not read mmexofast file '{path}': {e}.")
-        return None
+        raise CorruptMMEXOFASTFileError(
+            f"mmexofast file '{path}' exists but could not be read: {e}. "
+            f"A partially written file is usually a job killed mid-write. "
+            f"Delete it to regenerate, point 'mmexofast:' at a good file, "
+            f"supply start values for the microlensing parameters in the "
+            f"params file, or set 'mmexofast: false' on the lens block to "
+            f"opt out -- but do not let the fit start from defaults."
+        ) from e
+
+    if not isinstance(data, dict) or _REQUIRED_KEY not in data:
+        raise CorruptMMEXOFASTFileError(
+            f"mmexofast file '{path}' parsed but has no '{_REQUIRED_KEY}' "
+            f"key, so it is not MMEXOFAST exozippy-init output (got "
+            f"{type(data).__name__} with keys "
+            f"{sorted(data)[:6] if isinstance(data, dict) else 'n/a'}). "
+            f"Check the path, or delete the file to regenerate it."
+        )
+    return data
 
 
 def user_hints_sufficient(config_manager, is_binary, want_rho):
@@ -136,9 +211,18 @@ def push_seed_hints(data, config_manager, want_rho, is_binary, source="?"):
     same tier as any other data-driven hint and EVERY user entry -- an initval
     list, and equally a plain scalar initval -- outranks it.
 
+    A fit missing some of the observables this topology needs seeds only the
+    ones it has -- PARTIAL seeding, which is worse than none because the
+    unseeded parameters fall back to defaults.yaml while the seeded ones do
+    not, putting the start in a place no MMEXOFAST solution ever occupied.
+    That cannot be silent, so every skipped observable is named in a warning.
+    It is not fatal: which observables matter is the topology's call (a PSPL
+    JSON reused for a binary lens is a real, if degraded, start), and
+    ``user_hints_sufficient`` re-asks the relaxation engine afterwards.
+
     Returns the number of seed solutions pushed (0 when the file has none).
     """
-    fits = data.get("fits", [])
+    fits = data.get("fits") or []
     if not fits:
         logger.warning(
             f"mmexofast output '{source}' has no 'fits'; no seeds loaded."
@@ -147,9 +231,24 @@ def push_seed_hints(data, config_manager, want_rho, is_binary, source="?"):
 
     jd_offset = float(data.get("jd_offset", 0.0) or 0.0)
 
+    wanted = ["t_0", "u_0", "t_E"]
+    if want_rho:
+        wanted.append("rho")
+    if is_binary:
+        wanted += ["s", "alpha", "q"]
+
     seed_sets = []
-    for fit in fits:
+    for i, fit in enumerate(fits):
         p = fit.get("parameters", {})
+        absent = [k for k in wanted if k not in p]
+        if absent:
+            logger.warning(
+                f"mmexofast output '{source}' fit {i} has no {absent}; "
+                f"those parameters keep their defaults.yaml start while the "
+                f"rest are seeded from this fit. Check that the file matches "
+                f"this lens topology (binary={is_binary}, "
+                f"finite_source={want_rho})."
+            )
         d = {}
         if "t_0" in p:
             d["lens.0.t_0"] = float(p["t_0"]) - jd_offset
@@ -312,27 +411,63 @@ def run_or_load(
     ``limb_darkening_coeffs_gamma``) forwarded verbatim, so anything the
     fitter accepts is reachable from YAML without a new exozippy knob.
 
+    A cache that exists but cannot be parsed is REGENERATED, not tolerated
+    and not raised on: this file is exozippy's own derived artifact, so the
+    recovery is unambiguous (delete it and refit) -- the same call
+    ``utilities/zenodo.py`` makes for a corrupt download. It is never
+    overwritten silently, though: the unreadable file is moved aside to
+    ``<name>.corrupt`` and the warning names it, so a half-written cache is
+    still there to look at. Contrast ``load_json`` on a user-named
+    ``mmexofast: <file>``, which raises -- exozippy did not write that file
+    and cannot rebuild it.
+
     Raises ImportError with install instructions when the package is
     missing: silently continuing would start the fit from defaults.yaml
     values, which for a raw light curve is a hopeless (and on a cluster,
     expensive) start. Opt out with ``mmexofast: false`` on the lens block.
     """
     json_path = Path(json_path)
+    corrupt = None
     if json_path.exists():
-        logger.info(f"MMEXOFAST: using cached output '{json_path}'.")
-        return load_json(json_path)
+        try:
+            data = load_json(json_path)
+        except CorruptMMEXOFASTFileError as e:
+            corrupt = e
+        else:
+            # Logged only once the cache is known to be usable -- the old
+            # order announced "using cached output" and then used nothing.
+            logger.info(f"MMEXOFAST: using cached output '{json_path}'.")
+            return data
 
     try:
         import mmexofast as mmexo
     except ImportError as e:
+        preamble = (
+            f"The cached MMEXOFAST output is unusable ({corrupt}) and "
+            f"cannot be regenerated: "
+            if corrupt is not None
+            else ""
+        )
         raise ImportError(
-            "MMEXOFAST auto-initialization needs the 'mmexofast' package "
+            preamble
+            + "MMEXOFAST auto-initialization needs the 'mmexofast' package "
             "(poetry install --with microlensing, or pip install "
             "git+https://github.com/jenniferyee/MMEXOFAST.git). Either "
             "install it, supply start values for the microlensing "
             "parameters in the params file, or set 'mmexofast: false' on "
             "the lens block to opt out."
         ) from e
+
+    if corrupt is not None:
+        # Quarantine rather than clobber: the bad file is the only evidence
+        # of how the previous run died, and an overwrite that says nothing
+        # is the failure mode this whole path exists to stop.
+        quarantine = json_path.with_name(json_path.name + ".corrupt")
+        json_path.replace(quarantine)
+        logger.warning(
+            f"MMEXOFAST: {corrupt} Regenerating it -- the unreadable file "
+            f"was moved to '{quarantine}' and MMEXOFAST is being re-run."
+        )
 
     kwargs = dict(
         files=[str(f) for f in files],
@@ -363,8 +498,14 @@ def run_or_load(
         fitter.fit()
         data = fitter.initialize_exozippy()
 
+    # Write through a .part file and rename: json.dump straight onto the
+    # cache path is what produced the truncated caches this function now has
+    # to detect (a cluster job killed mid-write). os.replace is atomic
+    # within a filesystem, so the cache path only ever holds a complete file.
     json_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(json_path, "w") as f:
+    part = json_path.with_name(json_path.name + ".part")
+    with open(part, "w") as f:
         json.dump(data, f, indent=4)
+    os.replace(part, json_path)
     logger.info(f"MMEXOFAST: wrote '{json_path}'.")
     return data

--- a/src/exozippy/components/mulensing/mulensinstrument.py
+++ b/src/exozippy/components/mulensing/mulensinstrument.py
@@ -413,7 +413,10 @@ class MulensInstrument(Instrument):
 
         - explicit file path: the JSON's bad-data mask (``excluded_points``)
           and error factors (``errfacs``) are applied to this component's
-          files; the seed hints are pushed by Lens at stage 2 as before.
+          files; the seed hints are pushed by Lens at stage 2 as before. An
+          absent file warns and skips; an unparseable one raises (see
+          ``mmexofast_support.load_json``) rather than dropping the mask and
+          the error factors along with the seeds.
         - absent (default) or ``auto``: when the params file lacks start
           values for the microlensing parameters (or always, for ``auto``),
           MMEXOFAST is run on the raw light curves -- renormalize_errors on,

--- a/tests/test_mmexofast_support.py
+++ b/tests/test_mmexofast_support.py
@@ -8,6 +8,8 @@ by the DC2018 example workflow, not here -- it needs the optional package
 and minutes of CPU.
 """
 
+import json
+
 import numpy as np
 import pytest
 
@@ -461,6 +463,243 @@ def test_run_or_load_uses_cached_json(tmp_path):
     cached.write_text('{"fits": [], "errfacs": {}}')
     data = mmx.run_or_load(cached, ["a.txt"])
     assert data == {"fits": [], "errfacs": {}}
+
+
+# ---------------------------------------------------------------------------
+# load_json / run_or_load: absent vs valid vs CORRUPT
+#
+# A cache that exists but cannot be parsed used to return None with a
+# warning, which every caller read as "no seeds" -- so a job killed while
+# writing the cache produced a fit that started from defaults.yaml, with
+# nothing but a lost log line to say so. The three states must stay distinct.
+# ---------------------------------------------------------------------------
+
+
+_GOOD_JSON = {
+    "fits": [
+        {
+            "parameters": {"t_0": 2458554.9, "u_0": 0.14, "t_E": 18.2},
+            "sigmas": {"t_0": 0.02, "u_0": 0.004, "t_E": 0.3},
+        }
+    ],
+    "errfacs": {"a.txt": 1.4},
+    "excluded_points": {"a.txt": {"n_data": 100, "indices": [3, 7]}},
+}
+
+
+def _truncated_text():
+    """The observed corruption: half of a well-formed MMEXOFAST JSON."""
+    full = json.dumps(_GOOD_JSON, indent=4)
+    return full[: len(full) // 2]
+
+
+class _FakeFitter:
+    """Stands in for mmexofast.MMEXOFASTFitter so the regeneration path is
+    testable with or without the optional package installed. Injected via
+    sys.modules, so run_or_load's lazy `import mmexofast` finds it and the
+    module under test still imports the package nowhere else."""
+
+    calls = []
+
+    def __init__(self, **kwargs):
+        type(self).calls.append(kwargs)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def fit(self):
+        pass
+
+    def initialize_exozippy(self):
+        return {"fits": [{"parameters": {"t_0": 1.0, "u_0": 0.2, "t_E": 9.0}}]}
+
+
+@pytest.fixture
+def fake_mmexofast(monkeypatch):
+    """Inject a fake `mmexofast` module and hand back its fitter class."""
+    import sys
+    import types
+
+    _FakeFitter.calls = []
+    mod = types.ModuleType("mmexofast")
+    mod.MMEXOFASTFitter = _FakeFitter
+    monkeypatch.setitem(sys.modules, "mmexofast", mod)
+    return _FakeFitter
+
+
+def test_load_json_absent_file_returns_none_with_a_warning(tmp_path, caplog):
+    """
+    Given a path with no file at it,
+    When load_json reads it,
+    Then it returns None and warns -- absence is a normal state whose
+    recovery belongs to the caller, not an error.
+    """
+    with caplog.at_level("WARNING"):
+        assert mmx.load_json(tmp_path / "nope.json") is None
+    assert any("does not exist" in r.message for r in caplog.records)
+
+
+def test_load_json_truncated_file_raises(tmp_path):
+    """
+    Given a cache file truncated mid-write,
+    When load_json reads it,
+    Then it raises CorruptMMEXOFASTFileError naming the file, instead of
+    returning None and letting the caller run seedless.
+    """
+    bad = tmp_path / "event_mmexofast.json"
+    bad.write_text(_truncated_text())
+
+    with pytest.raises(mmx.CorruptMMEXOFASTFileError) as exc:
+        mmx.load_json(bad)
+    assert "event_mmexofast.json" in str(exc.value)
+
+
+def test_load_json_valid_json_without_fits_raises(tmp_path):
+    """
+    Given a file that is valid JSON but is not MMEXOFAST output (no 'fits'),
+    When load_json reads it,
+    Then it raises: a wrong or hand-mangled path would otherwise seed
+    nothing while looking like a successful load.
+    """
+    wrong = tmp_path / "wrong.json"
+    wrong.write_text('{"parameters": {"t_0": 2458554.9}}')
+
+    with pytest.raises(mmx.CorruptMMEXOFASTFileError) as exc:
+        mmx.load_json(wrong)
+    assert "fits" in str(exc.value)
+
+
+def test_load_json_valid_file_returns_the_dict(tmp_path):
+    """
+    Given a well-formed MMEXOFAST JSON,
+    When load_json reads it,
+    Then the parsed dict comes back unchanged (the fix must not disturb the
+    ordinary path).
+    """
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps(_GOOD_JSON))
+    assert mmx.load_json(good) == _GOOD_JSON
+
+
+def test_run_or_load_corrupt_cache_regenerates_and_keeps_the_bad_file(
+    tmp_path, caplog, fake_mmexofast
+):
+    """
+    Given a truncated cache at the auto-init path,
+    When run_or_load is called,
+    Then MMEXOFAST is re-run and its fresh solution is returned and cached
+    (NOT None), the unreadable file is preserved at <name>.corrupt rather
+    than silently overwritten, and a warning names both.
+    """
+    cache = tmp_path / "event_mmexofast.json"
+    cache.write_text(_truncated_text())
+
+    with caplog.at_level("WARNING"):
+        data = mmx.run_or_load(cache, ["a.txt"])
+
+    # The seeding outcome: real seeds, not the old silent None.
+    assert data["fits"][0]["parameters"]["t_0"] == 1.0
+    assert len(fake_mmexofast.calls) == 1
+    assert json.loads(cache.read_text()) == data
+
+    quarantine = tmp_path / "event_mmexofast.json.corrupt"
+    assert quarantine.read_text() == _truncated_text()
+    msg = " ".join(r.message for r in caplog.records)
+    assert ".corrupt" in msg and "Regenerating" in msg
+
+
+def test_run_or_load_corrupt_cache_without_the_package_raises(
+    tmp_path, monkeypatch
+):
+    """
+    Given a truncated cache and no mmexofast package to rebuild it with,
+    When run_or_load is called,
+    Then it raises ImportError mentioning the unusable cache -- the same
+    "seeding cannot happen, so say so" contract the missing-package path
+    already had -- and the bad file is left in place, since moving it aside
+    would destroy the only cache without being able to replace it.
+    """
+    import sys
+
+    cache = tmp_path / "event_mmexofast.json"
+    cache.write_text(_truncated_text())
+    monkeypatch.setitem(sys.modules, "mmexofast", None)
+
+    with pytest.raises(ImportError) as exc:
+        mmx.run_or_load(cache, ["a.txt"])
+    assert "cached MMEXOFAST output is unusable" in str(exc.value)
+    assert cache.read_text() == _truncated_text()
+    assert not (tmp_path / "event_mmexofast.json.corrupt").exists()
+
+
+def test_run_or_load_absent_cache_generates_it_atomically(
+    tmp_path, fake_mmexofast
+):
+    """
+    Given no cache at all (the normal first run),
+    When run_or_load is called,
+    Then MMEXOFAST runs, the result is returned and written to the cache
+    path, no .corrupt is created, and no .part scratch file survives -- the
+    write goes through a temporary and is renamed, so a job killed mid-write
+    can no longer leave the truncated cache these tests are about.
+    """
+    cache = tmp_path / "event_mmexofast.json"
+
+    data = mmx.run_or_load(cache, ["a.txt"])
+
+    assert len(fake_mmexofast.calls) == 1
+    assert data["fits"][0]["parameters"]["t_E"] == 9.0
+    assert json.loads(cache.read_text()) == data
+    assert sorted(p.name for p in tmp_path.iterdir()) == [
+        "event_mmexofast.json"
+    ]
+
+
+def test_run_or_load_valid_cache_never_runs_the_fitter(
+    tmp_path, fake_mmexofast
+):
+    """
+    Given a valid cache and an available mmexofast package,
+    When run_or_load is called,
+    Then the cached dict is returned and the fitter is never constructed --
+    the corrupt-cache regeneration must not have made reruns expensive.
+    """
+    cache = tmp_path / "event_mmexofast.json"
+    cache.write_text(json.dumps(_GOOD_JSON))
+
+    assert mmx.run_or_load(cache, ["a.txt"]) == _GOOD_JSON
+    assert fake_mmexofast.calls == []
+
+
+# ---------------------------------------------------------------------------
+# push_seed_hints: partial seeding is announced
+# ---------------------------------------------------------------------------
+
+
+def test_seed_hints_warn_when_a_fit_lacks_required_observables(caplog):
+    """
+    Given a point-lens JSON pushed against a binary, finite-source topology,
+    When seeds are pushed,
+    Then the observables it cannot supply are named in a warning -- partial
+    seeding (some parameters at the MMEXOFAST solution, the rest at
+    defaults.yaml) starts the fit where no solution lives, so it must not be
+    silent -- while the observables it does carry are still seeded.
+    """
+    data = {"fits": [{"parameters": {"t_0": 2458554.9, "u_0": 0.14}}]}
+    cm = _RecordingConfigManager()
+
+    with caplog.at_level("WARNING"):
+        n = mmx.push_seed_hints(data, cm, want_rho=True, is_binary=True)
+
+    assert n == 1
+    seed = cm.seed_hint_sets[0]
+    assert set(seed) == {"lens.0.t_0", "lens.0.u_0"}
+    msg = " ".join(r.message for r in caplog.records)
+    for missing in ("t_E", "rho", "s", "alpha", "q"):
+        assert missing in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_multiseed_mmexofast.py
+++ b/tests/test_multiseed_mmexofast.py
@@ -111,6 +111,50 @@ def test_mmexofast_loader_missing_file_warns_and_noops(caplog):
     assert any("mmexofast" in rec.message.lower() for rec in caplog.records)
 
 
+def test_mmexofast_loader_corrupt_file_raises_rather_than_seeding_nothing(
+    tmp_path,
+):
+    """
+    Given a lens config naming an mmexofast file that exists but is
+    truncated (a job killed mid-write),
+    When _load_mmexofast_seeds runs,
+    Then it raises CorruptMMEXOFASTFileError and pushes no seeds, instead of
+    warning once and letting the fit start from defaults.yaml. A user-named
+    file is not exozippy's to regenerate -- only run_or_load's own cache is
+    (tests/test_mmexofast_support.py covers that half).
+    """
+    from exozippy.components.mulensing.mmexofast_support import (
+        CorruptMMEXOFASTFileError,
+    )
+
+    good = {
+        "fits": [
+            {
+                "parameters": {
+                    "t_0": 2458554.9,
+                    "u_0": 0.14,
+                    "t_E": 18.2,
+                    "rho": 1e-3,
+                    "s": 0.98,
+                    "q": 1.1e-3,
+                    "alpha": -52.0,
+                },
+                "sigmas": {},
+            }
+        ]
+    }
+    bad = tmp_path / "mmexofast.json"
+    full = json.dumps(good, indent=4)
+    bad.write_text(full[: len(full) // 2])
+
+    lens, cfg_manager = _make_binary_lens(bad)
+    with pytest.raises(CorruptMMEXOFASTFileError) as exc:
+        lens._load_mmexofast_seeds()
+
+    assert "mmexofast.json" in str(exc.value)
+    assert cfg_manager.seed_hint_sets == []
+
+
 def test_mmexofast_key_absent_is_a_noop():
     """
     Given a lens config with no 'mmexofast' key (the default, opt-in feature),


### PR DESCRIPTION
From the codebase audit. A truncated or malformed MMEXOFAST cache silently disabled **all** seeding and the fit proceeded from `defaults.yaml`.

## Reproduced

Half a well-formed JSON written to the cache path:

```
INFO    MMEXOFAST: using cached output '.../event_mmexofast.json'.
WARNING Could not read mmexofast file '...': Expecting property name enclosed in double quotes: line 12 column 13
run_or_load returned: None   <-- no exception, no rerun
```

`MulensInstrument._resolve_mmexofast` then hits `if data is None: return`, dropping **all three** consumers at once -- 0 seed hints, 0 `excluded_points` masked, 0 `errfacs` `err_scale` starts.

Two aggravating details: the INFO line claims the cache was used *before* anything is parsed, and the bad file stays on disk, so every restart repeats it.

**Root cause of the corruption**: `run_or_load` did `json.dump` straight onto the cache path. A cluster job killed mid-write leaves exactly this file.

## The contract was already written down

`run_or_load`'s own docstring, unchanged on master:

> Raises ImportError with install instructions when the package is missing: **silently continuing would start the fit from defaults.yaml values, which for a raw light curve is a hopeless (and on a cluster, expensive) start.**

Identical end state, opposite handling.

## Raise vs regenerate, split by who owns the file

- **`run_or_load`'s own cache (`<prefix>_mmexofast.json`): regenerate.** It is exozippy's derived artifact and the recovery is unambiguous -- the same call `utilities/zenodo.py` documents ("a corrupt cached file is re-fetched rather than raising, since the recovery is unambiguous"). Not silently: the bad file is moved to `<name>.corrupt` and the warning names both paths, so evidence of how the previous run died survives. If mmexofast is not installed it raises `ImportError` quoting the cache error and **leaves the file in place** -- destroying the only cache without being able to replace it would be worse.
- **A user-named `mmexofast: <file>`: raise `CorruptMMEXOFASTFileError`.** Exozippy did not write that file, cannot rebuild it, and regenerating would overwrite the user's named path with a fit they did not ask for. No unambiguous recovery, so no automatic one.

`load_json` now returns `None` only for **absent**. Corrupt means unreadable, unparseable, not a JSON object, or lacking the `fits` key -- that last catches a wrong path or a half-written-but-still-parseable file, which `push_seed_hints` would otherwise absorb as a single lost warning. `fits: []` stays legal: an MMEXOFAST run that found nothing is a real answer.

**Prevention**: the cache is now written to `.part` and `os.replace`d, so the cache path only ever holds a complete file.

## Partial seeding is reachable, and worse than none

`push_seed_hints` copies each observable only `if key in p`, so a JSON missing `t_E` (or `rho`/`s`/`alpha`/`q` under a binary or finite-source topology) seeds the rest and leaves that one at its `defaults.yaml` start -- putting the chain where **no MMEXOFAST solution lives**, a worse start than a clean seedless one. Reachable from a PSPL JSON reused for a binary lens, or a hand-edited file.

Fixed as a **warning naming every dropped observable**, not an error: which observables matter is the topology's call, and `user_hints_sufficient` re-asks the relaxation engine afterwards.

The neighbours are clean -- `apply_excluded_points` and `push_errfac_hints` skip unmatched basenames with a warning each and validate `errfacs` values, and both are now unreachable-with-garbage anyway since a corrupt JSON never gets that far.

## Tests

`tests/test_mmexofast_support.py` +10, `tests/test_multiseed_mmexofast.py` +1. The regeneration path is driven by a fake `mmexofast` module injected into `sys.modules`, so it runs with or without the optional package and the module under test still imports it nowhere new (preserving the lazy-import rule).

**35 passed** at HEAD. **Stashing `src/`: 7 failed, 28 passed** -- the corrupt-cache regeneration, the corrupt-without-package raise, all three `load_json` contract tests, the partial-seeding warning and the Lens-level raise all fail pre-fix. The three that pass pre-fix are deliberate pinning tests (valid cache returns the dict, valid cache never runs the fitter, absent cache still generates).

Assertions are on the seeding outcome: fresh seeds returned and cached, `.corrupt` present holding the original bytes, `seed_hint_sets == []` on the raise, `set(seed) == {...}` on the partial case. Wider check across 9 mmexofast-touching test files: **139 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)