### PR TITLE
zenodo: machine-level shared cache so worktrees stop re-downloading 249 MB

### DIFF
--- a/src/exozippy/utilities/zenodo.py
+++ b/src/exozippy/utilities/zenodo.py
@@ -26,17 +26,69 @@ test that has nothing to do with downloading. So:
   mistaken for a cached one;
 * a corrupt cached file is re-fetched rather than raising, since the recovery
   is unambiguous.
+
+Machine-level shared cache
+--------------------------
+The destination directory is derived from the *source tree*
+(``DEFAULT_MODEL_ROOT = source_code_dir / "models"``, ``EEP_GRID_DIR``), so
+every git worktree and every checkout is a separate destination. During
+development that means re-fetching a quarter-gigabyte from a free academic
+host once per worktree, which is both slow and rude.
+
+So a machine-level cache sits *behind* this function, keyed by the asset's
+pinned md5, under ``$XDG_CACHE_HOME/exozippy/downloads`` (default
+``~/.cache/exozippy/downloads``). It does not change where callers read
+from: the destination is still populated, it is just populated by a hard
+link from the cache instead of by a download. Properties:
+
+* **Verified on adoption.** A cache entry is only published after the full
+  size+md5 check, by atomic rename, and its md5 is re-checked in full every
+  time it is linked into a new destination. A corrupt shared entry is
+  discarded and re-fetched rather than propagated to every worktree at once
+  -- a shared cache concentrates that risk, so it gets the stronger check.
+* **Hard link, copy only if forced.** ``os.link`` first, so N worktrees cost
+  one copy on disk and one file in the quota; any ``OSError`` (a
+  cross-device ``EXDEV`` being the expected one) falls back to
+  ``shutil.copyfile``. Entries are published mode 0444 so an in-place write
+  through one of the links cannot corrupt the shared copy.
+* **Concurrency-safe.** Fetches of the same asset serialize on an
+  ``flock``-ed lock file next to the entry (auto-released if the holder
+  dies), so parallel agents download it once; and even with no working lock
+  the publish is an atomic rename of a fully verified file, so the worst
+  case is duplicate work, never a torn entry.
+* **Never fatal.** An unset home, an unwritable or full cache directory, a
+  filesystem with no ``flock`` -- each degrades to exactly the old
+  behaviour (download straight to the destination) with one warning.
+* **Adopts what is already there.** A destination that already holds the
+  asset at the pinned size and md5 is hard-linked *into* the cache, so an
+  existing checkout seeds the machine cache for every later worktree with
+  no network access at all.
+
+Set ``EXOZIPPY_CACHE_DIR`` to relocate the cache (small home quota, shared
+scratch), or to an empty string / ``none`` / ``off`` / ``0`` to switch it
+off. Entries are keyed by content hash, so a re-uploaded asset simply gets a
+new entry; the stale one is inert and safe to delete by hand.
 """
 
 from __future__ import annotations
 
+import contextlib
+import errno
 import hashlib
 import logging
+import os
+import shutil
+import tempfile
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Callable, Mapping
+from typing import Callable, Iterator, Mapping
+
+try:  # POSIX only; the cache is correct without it, just less efficient.
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +98,29 @@ logger = logging.getLogger(__name__)
 _DOWNLOAD_ATTEMPTS = 4
 _RETRY_BACKOFF = 5  # seconds; doubles each attempt
 
+# Shared-cache configuration.
+_CACHE_ENV = "EXOZIPPY_CACHE_DIR"
+_CACHE_APP_DIR = "exozippy"
+_CACHE_SUBDIR = "downloads"
+_CACHE_OFF_VALUES = frozenset({"", "0", "off", "none", "false"})
+
+# How long to wait for another process to finish fetching the same asset
+# before giving up on the lock and fetching it ourselves. Generous, because
+# what we are waiting on is a 250 MB download on someone else's link; and
+# proceeding without the lock is safe (see _publish), only wasteful.
+_LOCK_TIMEOUT = 900.0  # seconds
+_LOCK_POLL = 0.5  # seconds
+
+# Set once, per process, the first time the cache proves unusable. Every
+# later call then goes straight down the old download-to-destination path
+# instead of re-discovering the same broken directory (and re-warning).
+_cache_disabled_reason: str | None = None
+
+# (destination, md5) pairs whose adoption into the cache has already been
+# attempted this process. Adoption costs a full md5 of a file we are
+# otherwise happy to trust on its size alone, so it happens at most once.
+_adoption_attempted: set[tuple[str, str]] = set()
+
 
 def _md5(path: Path, chunk: int = 1 << 20) -> str:
     """Streaming md5 of a file (the spectra grid is ~250 MB)."""
@@ -54,6 +129,440 @@ def _md5(path: Path, chunk: int = 1 << 20) -> str:
         for block in iter(lambda: f.read(chunk), b""):
             h.update(block)
     return h.hexdigest()
+
+
+# --- the machine-level shared cache ---------------------------------------
+
+
+def shared_cache_root() -> Path | None:
+    """Where the machine-level cache lives, or None if it is switched off.
+
+    ``EXOZIPPY_CACHE_DIR`` wins; otherwise the XDG convention
+    (``$XDG_CACHE_HOME/exozippy``, falling back to ``~/.cache/exozippy``).
+    Nothing is created here -- this is a pure path computation, so callers
+    and tests can ask the question without side effects.
+    """
+    override = os.environ.get(_CACHE_ENV)
+    if override is not None:
+        if override.strip().lower() in _CACHE_OFF_VALUES:
+            return None
+        return Path(override.strip()).expanduser()
+
+    xdg = os.environ.get("XDG_CACHE_HOME", "").strip()
+    try:
+        base = Path(xdg).expanduser() if xdg else Path.home() / ".cache"
+    except RuntimeError:  # pragma: no cover - no home directory at all
+        return None
+    return base / _CACHE_APP_DIR
+
+
+def _disable_cache(reason: str) -> None:
+    """Latch the cache off for this process, warning once."""
+    global _cache_disabled_reason
+    if _cache_disabled_reason is None:
+        _cache_disabled_reason = reason
+        logger.warning(
+            "Shared download cache unavailable (%s). Falling back to "
+            "downloading into the destination directory; set %s to a "
+            "writable path to re-enable it.",
+            reason,
+            _CACHE_ENV,
+        )
+
+
+def _cache_dir() -> Path | None:
+    """The cache directory, created and writable, or None if unusable."""
+    if _cache_disabled_reason is not None:
+        return None
+    root = shared_cache_root()
+    if root is None:
+        return None
+    path = root / _CACHE_SUBDIR
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        if not os.access(path, os.W_OK | os.X_OK):
+            raise PermissionError(f"{path} is not writable")
+    except OSError as e:
+        _disable_cache(str(e))
+        return None
+    return path
+
+
+def _entry_path(
+    cache: Path, filename: str, meta: Mapping[str, object]
+) -> Path:
+    """Cache path for an asset: content-addressed, but still readable.
+
+    Keyed by the pinned md5 so two assets can never collide and a
+    re-uploaded file gets a fresh entry; suffixed with the filename so the
+    directory can be understood by a human with ``ls``.
+    """
+    return cache / f"{meta['md5']}-{Path(filename).name}"
+
+
+@contextlib.contextmanager
+def _entry_lock(entry: Path) -> Iterator[None]:
+    """Serialize fetches of one asset across processes, best effort.
+
+    An exclusive ``flock`` on ``<entry>.lock``, polled so a stuck holder
+    cannot wedge a fit forever. The kernel drops the lock when the holder
+    exits, crashed or not, so there is no stale-lock recovery to get wrong.
+    Losing the lock (no fcntl, a filesystem that ignores it, the timeout) is
+    not an error: the publish path is safe without it, and the only cost is
+    a duplicated download.
+    """
+    if fcntl is None:
+        yield
+        return
+
+    lock_path = entry.with_name(entry.name + ".lock")
+    fd = None
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        deadline = time.monotonic() + _LOCK_TIMEOUT
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as e:
+                if e.errno not in (
+                    errno.EACCES,
+                    errno.EAGAIN,
+                    errno.EWOULDBLOCK,
+                ):
+                    # Not "somebody else holds it" but "this filesystem does
+                    # not do locks" (ENOLCK, EOPNOTSUPP, ...). Polling that
+                    # for 15 minutes would be a hang, so proceed unlocked.
+                    logger.debug("flock unsupported on %s (%s)", lock_path, e)
+                    break
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "Waited %.0fs for another process to fetch %s; "
+                        "fetching it ourselves.",
+                        _LOCK_TIMEOUT,
+                        entry.name,
+                    )
+                    break
+                time.sleep(_LOCK_POLL)
+    except OSError as e:
+        logger.debug("No lock on %s (%s); proceeding unlocked.", entry, e)
+
+    try:
+        yield
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            with contextlib.suppress(OSError):
+                os.close(fd)
+
+
+def _entry_is_intact(entry: Path, meta: Mapping[str, object]) -> bool:
+    """Full size+md5 verification of a shared-cache entry.
+
+    Deliberately stricter than the destination's size-only check: one
+    corrupt entry here would be linked into every worktree on the machine,
+    and the md5 is read once per destination, not once per run.
+    """
+    try:
+        if entry.stat().st_size != meta["size"]:
+            logger.warning(
+                "Shared cache entry %s is the wrong size; discarding it.",
+                entry,
+            )
+            return False
+        if _md5(entry) != meta["md5"]:
+            logger.warning(
+                "Shared cache entry %s fails its md5 check; discarding it.",
+                entry,
+            )
+            return False
+    except OSError as e:
+        logger.warning("Cannot read shared cache entry %s: %s", entry, e)
+        return False
+    return True
+
+
+def _discard_entry(entry: Path) -> None:
+    """Remove a cache entry that failed verification, best effort."""
+    with contextlib.suppress(OSError):
+        entry.unlink(missing_ok=True)
+
+
+def _publish(source: Path, entry: Path) -> bool:
+    """Move a verified file into the cache as `entry`.
+
+    `source` must already have passed size+md5 and must live in the cache
+    directory, so the rename is atomic: a concurrent reader sees either no
+    entry or a complete, verified one, never a partial write. Two processes
+    publishing the same asset simply overwrite identical bytes.
+    """
+    try:
+        with contextlib.suppress(OSError):
+            os.chmod(source, 0o444)  # a shared copy is nobody's scratch file
+        os.replace(source, entry)
+        return True
+    except OSError as e:
+        logger.warning(
+            "Could not populate the shared cache at %s: %s", entry, e
+        )
+        return False
+
+
+def _link_into(entry: Path, dest: Path, meta: Mapping[str, object]) -> bool:
+    """Materialize `entry` at `dest`; hard link if possible, else copy.
+
+    Staged under a temporary name in the destination directory and renamed,
+    for the same reason the download is: a half-copied file must never be
+    reachable at the destination path. A hard link is the same inode as the
+    already-verified entry and so is intact by construction; a copy is fresh
+    bytes and gets the same md5 check a fresh download would have got.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=dest.parent, prefix=dest.name + ".", suffix=".link"
+    )
+    os.close(fd)
+    tmp = Path(tmp_name)
+    try:
+        tmp.unlink()  # os.link refuses an existing target
+        try:
+            os.link(entry, tmp)
+            how = "hard link"
+        except OSError as e:
+            # EXDEV (cache and destination on different filesystems) is the
+            # expected case; EPERM/EMLINK/EOPNOTSUPP happen on some network
+            # and container filesystems. All of them mean the same thing
+            # here: we have to spend the disk.
+            logger.debug(
+                "Hard link %s -> %s failed (%s); copying.", entry, tmp, e
+            )
+            shutil.copyfile(entry, tmp)
+            how = f"copy ({e.strerror or e})"
+            if _md5(tmp) != meta["md5"]:
+                raise OSError(f"the copy of {entry} at {tmp} is corrupt")
+        if tmp.stat().st_size != meta["size"]:
+            raise OSError(f"{tmp} is short after {how}")
+        os.replace(tmp, dest)
+        if how == "hard link":
+            logger.info(
+                "Linked %s from the shared cache (hard link).", dest.name
+            )
+        else:
+            # Worth saying: st_dev is not a reliable test here (an automounted
+            # NFS home can report the same st_dev as a local disk while still
+            # refusing the link), so the only honest detection is to try it --
+            # and the user is the one who can fix it, by co-locating the cache.
+            logger.info(
+                "Copied %s from the shared cache (%s). Set %s to a directory "
+                "on the same filesystem as %s to hard-link instead, so every "
+                "checkout shares one copy on disk.",
+                dest.name,
+                how,
+                _CACHE_ENV,
+                dest.parent,
+            )
+        return True
+    except OSError as e:
+        logger.warning(
+            "Could not materialize %s from the shared cache: %s", dest, e
+        )
+        return False
+    finally:
+        with contextlib.suppress(OSError):
+            tmp.unlink(missing_ok=True)
+
+
+def _adopt_destination(
+    dest: Path, filename: str, meta: Mapping[str, object]
+) -> None:
+    """Seed the cache from a destination that already holds the asset.
+
+    An existing checkout typically has these files already. Verifying one
+    locally (an md5, once per process) is far cheaper than re-downloading a
+    quarter-gigabyte, so the first run in such a tree populates the machine
+    cache for every later worktree with no network access at all.
+    """
+    cache = _cache_dir()
+    if cache is None:
+        return
+    entry = _entry_path(cache, filename, meta)
+    key = (str(dest), str(meta["md5"]))
+    if key in _adoption_attempted or entry.exists():
+        return
+    _adoption_attempted.add(key)
+
+    if _md5(dest) != meta["md5"]:
+        logger.warning(
+            "%s is the pinned size but not the pinned md5. Leaving it alone "
+            "(it is what this tree has always used) but NOT adopting it into "
+            "the shared cache. Delete it to force a clean re-download.",
+            dest,
+        )
+        return
+
+    with _entry_lock(entry):
+        if entry.exists():
+            return
+        fd, tmp_name = tempfile.mkstemp(
+            dir=cache, prefix=Path(filename).name + ".", suffix=".adopt"
+        )
+        os.close(fd)
+        tmp = Path(tmp_name)
+        try:
+            tmp.unlink()
+            try:
+                os.link(dest, tmp)
+            except OSError:
+                # Same rule as _link_into: a copy is new bytes, so it is
+                # re-verified before it can become the entry every worktree
+                # on this machine will link to.
+                shutil.copyfile(dest, tmp)
+                if _md5(tmp) != meta["md5"]:
+                    raise OSError(f"the copy of {dest} at {tmp} is corrupt")
+            if _publish(tmp, entry):
+                logger.info(
+                    "Adopted the existing %s into the shared cache at %s.",
+                    dest.name,
+                    entry,
+                )
+        except OSError as e:
+            logger.warning(
+                "Could not adopt %s into the shared cache: %s", dest, e
+            )
+        finally:
+            with contextlib.suppress(OSError):
+                tmp.unlink(missing_ok=True)
+
+
+# --- downloading -----------------------------------------------------------
+
+
+def _download_verified(
+    meta: Mapping[str, object], filename: str, part: Path
+) -> None:
+    """Download `meta["url"]` onto `part`, verified, with retries.
+
+    On return `part` exists and has the pinned size and md5. On failure it
+    does not exist at all.
+
+    Retried with backoff. Zenodo is a free academic host serving a 250 MB
+    file, and it returns 5xx under load -- observed as
+    `HTTPError: HTTP Error 504: Gateway Time-out` failing CI on pull
+    requests that had touched nothing related. A transient gateway error
+    should cost a few seconds, not a whole run.
+
+    Only transport and integrity errors are retried. A 404 means the URL or
+    record is wrong, and retrying that just delays a real failure by
+    _RETRY_BACKOFF seconds, so it is re-raised at once.
+    """
+    last_error: BaseException | None = None
+    for attempt in range(1, _DOWNLOAD_ATTEMPTS + 1):
+        try:
+            urllib.request.urlretrieve(meta["url"], part)
+            size = part.stat().st_size
+            if size != meta["size"]:
+                raise RuntimeError(
+                    f"{filename} downloaded {size} bytes, expected "
+                    f"{meta['size']}. The download was truncated; retry."
+                )
+            digest = _md5(part)
+            if digest != meta["md5"]:
+                raise RuntimeError(
+                    f"{filename} has md5 {digest}, expected "
+                    f"{meta['md5']}. The file on Zenodo may have been "
+                    f"replaced, or the download was corrupted."
+                )
+            return
+        except urllib.error.HTTPError as e:
+            if e.code < 500:
+                part.unlink(missing_ok=True)
+                raise
+            last_error = e
+        except (urllib.error.URLError, TimeoutError, RuntimeError) as e:
+            last_error = e
+        part.unlink(missing_ok=True)
+
+        if attempt < _DOWNLOAD_ATTEMPTS:
+            delay = _RETRY_BACKOFF * 2 ** (attempt - 1)
+            logger.warning(
+                "Download of %s failed (attempt %d/%d): %s. Retrying in %ds.",
+                filename,
+                attempt,
+                _DOWNLOAD_ATTEMPTS,
+                last_error,
+                delay,
+            )
+            time.sleep(delay)
+
+    raise RuntimeError(
+        f"Could not download {filename} from Zenodo after "
+        f"{_DOWNLOAD_ATTEMPTS} attempts: {last_error}"
+    ) from last_error
+
+
+def _fetch_via_cache(
+    filename: str,
+    meta: Mapping[str, object],
+    dest: Path,
+    on_fetch: Callable[[str], None] | None,
+) -> bool:
+    """Populate `dest` through the machine-level cache.
+
+    Returns False if the cache could not serve or be populated, in which
+    case the caller falls back to downloading straight to the destination
+    (i.e. to the behaviour that predates the cache).
+    """
+    cache = _cache_dir()
+    if cache is None:
+        return False
+    entry = _entry_path(cache, filename, meta)
+
+    # Unlocked fast path: a warm cache costs one stat plus one md5.
+    if entry.exists():
+        if _entry_is_intact(entry, meta) and _link_into(entry, dest, meta):
+            return True
+        _discard_entry(entry)
+
+    with _entry_lock(entry):
+        # Re-check: whoever held the lock may have just fetched it for us.
+        if entry.exists():
+            if _entry_is_intact(entry, meta) and _link_into(entry, dest, meta):
+                return True
+            _discard_entry(entry)
+
+        if on_fetch is not None:
+            on_fetch(filename)
+        logger.info(f"Downloading {filename} from Zenodo...")
+
+        fd, tmp_name = tempfile.mkstemp(
+            dir=cache, prefix=Path(filename).name + ".", suffix=".part"
+        )
+        os.close(fd)
+        part = Path(tmp_name)
+        part.unlink()  # urlretrieve creates it; keep the name reserved only
+        try:
+            _download_verified(meta, filename, part)
+            if not _publish(part, entry):
+                # The download is good but the cache would not take it; use
+                # it rather than throwing away a 250 MB transfer.
+                return _link_into(part, dest, meta) or _move_into(part, dest)
+        finally:
+            with contextlib.suppress(OSError):
+                part.unlink(missing_ok=True)
+
+        return _link_into(entry, dest, meta)
+
+
+def _move_into(source: Path, dest: Path) -> bool:
+    """Last-ditch: move a verified download to the destination."""
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(dest))
+        return True
+    except OSError as e:  # pragma: no cover - both link and move failing
+        logger.warning("Could not place %s: %s", dest, e)
+        return False
 
 
 def fetch_assets(
@@ -71,13 +580,16 @@ def fetch_assets(
         (``https://zenodo.org/api/records/<id>``); they pin the content, so a
         re-uploaded or truncated file is caught rather than silently used.
     dest_dir
-        Cache directory. Created if a fetch is actually needed; a call that
-        finds everything cached touches nothing.
+        Destination directory -- unchanged by the shared cache, which sits
+        behind this function and only changes where the bytes come from.
+        Created if a fetch is actually needed; a call that finds everything
+        cached touches nothing.
     on_fetch
         Called with the filename immediately before each real download, and
-        never when the cache is warm. Callers use it for one-time warnings
-        that only make sense when the asset is genuinely being fetched (see
-        make_bc's downsampling warning). Keep it cheap and idempotent.
+        never when either cache is warm. Callers use it for one-time
+        warnings that only make sense when the asset is genuinely being
+        fetched (see make_bc's downsampling warning). Keep it cheap and
+        idempotent.
 
     Raises
     ------
@@ -95,6 +607,7 @@ def fetch_assets(
         if dest.exists():
             actual = dest.stat().st_size
             if actual == meta["size"]:
+                _adopt_destination(dest, filename, meta)
                 continue
             logger.warning(
                 "Cached %s is %d bytes, expected %d -- it is truncated or "
@@ -105,68 +618,22 @@ def fetch_assets(
             )
             dest.unlink()
 
+        if _fetch_via_cache(filename, meta, dest, on_fetch):
+            logger.info(f"Saved {filename} to {dest}")
+            continue
+
+        # No usable shared cache: download straight into the destination,
+        # exactly as this function did before the cache existed.
         if on_fetch is not None:
             on_fetch(filename)
 
         logger.info(f"Downloading {filename} from Zenodo...")
         dest_dir.mkdir(parents=True, exist_ok=True)
         part = dest.with_name(dest.name + ".part")
-
-        # Retried with backoff. Zenodo is a free academic host serving a 250 MB
-        # file, and it returns 5xx under load -- observed as
-        # `HTTPError: HTTP Error 504: Gateway Time-out` failing CI on pull
-        # requests that had touched nothing related. A transient gateway error
-        # should cost a few seconds, not a whole run.
-        #
-        # Only transport and integrity errors are retried. A 404 means the URL
-        # or record is wrong, and retrying that just delays a real failure by
-        # _RETRY_BACKOFF seconds, so it is re-raised at once.
-        last_error = None
-        for attempt in range(1, _DOWNLOAD_ATTEMPTS + 1):
-            try:
-                urllib.request.urlretrieve(meta["url"], part)
-                size = part.stat().st_size
-                if size != meta["size"]:
-                    raise RuntimeError(
-                        f"{filename} downloaded {size} bytes, expected "
-                        f"{meta['size']}. The download was truncated; retry."
-                    )
-                digest = _md5(part)
-                if digest != meta["md5"]:
-                    raise RuntimeError(
-                        f"{filename} has md5 {digest}, expected "
-                        f"{meta['md5']}. The file on Zenodo may have been "
-                        f"replaced, or the download was corrupted."
-                    )
-                part.replace(dest)  # atomic within the same directory
-                last_error = None
-                break
-            except urllib.error.HTTPError as e:
-                if e.code < 500:
-                    raise
-                last_error = e
-            except (urllib.error.URLError, TimeoutError, RuntimeError) as e:
-                last_error = e
-            finally:
-                part.unlink(missing_ok=True)
-
-            if attempt < _DOWNLOAD_ATTEMPTS:
-                delay = _RETRY_BACKOFF * 2 ** (attempt - 1)
-                logger.warning(
-                    "Download of %s failed (attempt %d/%d): %s. "
-                    "Retrying in %ds.",
-                    filename,
-                    attempt,
-                    _DOWNLOAD_ATTEMPTS,
-                    last_error,
-                    delay,
-                )
-                time.sleep(delay)
-
-        if last_error is not None:
-            raise RuntimeError(
-                f"Could not download {filename} from Zenodo after "
-                f"{_DOWNLOAD_ATTEMPTS} attempts: {last_error}"
-            ) from last_error
+        try:
+            _download_verified(meta, filename, part)
+            part.replace(dest)  # atomic within the same directory
+        finally:
+            part.unlink(missing_ok=True)
 
         logger.info(f"Saved {filename} to {dest}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,32 @@ requires_fork = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_shared_download_cache(monkeypatch):
+    """Keep the machine-level Zenodo cache out of the test suite by default.
+
+    utilities/zenodo.py caches large downloads under ~/.cache/exozippy and
+    adopts an already-present destination into it. Both are exactly what we
+    want in a fit and exactly what we do not want in a test: the suite would
+    md5 (and possibly copy) the real 250 MB NextGen spectra, and tests using
+    fake payloads would leave entries in the developer's own cache.
+
+    Tests that exercise the cache opt back in by pointing EXOZIPPY_CACHE_DIR
+    at a tmp_path of their own; with it switched off here, everything else
+    behaves exactly as it did before the cache existed. The module-level
+    latches are reset too, so one test's unwritable-cache warning cannot
+    leak into the next.
+    """
+    from exozippy.utilities import zenodo
+
+    monkeypatch.setenv("EXOZIPPY_CACHE_DIR", "")
+    # raising=False so this fixture keeps working against a zenodo.py that
+    # predates the cache (bisects, and the pre-fix run that proves the cache
+    # tests really do fail without it).
+    monkeypatch.setattr(zenodo, "_cache_disabled_reason", None, raising=False)
+    monkeypatch.setattr(zenodo, "_adoption_attempted", set(), raising=False)
+
+
 class _DummyConfigManager:
     """Minimal ConfigManager stub for tests that only need a no-op hint interface."""
 

--- a/tests/test_zenodo_fetch.py
+++ b/tests/test_zenodo_fetch.py
@@ -4,14 +4,24 @@ Tests for the shared Zenodo fetch-verify-cache core
 (components/sed/make_bc.ensure_model_data, models/MIST/eep_grid).
 
 Nothing here touches the network: urlretrieve is always monkeypatched.
+
+The machine-level cache is switched off for the whole suite by conftest's
+autouse _no_shared_download_cache fixture, so every test that is not about
+the cache sees exactly the pre-cache behaviour. The cache tests below opt
+back in with the `cache_root` fixture.
 """
 
+import errno
 import hashlib
+import multiprocessing
+import os
+import time
 import urllib.error
 from pathlib import Path
 
 import pytest
 
+from conftest import requires_fork
 from exozippy.utilities import zenodo
 
 
@@ -24,6 +34,23 @@ def _fake_assets(payload=b"hello", name="f.csv"):
             "md5": hashlib.md5(payload).hexdigest(),
         }
     }
+
+
+@pytest.fixture
+def cache_root(tmp_path, monkeypatch):
+    """Point the machine-level cache at a private directory and enable it."""
+    root = tmp_path / "xdg-cache" / "exozippy"
+    monkeypatch.setenv("EXOZIPPY_CACHE_DIR", str(root))
+    return root
+
+
+def _entry_of(cache_root, assets, name="f.csv"):
+    """Where the cache keeps `name`: content-addressed by its pinned md5."""
+    return Path(cache_root) / "downloads" / f"{assets[name]['md5']}-{name}"
+
+
+def _refuse_to_download(url, dest):
+    raise AssertionError(f"network access attempted for {url}")
 
 
 # --- retry / failure behavior --------------------------------------------
@@ -252,6 +279,396 @@ def test_a_truncated_cached_file_is_refetched_not_raised(
     assert (tmp_path / "f.csv").read_bytes() == payload
 
 
+# --- the machine-level shared cache ---------------------------------------
+
+
+def test_cache_location_follows_xdg_and_the_env_override(monkeypatch):
+    """
+    Given the usual environments,
+    When the cache root is resolved,
+    Then it is $XDG_CACHE_HOME/exozippy, ~/.cache/exozippy without XDG, the
+    override when EXOZIPPY_CACHE_DIR is set, and None when it is switched
+    off -- never a temp filesystem someone's /tmp cannot hold 250 MB in.
+    """
+    # ARRANGE / ACT / ASSERT
+    monkeypatch.delenv("EXOZIPPY_CACHE_DIR", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", "/xdg")
+    assert zenodo.shared_cache_root() == Path("/xdg/exozippy")
+
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    assert zenodo.shared_cache_root() == Path.home() / ".cache" / "exozippy"
+
+    monkeypatch.setenv("EXOZIPPY_CACHE_DIR", "/scratch/mine")
+    assert zenodo.shared_cache_root() == Path("/scratch/mine")
+
+    for off in ("", "none", "0", "OFF"):
+        monkeypatch.setenv("EXOZIPPY_CACHE_DIR", off)
+        assert zenodo.shared_cache_root() is None
+
+
+def test_a_second_destination_is_served_from_the_cache_with_no_network(
+    tmp_path, cache_root, monkeypatch
+):
+    """
+    Given one destination has already been populated on this machine,
+    When a second destination (a second worktree) asks for the same asset,
+    Then it is served from the machine-level cache without any download.
+
+    This is the whole point: a dozen worktrees used to mean a dozen 250 MB
+    fetches from a free academic host.
+    """
+    # ARRANGE
+    payload = b"hello"
+    assets = _fake_assets(payload)
+    downloads = []
+
+    def counting(url, dest):
+        downloads.append(url)
+        Path(dest).write_bytes(payload)
+
+    monkeypatch.setattr(zenodo.urllib.request, "urlretrieve", counting)
+    first = tmp_path / "worktree_a" / "BCs"
+    zenodo.fetch_assets(assets, first)
+    assert len(downloads) == 1
+
+    # ACT -- a fetcher that would blow up if it were called at all
+    monkeypatch.setattr(
+        zenodo.urllib.request, "urlretrieve", _refuse_to_download
+    )
+    second = tmp_path / "worktree_b" / "BCs"
+    fetched = []
+    zenodo.fetch_assets(assets, second, on_fetch=fetched.append)
+
+    # ASSERT
+    assert (second / "f.csv").read_bytes() == payload
+    assert len(downloads) == 1, "the second worktree re-downloaded"
+    assert fetched == [], "a shared-cache hit is a cache hit, not a fetch"
+    assert _entry_of(cache_root, assets).exists()
+
+
+def test_the_cache_hard_links_so_n_worktrees_cost_one_copy(
+    tmp_path, cache_root, monkeypatch
+):
+    """
+    Given a cache on the same filesystem as the destinations,
+    When two destinations are populated,
+    Then all three paths are the same inode -- one copy on disk, one file
+    against the user's quota, however many worktrees there are.
+    """
+    # ARRANGE
+    payload = b"hello"
+    assets = _fake_assets(payload)
+    monkeypatch.setattr(
+        zenodo.urllib.request,
+        "urlretrieve",
+        lambda url, dest: Path(dest).write_bytes(payload),
+    )
+
+    # ACT
+    zenodo.fetch_assets(assets, tmp_path / "a")
+    zenodo.fetch_assets(assets, tmp_path / "b")
+
+    # ASSERT
+    entry = _entry_of(cache_root, assets)
+    a, b = tmp_path / "a" / "f.csv", tmp_path / "b" / "f.csv"
+    assert a.stat().st_ino == entry.stat().st_ino
+    assert b.stat().st_ino == entry.stat().st_ino
+    assert entry.stat().st_nlink == 3
+    assert b.read_bytes() == payload
+
+
+def test_it_copies_when_the_filesystems_do_not_allow_a_hard_link(
+    tmp_path, cache_root, monkeypatch
+):
+    """
+    Given the cache and the destination are on different filesystems
+    (os.link raising EXDEV -- the case detected by simply trying it),
+    When the asset is materialized,
+    Then it is copied instead, and the copy is a distinct, intact file.
+    """
+    # ARRANGE
+    payload = b"hello"
+    assets = _fake_assets(payload)
+    monkeypatch.setattr(
+        zenodo.urllib.request,
+        "urlretrieve",
+        lambda url, dest: Path(dest).write_bytes(payload),
+    )
+
+    def cross_device(src, dst):
+        raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+    monkeypatch.setattr(zenodo.os, "link", cross_device)
+
+    # ACT
+    zenodo.fetch_assets(assets, tmp_path / "a")
+
+    # ASSERT
+    entry = _entry_of(cache_root, assets)
+    dest = tmp_path / "a" / "f.csv"
+    assert dest.read_bytes() == payload
+    assert dest.stat().st_ino != entry.stat().st_ino, "expected a real copy"
+    assert entry.read_bytes() == payload
+
+
+def test_a_corrupt_cache_entry_is_refetched_not_propagated(
+    tmp_path, cache_root, monkeypatch
+):
+    """
+    Given a shared-cache entry with the right size but the wrong bytes,
+    When a destination asks for the asset,
+    Then the md5 check rejects the entry, the asset is re-downloaded, and
+    both the destination and the repaired entry hold the real payload.
+
+    A shared cache concentrates the truncated-download failure -- one bad
+    entry would otherwise poison every worktree on the machine at once --
+    so it is verified in full, not on size alone, every time it is adopted.
+    """
+    # ARRANGE
+    payload = b"hello"
+    assets = _fake_assets(payload)
+    entry = _entry_of(cache_root, assets)
+    entry.parent.mkdir(parents=True)
+    entry.write_bytes(b"world")  # same length, wrong content
+
+    downloads = []
+
+    def counting(url, dest):
+        downloads.append(url)
+        Path(dest).write_bytes(payload)
+
+    monkeypatch.setattr(zenodo.urllib.request, "urlretrieve", counting)
+
+    # ACT
+    zenodo.fetch_assets(assets, tmp_path / "a")
+
+    # ASSERT
+    assert (tmp_path / "a" / "f.csv").read_bytes() == payload
+    assert len(downloads) == 1, "a corrupt entry must be re-fetched"
+    assert entry.read_bytes() == payload, "the entry must be repaired"
+
+
+def test_a_truncated_cache_entry_is_refetched(
+    tmp_path, cache_root, monkeypatch
+):
+    """
+    Given a shared-cache entry left short by a crashed writer,
+    When a destination asks for the asset,
+    Then the size check rejects it and it is re-downloaded.
+    """
+    # ARRANGE
+    payload = b"hello"
+    assets = _fake_assets(payload)
+    entry = _entry_of(cache_root, assets)
+    entry.parent.mkdir(parents=True)
+    entry.write_bytes(b"hel")
+
+    monkeypatch.setattr(
+        zenodo.urllib.request,
+        "urlretrieve",
+        lambda url, dest: Path(dest).write_bytes(payload),
+    )
+
+    # ACT
+    zenodo.fetch_assets(assets, tmp_path / "a")
+
+    # ASSERT
+    assert (tmp_path / "a" / "f.csv").read_bytes() == payload
+    assert entry.read_bytes() == payload
+
+
+def test_the_destination_never_sees_a_partial_file_via_the_cache(
+    tmp_path, cache_root, monkeypatch
+):
+    """
+    Given a download in progress through the shared cache,
+    When fetch_assets writes it,
+    Then the bytes land on a .part file inside the cache directory and
+    neither the cache entry nor the destination exists until size and md5
+    have been verified.
+
+    Same staging guarantee as the no-cache path, one directory further
+    back: the rename into the cache is what makes a concurrent reader see
+    all-or-nothing.
+    """
+    # ARRANGE
+    payload = b"hello"
+    assets = _fake_assets(payload)
+    entry = _entry_of(cache_root, assets)
+    seen = {}
+
+    def observant(url, dest):
+        dest = Path(dest)
+        seen["staged_in_cache"] = dest.parent == entry.parent
+        seen["suffix"] = dest.suffix
+        dest.write_bytes(payload)
+        seen["entry_exists_during"] = entry.exists()
+        seen["dest_exists_during"] = (tmp_path / "a" / "f.csv").exists()
+
+    monkeypatch.setattr(zenodo.urllib.request, "urlretrieve", observant)
+
+    # ACT
+    zenodo.fetch_assets(assets, tmp_path / "a")
+
+    # ASSERT
+    assert seen["staged_in_cache"] is True
+    assert seen["suffix"] == ".part"
+    assert seen["entry_exists_during"] is False
+    assert seen["dest_exists_during"] is False
+    assert not list(entry.parent.glob("*.part"))
+
+
+def test_an_existing_destination_is_adopted_into_the_cache(
+    tmp_path, cache_root, monkeypatch
+):
+    """
+    Given a checkout that already holds the asset (every worktree created
+    before this cache existed does),
+    When fetch_assets is called there and then in a fresh worktree,
+    Then the existing file is hard-linked into the cache and serves the new
+    worktree -- the ~250 MB already on disk is adopted, not re-downloaded.
+    """
+    # ARRANGE
+    payload = b"hello"
+    assets = _fake_assets(payload)
+    old = tmp_path / "old_worktree"
+    old.mkdir()
+    (old / "f.csv").write_bytes(payload)
+    monkeypatch.setattr(
+        zenodo.urllib.request, "urlretrieve", _refuse_to_download
+    )
+
+    # ACT
+    zenodo.fetch_assets(assets, old)  # warm destination: adopt, do not fetch
+    zenodo.fetch_assets(assets, tmp_path / "new_worktree")
+
+    # ASSERT
+    entry = _entry_of(cache_root, assets)
+    assert entry.read_bytes() == payload
+    assert (tmp_path / "new_worktree" / "f.csv").read_bytes() == payload
+    assert entry.stat().st_ino == (old / "f.csv").stat().st_ino
+
+
+def test_a_destination_with_the_wrong_md5_is_not_adopted(
+    tmp_path, cache_root, monkeypatch, caplog
+):
+    """
+    Given a destination file of the right size but the wrong content,
+    When it is considered for adoption,
+    Then it is left alone (that is the pre-cache behaviour) but is NOT
+    published to the cache, so one bad local file cannot poison the
+    machine.
+    """
+    # ARRANGE
+    payload = b"hello"
+    assets = _fake_assets(payload)
+    old = tmp_path / "old"
+    old.mkdir()
+    (old / "f.csv").write_bytes(b"world")
+    monkeypatch.setattr(
+        zenodo.urllib.request, "urlretrieve", _refuse_to_download
+    )
+
+    # ACT
+    with caplog.at_level("WARNING"):
+        zenodo.fetch_assets(assets, old)
+
+    # ASSERT
+    assert not _entry_of(cache_root, assets).exists()
+    assert any("shared cache" in r.getMessage() for r in caplog.records)
+
+
+def test_an_unwritable_cache_degrades_to_a_plain_download(
+    tmp_path, monkeypatch, caplog
+):
+    """
+    Given a cache directory that cannot be created (read-only parent),
+    When fetch_assets runs,
+    Then it warns once and downloads straight to the destination, exactly
+    as it did before the cache existed. A cache is an optimization; it must
+    never fail a fit.
+    """
+    # ARRANGE
+    if os.geteuid() == 0:
+        pytest.skip("root ignores directory permissions")
+    locked = tmp_path / "locked"
+    locked.mkdir(mode=0o500)
+    monkeypatch.setenv("EXOZIPPY_CACHE_DIR", str(locked / "exozippy"))
+
+    payload = b"hello"
+    assets = _fake_assets(payload)
+    fetched = []
+
+    def observant(url, dest):
+        assert Path(dest).name == "f.csv.part", "expected the legacy staging"
+        Path(dest).write_bytes(payload)
+
+    monkeypatch.setattr(zenodo.urllib.request, "urlretrieve", observant)
+
+    # ACT
+    with caplog.at_level("WARNING"):
+        zenodo.fetch_assets(assets, tmp_path / "a", on_fetch=fetched.append)
+
+    # ASSERT
+    assert (tmp_path / "a" / "f.csv").read_bytes() == payload
+    assert fetched == ["f.csv"]
+    assert any(
+        "cache unavailable" in r.getMessage() for r in caplog.records
+    ), "an unusable cache must say so once"
+
+
+@requires_fork
+def test_concurrent_fetches_download_once_and_never_tear_the_entry(
+    tmp_path, cache_root, monkeypatch
+):
+    """
+    Given four processes (parallel agents, or four worktrees at once) racing
+    for the same asset,
+    When they all call fetch_assets,
+    Then the flock around the cache entry means exactly one download, every
+    destination is intact, and no .part or .link debris is left behind.
+    """
+    # ARRANGE
+    payload = b"payload-bytes" * 64
+    assets = _fake_assets(payload)
+    counter = tmp_path / "downloads.log"
+    counter.write_bytes(b"")
+
+    def slow_download(url, dest):
+        with open(counter, "ab") as f:  # O_APPEND: atomic for one small write
+            f.write(b"x")
+        time.sleep(0.5)  # long enough for the others to pile up on the lock
+        Path(dest).write_bytes(payload)
+
+    monkeypatch.setattr(zenodo.urllib.request, "urlretrieve", slow_download)
+
+    dests = [tmp_path / f"worktree{i}" for i in range(4)]
+
+    def child(dest_dir):
+        zenodo.fetch_assets(assets, dest_dir)
+
+    ctx = multiprocessing.get_context("fork")
+
+    # ACT
+    procs = [ctx.Process(target=child, args=(d,)) for d in dests]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(120)
+
+    # ASSERT
+    assert [p.exitcode for p in procs] == [0, 0, 0, 0]
+    for d in dests:
+        assert (d / "f.csv").read_bytes() == payload
+    entry = _entry_of(cache_root, assets)
+    assert entry.read_bytes() == payload
+    assert counter.stat().st_size == 1, (
+        f"{counter.stat().st_size} processes downloaded the same asset; "
+        "the cache lock did not serialize them"
+    )
+    assert not list(entry.parent.glob("*.part"))
+
+
 # --- the two wrappers -----------------------------------------------------
 
 
@@ -322,6 +739,43 @@ def test_mist_grid_fetch_does_not_emit_the_spectra_warning(
     assert path == tmp_path / "afe_p0_vvcrit0.0.grid.parquet"
     assert path.read_bytes() == payload
     assert not [r for r in caplog.records if "DOWNSAMPLED" in r.getMessage()]
+
+
+def test_the_mist_grid_shares_the_machine_cache_too(
+    tmp_path, cache_root, monkeypatch
+):
+    """
+    Given the EEP grid has been fetched once on this machine,
+    When a second checkout's EEP_GRID_DIR asks for it,
+    Then it comes from the shared cache with no download -- the second
+    caller of fetch_assets gets the cache for free, with no code of its own.
+    """
+    # ARRANGE
+    from exozippy.models.MIST import eep_grid
+
+    payload = b"parquet-bytes"
+    name = "afe_p0_vvcrit0.0.grid.parquet"
+    assets = _fake_assets(payload, name=name)
+    monkeypatch.setattr(eep_grid, "_EEP_GRID_ASSETS", assets)
+    monkeypatch.setattr(eep_grid, "EEP_GRID_DIR", tmp_path / "checkout_a")
+    monkeypatch.setattr(
+        zenodo.urllib.request,
+        "urlretrieve",
+        lambda url, dest: Path(dest).write_bytes(payload),
+    )
+    eep_grid.ensure_eep_grid()
+
+    # ACT
+    monkeypatch.setattr(eep_grid, "EEP_GRID_DIR", tmp_path / "checkout_b")
+    monkeypatch.setattr(
+        zenodo.urllib.request, "urlretrieve", _refuse_to_download
+    )
+    path = eep_grid.ensure_eep_grid()
+
+    # ASSERT
+    assert path == tmp_path / "checkout_b" / name
+    assert path.read_bytes() == payload
+    assert _entry_of(cache_root, assets, name=name).exists()
 
 
 def test_mist_grid_is_not_refetched_when_already_cached(tmp_path, monkeypatch):


### PR DESCRIPTION
`fetch_assets` caches into a path derived from the *source tree*, so every git worktree downloads its own copy. The NextGen spectra alone are **249 MB**, and heavy development means a lot of worktrees -- over 1 GB of duplicate transfers currently sitting across four of them, each one re-fetched from Zenodo, which is a free academic host that `zenodo.py`'s own retry comment already notes 5xx-es under load.

This adds a machine-level cache **behind** `fetch_assets`. Destinations are unchanged -- `{model_root}/{model}/BCs` and `EEP_GRID_DIR` are still what gets populated, just from a link instead of a download. Both callers (`make_bc`, MIST `eep_grid`) benefit with no code of their own; a test pins that for MIST.

## Location

`$XDG_CACHE_HOME/exozippy/downloads`, falling back to `~/.cache/exozippy/downloads`. `EXOZIPPY_CACHE_DIR` relocates it; `""` / `none` / `off` / `0` switches it off. Entries are content-addressed, `<md5>-<filename>`, so two assets cannot collide, a re-upload gets a fresh entry, and a stale one is inert rather than wrong.

## Link vs copy, and why detection is by trying

`os.link` first, `shutil.copyfile` on any `OSError`. Detection is deliberately **not** an `st_dev` comparison, because on the development box that would give the wrong answer both ways: `stat()` reports `st_dev` 2049 for both `~/.cache` and `/pool/radish1` yet the link is refused, and reports 60 for a file whose own directory links fine. `EXDEV` is only the expected failure; `EPERM`/`EMLINK`/`EOPNOTSUPP` all occur on network and container filesystems and all mean the same thing here. The copy path logs a line naming `EXOZIPPY_CACHE_DIR`, since co-locating the cache is the user's fix.

## Concurrency

An `flock` on `<entry>.lock` serializes fetches of one asset, so parallel processes download it once. The kernel drops it when the holder exits, crashed or not, so there is no stale-lock recovery to get wrong.

It is **best effort by construction**: a filesystem that does not support locks is discriminated by errno (so it never polls for 15 minutes -- that would be a hang, not a safeguard) and proceeds unlocked, as does the timeout. That is safe because publishing is an atomic rename of a fully verified file: a concurrent reader sees either no entry or a complete one, never a partial write. Worst case is a duplicated download, never a torn entry. Pinned by a 4-process fork test asserting exactly one download and four intact destinations.

## Integrity

The shared entry is verified in full -- size **and** md5, not size alone -- every time it is adopted into a new destination. That is deliberately stricter than the destination's own per-call size check, because one corrupt entry here would be linked into every worktree on the machine at once. A failure discards the entry, re-downloads, and repairs it.

A hard link is the same inode as the verified entry, so it is intact by construction; a cross-filesystem copy is fresh bytes and gets the same md5 check a fresh download would have got. Entries are published mode `0444`, so an in-place write through any link cannot corrupt the shared copy.

An unwritable or absent cache degrades to the pre-cache path with one warning, latched per process. If the cache refuses a good download, the 250 MB transfer is used rather than thrown away.

## Adopting the copies already on disk

A destination already holding the asset at the pinned size and md5 is published into the cache instead of being re-downloaded -- an md5 once per process is far cheaper than a quarter-gigabyte transfer. Verified live against the real 249 MB `NextGen.spectra.csv` with `urlretrieve` patched to raise: adopted in 3.3 s, and a fresh destination then materialized from it in 0.5 s with no network.

A destination that is the pinned size but **not** the pinned md5 is left alone (it is what that tree has always used) and explicitly *not* adopted, with a warning saying to delete it to force a clean re-download.

## Tests

`tests/test_zenodo_fetch.py`: 24 pass, 12 new. On the pre-fix `zenodo.py`: **12 failed, 12 passed** -- every new test fails, every old one still passes. Existing assertions untouched, including the `.part`-then-rename staging test.

A new autouse `conftest.py` fixture switches the cache off for the suite, so nothing else changes behaviour and no test writes into a developer's real `~/.cache`; cache tests opt back in by pointing `EXOZIPPY_CACHE_DIR` at their own `tmp_path`. `tests/test_sed.py` (50 passed) checks that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
