### PR TITLE
gitignore: also ignore the pre-restructure NextGen spectra path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@ src/exozippy/components/evolutionarymodel/missing_grid_points_afe0_vvcrit0_inter
 src/exozippy/models/find_interpolatable_missing_grid_points.py
 /src/exozippy/models/MIST/MISTv2.5/EEPs/MissingGridPoints
 src/exozippy/models/MIST/MISTv2.5/EEPs/afe_p0_vvcrit0.0.grid.parquet
+
+# Pre-restructure location of the downloaded NextGen spectra (~250 MB).  The
+# live path is ignored above; this one is a leftover that make_bc wrote to
+# before the models/ tree moved, and it is still populated in working trees
+# that ran the SED tests.  Unignored, a `git add -A` in any worktree tries to
+# commit a 247 MB file and GitHub rejects the push.
+src/exozippy/components/sed/models/


### PR DESCRIPTION
`.gitignore` covers `src/exozippy/models/NextGen/BCs/` -- the location the models tree moved to in PR #106 -- but not the component-local path `make_bc` wrote to before that move.

That directory is **still populated (~249 MB)** in working trees that have run the SED tests, and it is not ignored, so it is one `git add -A` away from a rejected push: GitHub's file size limit is 100 MB and `NextGen.spectra.csv` is 247 MB.

Found the hard way while resolving a merge conflict in a worktree -- the push was rejected by the pre-receive hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)