### PR TITLE
evidence: count unsupported proposal draws instead of dropping them (review 3.16)

### DIFF
--- a/src/exozippy/outputs/evidence.py
+++ b/src/exozippy/outputs/evidence.py
@@ -41,6 +41,10 @@ outputs.modes already clusters on):
      falls back to occupancy for the whole report (softmax evidence weights
      need every mode's lnZ, so a single refusal invalidates the set).
 
+     A proposal draw at which the target logp is NOT FINITE is refusal
+     evidence too, and is handled here rather than thrown away -- see the
+     "Unsupported proposal draws" note below.
+
      That bound-pileup case is exactly what a warp would fix, and is the
      obvious next step if refusals prove common: Warp-III (Meng & Schilling
      2002) symmetrizes the target about its mode by mixing x with 2*mu - x,
@@ -50,6 +54,31 @@ outputs.modes already clusters on):
 
   5. Weights.  Accepted lnZ_k -> softmax weights w_k; lnZ error bars propagate
      to softmax weight uncertainties dw_k by linearization.
+
+Unsupported proposal draws
+--------------------------
+The fitted Gaussian is unbounded, so some of its draws can land where the
+target density is zero (logp = -inf) or where the logp evaluation fails
+(nan).  Those draws are NOT dropped.  Dropping them and renormalizing the
+proposal-side average over the survivors is exactly the estimator for a
+proposal truncated to the target's support, which is not the proposal that
+was drawn from: it inflates the numerator by N2 / N2_kept and biases lnZ
+UPWARD by log(N2 / N2_kept) per mode.  Worse, it defeats the very diagnostic
+meant to catch it -- the discarded draws are the ones with the smallest
+bridge function, so removing them LOWERS re2 and the proposal is reported as
+healthier than it is.
+
+The bridge identity already has the right value for such a draw: the optimal
+bridge function is p~/(s1 p~ + s2 Z q), which is exactly 0 where p~ = 0.  So
+an unsupported draw enters the proposal-side average as a zero, N2 stays the
+number of draws actually taken, lnZ stays unbiased, and the zeros widen the
+spread of the bridge function that re2 measures.
+
+That leaves a residual the error bar cannot express: a nan is a FAILED
+evaluation, not a demonstrated zero, and scoring it as zero density biases
+lnZ downward by up to log(1 / (1 - f)) nats for an unsupported fraction f.
+That systematic has no sign and no error bar, so past a threshold the mode is
+refused outright rather than reported (see DEFAULT_UNSUPPORTED_MAX).
 
 The logp evaluations reuse run.py's fork-parallel pattern (compiled PyTensor
 logp inherited by forked workers via copy-on-write; only numpy point arrays
@@ -62,7 +91,7 @@ NOT implemented here: they are lower priority than the bridge path and are
 
 import logging
 import multiprocessing as mp
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
 
@@ -79,6 +108,53 @@ logger = logging.getLogger(__name__)
 DEFAULT_RE2_MAX = 0.25
 
 
+# Refuse a mode when this fraction of its proposal draws land where the
+# target logp is not finite.
+#
+# Those draws are kept (as zero-density draws, which is their correct bridge
+# value -- see the module docstring), so lnZ itself stays unbiased and re2
+# does grow.  But the growth is only ~f / ((1 - f) N2): a purely Monte-Carlo
+# effect, invisible at N2 ~ 1e3 for any f a real fit produces.  re2 is
+# therefore the WRONG gate for this, and the honest one is the systematic the
+# error bar cannot carry: nan means the logp evaluation FAILED, not that the
+# density is demonstrably zero, so scoring the non-finite draws as zeros can
+# shift lnZ by up to log(1 / (1 - f)) nats in an undetermined direction.
+#
+# 0.10 caps that unquantified systematic at 0.105 nat -- five times tighter
+# than the 0.5-nat lnZ error bar at which re2_max already refuses, so it can
+# never be the loose gate of the two, and small enough that softmax weights
+# move by at most ~2.5 percentage points because of it.
+#
+# It is also far above what ordinary modes do.  Measured on real saved traces
+# (fit the proposal exactly as estimate_mode_evidences does, then count the
+# non-finite target logp among its draws):
+#
+#   KELT-4 RV-only (15 raw dims, 4 modes):        0 / 1933, 0 / 275,
+#                                                 0 / 164,  0 / 108
+#   DC2018_128 Roman binary lens (27 raw dims):   0 / 429,  0 / 424
+#
+# i.e. exactly zero on every mode of either fit, so 10% is not a threshold
+# ordinary modes come anywhere near.  A model with hard-edged derived
+# quantities (e < 1, a variance that can go negative) can produce a few
+# percent; 10% is not reachable without the fitted Gaussian genuinely
+# straddling an edge of the support, which is the case being refused.
+DEFAULT_UNSUPPORTED_MAX = 0.10
+
+
+# Outcome vocabulary for one mode's estimate, mirroring the four-state
+# hot-search reporting in outputs/ledger.py: "it worked", "it ran and the
+# diagnostics said no", and "it could not be attempted" must be
+# distinguishable in the report, never collapsed into a bare missing number.
+EV_OK = "ok"
+EV_REFUSED = "refused"  # generic: a result carrying no state of its own
+EV_NO_FREE_RVS = "no-free-rvs"
+EV_TOO_FEW_DRAWS = "too-few-draws"
+EV_UNSUPPORTED = "unsupported-proposal-mass"
+EV_INVALID_POSTERIOR = "invalid-posterior-draws"
+EV_NOT_CONVERGED = "not-converged"
+EV_RE2 = "re2-too-large"
+
+
 @dataclass
 class EvidenceResult:
     """Bridge-sampling result for one mode.
@@ -86,6 +162,14 @@ class EvidenceResult:
     lnZ / lnZ_err are the mode's local log-evidence relative to its proposal
     and its (relative-MSE-derived) error bar.  ``refused`` is True when the
     diagnostics could not support a confident answer; ``reason`` says why.
+
+    ``n_post`` / ``n_prop`` are the draw counts the estimate was actually
+    computed FROM, so the provenance line describes what was used and not
+    what was staged.  ``status`` carries the machine-readable outcome: a
+    ``state`` from the EV_* vocabulary plus the raw counts
+    (``n_prop_unsupported``, ``frac_unsupported``, ``n_post_invalid``, ...),
+    following the status-dict pattern outputs/ledger.py uses for the
+    hot-chain search.
     """
 
     mode: int
@@ -96,6 +180,19 @@ class EvidenceResult:
     n_prop: int
     refused: bool
     reason: str = ""
+    status: dict = field(default_factory=dict)
+
+    @property
+    def state(self):
+        """EV_* outcome label.
+
+        Falls back to the generic labels when ``status`` was never filled in
+        (a hand-built result), so a renderer never has to print an empty
+        bracket.
+        """
+        return self.status.get("state") or (
+            EV_REFUSED if self.refused else EV_OK
+        )
 
 
 # ----------------------------------------------------------------------
@@ -146,7 +243,14 @@ def _segments(values, mask, lengths):
     return out
 
 
-def bridge_lnZ(l1, l2, maxiter=1000, tol=DEFAULT_BRIDGE_RTOL, l1_chains=None):
+def bridge_lnZ(
+    l1,
+    l2,
+    maxiter=1000,
+    tol=DEFAULT_BRIDGE_RTOL,
+    l1_chains=None,
+    status=None,
+):
     """Optimal iterative bridge-sampling estimate of a log normalizing constant.
 
     Parameters
@@ -162,6 +266,13 @@ def bridge_lnZ(l1, l2, maxiter=1000, tol=DEFAULT_BRIDGE_RTOL, l1_chains=None):
     maxiter : maximum fixed-point iterations.
     tol : RELATIVE convergence tolerance on lr (see DEFAULT_BRIDGE_RTOL);
         the effective absolute threshold is ``tol * max(1, |lr|)``.
+    status : dict, optional -- filled in with the draw bookkeeping the caller
+        needs to judge the result: ``n_prop`` / ``n_prop_unsupported`` /
+        ``frac_unsupported`` (proposal draws taken, of which the target logp
+        was not finite), and ``n_post`` / ``n_post_invalid`` /
+        ``frac_post_invalid`` (posterior draws used, of which some had to be
+        discarded).  Same in/out dict convention as
+        outputs.ledger.discover_hot_modes.
 
     Returns
     -------
@@ -173,6 +284,14 @@ def bridge_lnZ(l1, l2, maxiter=1000, tol=DEFAULT_BRIDGE_RTOL, l1_chains=None):
 
     Notes
     -----
+    Non-finite entries of ``l2`` are proposal draws the target does not
+    support.  They are RETAINED at their correct bridge value of zero rather
+    than dropped -- dropping them renormalizes the proposal-side average over
+    a proposal nobody sampled from and biases lnZ up by log(N2 / N2_kept)
+    (see the module docstring).  Non-finite entries of ``l1`` have no such
+    correct value -- a draw the sampler produced cannot have zero target
+    density, so it is a failed evaluation -- and are discarded and counted.
+
     Everything downstream of the fixed point is computed **recentered by lr**.
     The textbook bridge diagnostic is written with
 
@@ -192,13 +311,35 @@ def bridge_lnZ(l1, l2, maxiter=1000, tol=DEFAULT_BRIDGE_RTOL, l1_chains=None):
     lnZ_err are exactly the quantities the unrecentered form intends, and
     reproduce it to float precision wherever it was representable at all.
     """
+    if status is None:
+        status = {}
     l1 = np.asarray(l1, dtype=float)
     l2 = np.asarray(l2, dtype=float)
     finite1 = np.isfinite(l1)
     finite2 = np.isfinite(l2)
+    n_prop_taken = int(l2.size)
+    n_unsupported = int(n_prop_taken - finite2.sum())
+    n_post_invalid = int(l1.size - finite1.sum())
+    # Posterior side: no valid substitute, so drop-and-count.
     l1 = l1[finite1]
-    l2 = l2[finite2]
+    # Proposal side: the target puts no mass there, and the optimal bridge
+    # function IS zero there, so keep the draw and let it count as a zero.
+    # -inf is the exact log of that zero and propagates correctly through
+    # both the fixed point (logaddexp) and the diagnostic (1/inf -> 0).
+    l2 = np.where(finite2, l2, -np.inf)
     N1, N2 = l1.size, l2.size
+    status.update(
+        n_prop=N2,
+        n_prop_unsupported=n_unsupported,
+        frac_unsupported=(n_unsupported / N2 if N2 else 0.0),
+        n_post=N1,
+        n_post_invalid=n_post_invalid,
+        frac_post_invalid=(
+            n_post_invalid / (N1 + n_post_invalid)
+            if (N1 + n_post_invalid)
+            else 0.0
+        ),
+    )
     if N1 < 2 or N2 < 2:
         return np.nan, np.inf, np.inf, False
 
@@ -314,10 +455,11 @@ def _ev_eval_block(args):
         row = block[i]
         point = {}
         for vname, start, size, shape in _EV_LAYOUT:
-            seg = row[start : start + size]
-            point[vname] = (
-                seg.reshape(shape) if len(shape) else np.atleast_1d(seg)
-            )
+            # ``shape`` is the VALUE VARIABLE's shape, not the trace's -- see
+            # _build_layout.  pymc's compiled logp checks ndim exactly and the
+            # except below swallows the mismatch as a nan, so getting this
+            # wrong refuses every mode of a whole model type silently.
+            point[vname] = row[start : start + size].reshape(shape)
         try:
             out[i] = float(_EV_LP_FN(point))
         except Exception:
@@ -331,6 +473,17 @@ def _build_layout(model, idata):
     Returns (layout, D) where layout is a list of
     (rv_name, value_name, start, size, shape) and D is the total dimension.
     rv_name indexes idata.posterior; value_name is the logp_fn input key.
+
+    ``size`` comes from the trace (it is just an element count) but ``shape``
+    is reconciled against the VALUE VARIABLE, because the two disagree in a
+    case every real fit hits: an EXOZIPPy Parameter with one element is a
+    length-1 vector RV, ``shape=(1,)``, and the trace stores it SQUEEZED to
+    0-d.  pymc's compiled logp checks ndim exactly and _ev_eval_block's broad
+    except turns the mismatch into a nan, so taking the shape from the trace
+    would silently nan every draw of every one-element parameter -- and
+    taking it from the trace unconditionally likewise breaks a genuinely 0-d
+    RV in the other direction.  Neither failure is visible except as a mode
+    refused for a reason that is not the real one.
     """
     layout = []
     start = 0
@@ -339,8 +492,22 @@ def _build_layout(model, idata):
         vv = model.rvs_to_values.get(rv)
         if vv is None or rv.name not in post.data_vars:
             continue
-        shape = tuple(post[rv.name].shape[2:])
-        size = int(np.prod(shape)) if shape else 1
+        trace_shape = tuple(post[rv.name].shape[2:])
+        size = int(np.prod(trace_shape)) if trace_shape else 1
+        ndim = vv.type.ndim
+        if ndim == len(trace_shape):
+            shape = trace_shape
+        elif ndim == 0:
+            shape = ()  # trace kept a length-1 axis the model does not have
+        elif ndim == 1:
+            shape = (size,)  # trace squeezed the model's length-1 vector
+        else:
+            static = tuple(rv.type.shape)
+            shape = (
+                static
+                if len(static) == ndim and None not in static
+                else trace_shape
+            )
         layout.append((rv.name, vv.name, start, size, shape))
         start += size
     return layout, start
@@ -459,6 +626,7 @@ def estimate_mode_evidences(
     n_proposal=None,
     max_posterior_draws=4000,
     re2_max=DEFAULT_RE2_MAX,
+    unsupported_max=DEFAULT_UNSUPPORTED_MAX,
     seed=20260712,
 ):
     """Estimate each mode's local evidence by bridge sampling.
@@ -478,6 +646,10 @@ def estimate_mode_evidences(
         many for the (many) logp evaluations.  Thinning is a per-chain stride
         so the retained draws stay a time series (see _mode_draw_index).
     re2_max : refuse a mode whose bridge relative-MSE exceeds this.
+    unsupported_max : refuse a mode when more than this fraction of its
+        proposal draws land where the target logp is not finite (see
+        DEFAULT_UNSUPPORTED_MAX).  Those draws are counted and kept as
+        zero-density draws either way -- they are never dropped.
     seed : RNG seed for reproducible proposal draws.
 
     Returns
@@ -504,7 +676,15 @@ def estimate_mode_evidences(
         for k in range(mode_report.n_modes):
             results.append(
                 EvidenceResult(
-                    k, np.nan, np.inf, np.inf, 0, 0, True, "no usable free RVs"
+                    k,
+                    np.nan,
+                    np.inf,
+                    np.inf,
+                    0,
+                    0,
+                    True,
+                    "no usable free RVs",
+                    {"state": EV_NO_FREE_RVS},
                 )
             )
         return results
@@ -553,6 +733,7 @@ def estimate_mode_evidences(
                     0,
                     True,
                     "too few draws to fit a proposal",
+                    {"state": EV_TOO_FEW_DRAWS},
                 )
             )
             continue
@@ -567,33 +748,94 @@ def estimate_mode_evidences(
         l1 = logp1 - logq1
         l2 = logp2 - logq2
 
+        status = {}
         lnZ, lnZ_err, re2, converged = bridge_lnZ(
-            l1, l2, l1_chains=chain_lengths
+            l1, l2, l1_chains=chain_lengths, status=status
         )
 
+        n_unsup = status.get("n_prop_unsupported", 0)
+        frac_unsup = status.get("frac_unsupported", 0.0)
+        n_bad_post = status.get("n_post_invalid", 0)
+        frac_bad_post = status.get("frac_post_invalid", 0.0)
+        # The counts above are already IN the estimate: the unsupported
+        # proposal draws entered the bridge average as zeros (unbiased lnZ,
+        # and their spread is inside re2).  What follows decides whether the
+        # part of them that cannot be quantified -- a nan is a failed
+        # evaluation, not a demonstrated zero -- is too large to report
+        # around.  See DEFAULT_UNSUPPORTED_MAX.
         refused = False
         reason = ""
-        if not converged or not np.isfinite(lnZ):
-            refused, reason = True, "bridge iteration did not converge"
+        state = EV_OK
+        # Posterior side first: a draw the sampler produced cannot have zero
+        # target density, so a non-finite logp there is an unambiguous
+        # EVALUATION failure and diagnoses itself.  Reading such a run as a
+        # proposal-support problem would name the wrong cause -- and when the
+        # evaluation is broken, the proposal side is non-finite too.
+        if frac_bad_post > unsupported_max:
+            refused = True
+            state = EV_INVALID_POSTERIOR
+            reason = (
+                f"{n_bad_post} of {n_bad_post + n1} posterior draws "
+                f"({frac_bad_post:.1%}) re-evaluated to a non-finite logp, "
+                f"above the {unsupported_max:.0%} limit; a draw the sampler "
+                f"produced cannot have zero target density, so these are "
+                f"failed evaluations and the mode's draws cannot be trusted"
+            )
+        elif frac_unsup > unsupported_max:
+            refused = True
+            state = EV_UNSUPPORTED
+            # log1p(-1) is -inf, and an all-unsupported proposal is exactly
+            # the case that reaches this; say inf rather than warn.
+            syst = (
+                np.inf if frac_unsup >= 1.0 else float(-np.log1p(-frac_unsup))
+            )
+            reason = (
+                f"{n_unsup} of {n2} proposal draws ({frac_unsup:.1%}) land "
+                f"where the target logp is not finite, over the "
+                f"{unsupported_max:.0%} limit: the fitted Gaussian puts mass "
+                f"outside the target's support, and lnZ then carries up to "
+                f"{syst:.2f} nat of systematic that no error bar covers"
+            )
+        elif not converged or not np.isfinite(lnZ):
+            refused, state = True, EV_NOT_CONVERGED
+            reason = "bridge iteration did not converge"
         elif not np.isfinite(re2) or re2 > re2_max:
             refused = True
+            state = EV_RE2
             reason = (
                 f"relative-MSE diagnostic re2={re2:.3g} exceeds "
                 f"{re2_max:g} (proposal poorly supports the target -- "
                 f"likely a bound pileup); lnZ error bar ~{lnZ_err:.2g} nat"
             )
+        status["state"] = state
         results.append(
-            EvidenceResult(k, lnZ, lnZ_err, re2, n1, n2, refused, reason)
+            EvidenceResult(
+                k,
+                lnZ,
+                lnZ_err,
+                re2,
+                status.get("n_post", n1),
+                status.get("n_prop", n2),
+                refused,
+                reason,
+                status,
+            )
         )
         if refused:
-            logger.warning("evidence: mode %d refused (%s)", k + 1, reason)
+            logger.warning(
+                "evidence: mode %d refused [%s] (%s)", k + 1, state, reason
+            )
         else:
             logger.info(
-                "evidence: mode %d lnZ=%.3f +/- %.3f (re2=%.3g)",
+                "evidence: mode %d lnZ=%.3f +/- %.3f (re2=%.3g, "
+                "N_post=%d, N_prop=%d of which %d unsupported)",
                 k + 1,
                 lnZ,
                 lnZ_err,
                 re2,
+                status.get("n_post", n1),
+                status.get("n_prop", n2),
+                n_unsup,
             )
     return results
 
@@ -613,6 +855,34 @@ def softmax_weights(lnZ, lnZ_err):
         jac = w[k] * ((np.arange(w.size) == k).astype(float) - w)
         dw[k] = np.sqrt(np.sum((jac * err) ** 2))
     return w, dw
+
+
+def evidence_status_to_text(results):
+    """One human-readable line per mode's estimate outcome.
+
+    Rendered into the mode report so a reader can tell an estimate that ran
+    and was believed from one that ran and was refused, and WHY -- the same
+    reason outputs/ledger.py renders its four hot-search states instead of
+    letting "nothing happened" and "it found nothing" print identically.
+    """
+    lines = []
+    for r in results:
+        counts = (
+            f"N_post={r.n_post}, N_prop={r.n_prop}"
+            f" ({r.status.get('n_prop_unsupported', 0)} outside the target "
+            f"support, kept as zero-density draws)"
+        )
+        if r.refused:
+            lines.append(
+                f"mode {r.mode + 1}: REFUSED [{r.state}] -- {r.reason} "
+                f"[{counts}]"
+            )
+        else:
+            lines.append(
+                f"mode {r.mode + 1}: lnZ={r.lnZ:.2f}+/-{r.lnZ_err:.2f} "
+                f"(re2={r.re2:.3g}; {counts})"
+            )
+    return lines
 
 
 def apply_evidence_weighting(
@@ -644,13 +914,21 @@ def apply_evidence_weighting(
         ids = ", ".join(str(r.mode + 1) for r in refused)
         note = (
             f"evidence weighting refused for mode(s) {ids}; kept occupancy "
-            f"weights. First reason: {refused[0].reason}"
+            f"weights. Reasons: "
+            + "; ".join(
+                f"mode {r.mode + 1} [{r.state}] {r.reason}" for r in refused
+            )
         )
         mode_report.notes.append(note)
+        # Every mode's outcome, not just the refused ones: an accepted mode
+        # sitting next to a refused one is part of the picture a reader needs.
+        mode_report.notes.append(
+            "bridge-sampling evidence per mode -- "
+            + "; ".join(evidence_status_to_text(results))
+        )
         mode_report.provenance = (
-            "occupancy (evidence weighting refused: "
-            + refused[0].reason
-            + "; see notes)"
+            f"occupancy (evidence weighting refused for mode(s) {ids} "
+            f"[{refused[0].state}]: " + refused[0].reason + "; see notes)"
         )
         logger.warning(
             "evidence weighting refused for mode(s) %s; "
@@ -675,20 +953,35 @@ def apply_evidence_weighting(
         m.lnZ = float(lnZ[k])
         m.lnZ_err = float(err[k])
     max_re2 = max(r.re2 for r in results)
+    # Counts as USED, not as staged: these numbers exist so a reader can tell
+    # what the estimate was computed from.  They used to be quoted before the
+    # non-finite draws were removed, which described a sample size the
+    # estimator never saw.  Nothing is silently removed any more -- the
+    # unsupported proposal draws are kept as zero-density draws -- so the
+    # count is quoted alongside instead of hidden.
     n_post = min(r.n_post for r in results)
     n_prop = min(r.n_prop for r in results)
+    n_unsup = sum(r.status.get("n_prop_unsupported", 0) for r in results)
+    n_bad_post = sum(r.status.get("n_post_invalid", 0) for r in results)
+    used = (
+        f"N_post>={n_post} used"
+        + (f" ({n_bad_post} discarded as non-finite)" if n_bad_post else "")
+        + f", N_prop>={n_prop} used"
+        + (
+            f" ({n_unsup} outside the target support, kept as zero-density "
+            f"draws)"
+            if n_unsup
+            else ""
+        )
+    )
     mode_report.provenance = (
         f"evidence (bridge sampling: max relative MSE {max_re2:.2g}, "
-        f"N_post>={n_post}, N_prop>={n_prop}; lnZ error bars propagated to "
-        f"weight uncertainties)"
+        f"{used}; lnZ error bars propagated to weight uncertainties)"
     )
     mode_report.weights_reliable = True
     mode_report.notes.append(
         "mode weights are bridge-sampling evidence weights: "
-        + "; ".join(
-            f"mode {r.mode + 1} lnZ={r.lnZ:.2f}+/-{r.lnZ_err:.2f}"
-            for r in results
-        )
+        + "; ".join(evidence_status_to_text(results))
     )
     # Cross-check line: evidence weighting needs no mode transitions at all,
     # occupancy needs them and reports its own mixing-derived error bar, so

--- a/tests/test_mode_evidence.py
+++ b/tests/test_mode_evidence.py
@@ -50,6 +50,8 @@ import pytest
 from conftest import requires_fork
 from exozippy.outputs.autocorr import iact
 from exozippy.outputs.evidence import (
+    EV_RE2,
+    EV_UNSUPPORTED,
     EvidenceResult,
     _mode_draw_index,
     _segments,
@@ -286,17 +288,75 @@ def test_apply_evidence_weighting_falls_back_on_refusal():
 @requires_fork
 def test_evidence_refuses_heavy_tailed_mode():
     """
-    Given a single mode whose raw-space target is heavy-tailed (Cauchy) so a
-      Gaussian proposal cannot support the tails (the raw-space signature of a
-      bound pileup),
+    Given a single mode whose raw-space target is heavy-tailed (a 10-D
+      product of Cauchys) so a moment-matched Gaussian proposal cannot
+      support the tails,
     When estimate_mode_evidences runs,
-    Then it refuses the mode rather than reporting a number.
+    Then it refuses the mode ON THE RELATIVE-MSE DIAGNOSTIC rather than
+      reporting a number.
+
+    The dimension is load-bearing and so is the asserted state.  The OPTIMAL
+    bridge tolerates a Cauchy target against a Gaussian proposal easily in low
+    dimension (measured through this same path: re2 ~ 0.01 at d = 1, 0.05-0.08
+    at d = 5, and only past d ~ 8 does the mismatch compound into
+    re2 > re2_max) -- it is far more forgiving than plain importance sampling
+    -- so the 1-D version of this test asserted a refusal that the estimator
+    had no reason to make.  It passed anyway, because _ev_eval_block fed pymc
+    a 1-D array for a SCALAR free RV, every logp evaluation raised, and the
+    mode was refused for a reason the test never checked.  Asserting the
+    state is what keeps that from recurring.
     """
+    d = 10
     rng = np.random.default_rng(3)
-    x = rng.standard_cauchy(N)
     # keep values finite/representable but retain the fat tail
-    x = np.clip(x, -1e6, 1e6)
-    lp = -np.log1p(x**2)
+    x = np.clip(rng.standard_cauchy((N, d)), -1e4, 1e4)
+    lp = -np.log1p(x**2).sum(axis=-1)
+    idata = az.from_dict(
+        {
+            "posterior": {"x_raw": x.reshape(N_CHAIN, N_DRAW, d)},
+            "sample_stats": {"lp": lp.reshape(N_CHAIN, N_DRAW)},
+        }
+    )
+    report = _fake_one_mode_report(idata)
+
+    with pm.Model() as model:
+        xt = pm.Flat("x_raw", shape=d)
+        pm.Potential("cauchy", -pt.sum(pt.log1p(xt**2)))
+
+    results = estimate_mode_evidences(
+        model, idata, report, max_posterior_draws=800, n_proposal=800
+    )
+
+    assert len(results) == 1
+    assert results[0].refused
+    assert results[0].state == EV_RE2
+    assert results[0].status["n_prop_unsupported"] == 0  # not THIS failure
+    assert not apply_evidence_weighting(report, results)
+
+
+@requires_fork
+@pytest.mark.parametrize("rv_shape", [None, 1])
+def test_logp_point_shapes_come_from_the_value_variable(rv_shape):
+    """
+    Given a trace whose posterior stores a variable as 0-d, for a model in
+      which that variable is EITHER a genuinely scalar free RV (rv_shape
+      None) OR a length-1 vector (rv_shape 1, which is what every EXOZIPPy
+      Parameter with one element is -- lens.t_0_raw, star.logmass_raw,
+      planet.mass_raw are all shape (1,), stored squeezed in the trace),
+    When estimate_mode_evidences evaluates the model logp at those draws,
+    Then the evaluations succeed in both cases.
+
+    The trace shape cannot decide this: it is 0-d either way, while pymc's
+    compiled logp checks ndim exactly and _ev_eval_block's broad except turns
+    a mismatch into a nan.  Reading the shape off the trace nans out every
+    one-element parameter of every real fit; reading a 1-d array in
+    unconditionally nans out a genuinely scalar RV.  Both then surface as a
+    mode "refused" for a reason that is not the real one, which is why this
+    is pinned from both sides.
+    """
+    rng = np.random.default_rng(13)
+    x = rng.normal(0.0, 1.0, N)
+    lp = -0.5 * x**2
     idata = az.from_dict(
         {
             "posterior": {"x_raw": x.reshape(N_CHAIN, N_DRAW)},
@@ -306,16 +366,19 @@ def test_evidence_refuses_heavy_tailed_mode():
     report = _fake_one_mode_report(idata)
 
     with pm.Model() as model:
-        xt = pm.Flat("x_raw")
-        pm.Potential("cauchy", -pt.log1p(xt**2))
+        xt = pm.Flat("x_raw", shape=rv_shape) if rv_shape else pm.Flat("x_raw")
+        pm.Potential("gauss", -0.5 * pt.sum(xt**2))
 
     results = estimate_mode_evidences(
         model, idata, report, max_posterior_draws=800, n_proposal=800
     )
 
-    assert len(results) == 1
-    assert results[0].refused
-    assert not apply_evidence_weighting(report, results)
+    r = results[0]
+    assert r.status["n_post_invalid"] == 0
+    assert r.status["n_prop_unsupported"] == 0
+    assert not r.refused
+    # N(0,1) unnormalized by exp(-x^2/2) integrates to sqrt(2 pi)
+    assert r.lnZ == pytest.approx(0.5 * np.log(2 * np.pi), abs=5 * r.lnZ_err)
 
 
 # ----------------------------------------------------------------------
@@ -553,6 +616,263 @@ def test_bridge_error_bar_grows_with_posterior_autocorrelation():
     _z, err_cor, _re2, _c = bridge_lnZ(l1_cor, l2, l1_chains=[n])
 
     assert err_cor > 3.0 * err_iid
+
+
+# ----------------------------------------------------------------------
+# proposal draws the target does not support
+#
+# The fitted Gaussian is unbounded, so some of its draws land where the
+# target density is zero (or where the logp evaluation fails).  Those draws
+# used to be silently dropped and the proposal-side average renormalized over
+# the survivors, which is the estimator for a proposal truncated to the
+# target's support -- not the proposal that was drawn from.  It biased lnZ up
+# by log(N2 / N2_kept) per mode AND defeated the re2 guard meant to catch it:
+# the dropped draws are exactly the ones with the smallest bridge function, so
+# removing them LOWERS re2 and reports the proposal as healthier than it is.
+# ----------------------------------------------------------------------
+
+
+def _truncated_support_inputs(logC, frac_outside, n, seed):
+    """Bridge inputs for a target that is the proposal restricted to a set S.
+
+    With p~(x) = C q(x) 1[x in S], the log-ratio is log C on S and -inf off
+    it, the posterior draws all sit in S, and the true evidence is
+    Z = C Q(S) -- i.e. lnZ = log C + log(1 - frac_outside), ANALYTICALLY.
+    Returns (l1, l2, lnZ_true, n_outside).
+    """
+    rng = np.random.default_rng(seed)
+    l1 = np.full(n, float(logC))
+    outside = rng.random(n) < frac_outside
+    l2 = np.where(outside, -np.inf, float(logC))
+    n_outside = int(outside.sum())
+    lnZ_true = logC + np.log1p(-n_outside / n)
+    return l1, l2, lnZ_true, n_outside
+
+
+@pytest.mark.parametrize("frac", [0.0, 0.05, 0.2, 0.5])
+def test_unsupported_proposal_draws_do_not_bias_lnZ(frac):
+    """
+    Given a target that is exactly the proposal restricted to a subset of its
+      support, so a known fraction of proposal draws have zero target density
+      and the true lnZ is analytic,
+    When bridge_lnZ runs,
+    Then it returns the true lnZ -- the unsupported draws enter the bridge
+      average at their correct value of zero -- whereas DROPPING them (the
+      behavior this replaced) inflates lnZ by exactly log(N2 / N2_kept).
+    """
+    logC = 1.7
+    n = 4000
+    l1, l2, lnZ_true, n_outside = _truncated_support_inputs(logC, frac, n, 5)
+
+    lnZ, _err, _re2, converged = bridge_lnZ(l1, l2)
+    lnZ_dropped, _e, _r, _c = bridge_lnZ(l1, l2[np.isfinite(l2)])
+
+    assert converged
+    assert lnZ == pytest.approx(lnZ_true, abs=1e-6)
+    # and the old behavior's bias is exactly the renormalization it performed
+    assert lnZ_dropped - lnZ == pytest.approx(
+        -np.log1p(-n_outside / n), abs=1e-6
+    )
+    if frac == 0.0:
+        # a clean mode is untouched: same number, to the last bit
+        assert lnZ_dropped == lnZ
+
+
+def test_bridge_status_counts_the_unsupported_draws():
+    """
+    Given proposal draws of which a known number have a non-finite log-ratio,
+    When bridge_lnZ runs with a status dict,
+    Then the status reports the proposal draws taken, how many were outside
+      the target support, and the fraction -- the provenance and the refusal
+      decision both read those counts, so they must describe what was used.
+    """
+    l1, l2, _z, n_outside = _truncated_support_inputs(1.7, 0.2, 4000, 5)
+    status = {}
+
+    bridge_lnZ(l1, l2, status=status)
+
+    assert status["n_prop"] == 4000  # NOT the post-filter survivor count
+    assert status["n_prop_unsupported"] == n_outside
+    assert status["frac_unsupported"] == pytest.approx(n_outside / 4000)
+    assert status["n_post"] == 4000
+    assert status["n_post_invalid"] == 0
+
+
+def test_diagnostic_sees_the_unsupported_draws():
+    """
+    Given the same bridge problem measured with the unsupported proposal draws
+      retained and with them dropped,
+    When the relative-MSE diagnostic is compared,
+    Then retaining them RAISES re2 -- the dropped draws are the smallest
+      values of the bridge function, so filtering them out flattered the very
+      diagnostic that is supposed to catch a proposal spilling outside the
+      target's support.
+    """
+    frac, n = 0.2, 4000
+    l1, l2, _z, n_outside = _truncated_support_inputs(1.7, frac, n, 5)
+
+    _lnZ, err_keep, re2_keep, _c = bridge_lnZ(l1, l2)
+    _lnZ, err_drop, re2_drop, _c = bridge_lnZ(l1, l2[np.isfinite(l2)])
+
+    assert re2_keep > re2_drop
+    assert err_keep > err_drop
+    # the zeros contribute f / ((1 - f) N2) of relative variance
+    k = 1.0 - n_outside / n
+    assert re2_keep - re2_drop == pytest.approx((1 - k) / k / n, rel=0.2)
+
+
+def test_posterior_side_non_finite_draws_are_counted_not_hidden():
+    """
+    Given posterior draws of which some re-evaluate to a non-finite logp (a
+      failed evaluation -- a draw the sampler produced cannot have zero target
+      density, so unlike the proposal side there is no correct value to
+      substitute),
+    When bridge_lnZ runs,
+    Then those draws are excluded from the estimate but REPORTED in the
+      status, so the caller can refuse rather than quietly average over a
+      shrunken sample.
+    """
+    l1, l2, _z, _n = _truncated_support_inputs(1.7, 0.0, 1000, 5)
+    l1 = l1.copy()
+    l1[:150] = np.nan
+    status = {}
+
+    bridge_lnZ(l1, l2, status=status)
+
+    assert status["n_post"] == 850
+    assert status["n_post_invalid"] == 150
+    assert status["frac_post_invalid"] == pytest.approx(0.15)
+
+
+@requires_fork
+def test_evidence_refuses_mode_with_unsupported_proposal_mass():
+    """
+    Given a mode whose raw-space target has a hard edge (an exponential
+      target, zero density for x <= 0) so the moment-matched Gaussian
+      proposal puts ~16% of its draws where the target has none,
+    When estimate_mode_evidences runs,
+    Then the mode is REFUSED, with the count and the fraction of unsupported
+      draws in the reason and the machine-readable state -- the estimator
+      never reports a number whose systematic it cannot bound, and the count
+      is refusal evidence rather than something to filter away.
+    """
+    rng = np.random.default_rng(5)
+    x = rng.exponential(1.0, N)
+    lp = -x
+    idata = az.from_dict(
+        {
+            "posterior": {"x_raw": x.reshape(N_CHAIN, N_DRAW)},
+            "sample_stats": {"lp": lp.reshape(N_CHAIN, N_DRAW)},
+        }
+    )
+    report = _fake_one_mode_report(idata)
+
+    with pm.Model() as model:
+        xt = pm.Flat("x_raw")
+        pm.Potential("exp_target", pt.switch(xt > 0, -xt, -np.inf))
+
+    results = estimate_mode_evidences(
+        model, idata, report, max_posterior_draws=800, n_proposal=800
+    )
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.refused
+    assert r.state == EV_UNSUPPORTED
+    assert r.status["n_prop_unsupported"] > 0.10 * r.status["n_prop"]
+    # the count and the fraction are IN the reason a user reads
+    assert str(r.status["n_prop_unsupported"]) in r.reason
+    assert f"{r.status['frac_unsupported']:.1%}" in r.reason
+    # and the count was never removed from the sample it describes
+    assert r.n_prop == 800
+
+    assert not apply_evidence_weighting(report, results)
+    assert "refused" in report.provenance
+    assert EV_UNSUPPORTED in report.provenance
+    assert str(r.status["n_prop_unsupported"]) in " ".join(report.notes)
+    # visible in the RENDERED report, not only in a log line
+    assert str(r.status["n_prop_unsupported"]) in report.to_text()
+
+
+@requires_fork
+def test_clean_mode_lnZ_is_unchanged_by_the_unsupported_handling():
+    """
+    Given a well-behaved mode whose Gaussian proposal is supported everywhere
+      (no draw has a non-finite logp),
+    When estimate_mode_evidences runs,
+    Then nothing about the unsupported-draw handling touches it: it is
+      accepted, its status reports zero unsupported draws, and its lnZ is the
+      analytic local evidence of the bump.
+    """
+    rng = np.random.default_rng(9)
+    mu0, mu1 = np.array([0.0, 0.0]), np.array([8.0, 0.0])
+    w0, w1 = 0.75, 0.25
+    x = rng.normal(mu0, 1.0, size=(N, 2))
+    lp = _mixture_lp(x, mu0, mu1, w0, w1)
+    idata = az.from_dict(
+        {
+            "posterior": {"x_raw": x.reshape(N_CHAIN, N_DRAW, 2)},
+            "sample_stats": {"lp": lp.reshape(N_CHAIN, N_DRAW)},
+        }
+    )
+    report = _fake_one_mode_report(idata)
+    model = _two_bump_mixture_model(mu0, mu1, w0, w1)
+
+    results = estimate_mode_evidences(
+        model, idata, report, max_posterior_draws=800, n_proposal=800
+    )
+
+    r = results[0]
+    assert not r.refused
+    assert r.status["n_prop_unsupported"] == 0
+    assert r.status["n_post_invalid"] == 0
+    assert r.n_post == 800 and r.n_prop == 800
+    assert abs(r.lnZ - np.log(w0)) <= max(0.05, 5 * r.lnZ_err)
+
+
+def test_provenance_counts_describe_the_draws_actually_used():
+    """
+    Given accepted bridge results that carry the post-filter draw bookkeeping,
+    When apply_evidence_weighting builds the weight provenance,
+    Then the quoted N_post / N_prop are the counts the estimate was computed
+      from and the unsupported draws are stated rather than hidden -- the
+      string used to quote pre-filter counts, so nothing downstream could tell
+      that any filtering had happened at all.
+    """
+    report = _fake_two_mode_report(w0_occ=0.5, w1_occ=0.5)
+    results = [
+        EvidenceResult(
+            0,
+            np.log(0.75),
+            0.03,
+            0.001,
+            790,
+            800,
+            False,
+            "",
+            {"n_post": 790, "n_post_invalid": 10, "n_prop_unsupported": 12},
+        ),
+        EvidenceResult(
+            1,
+            np.log(0.25),
+            0.05,
+            0.002,
+            800,
+            800,
+            False,
+            "",
+            {"n_post": 800, "n_post_invalid": 0, "n_prop_unsupported": 0},
+        ),
+    ]
+
+    assert apply_evidence_weighting(report, results)
+
+    prov = report.provenance
+    assert "N_post>=790 used" in prov
+    assert "10 discarded as non-finite" in prov
+    assert "12 outside the target support" in prov
+    assert "N_prop>=800 used" in prov
+    assert "12" in report.to_text()
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Review item **3.16**, found while auditing the silent-bandaid class (#115): `evidence.py:181` **dropped** non-finite logp values, so the bridge estimator renormalized over the survivors and biased `lnZ` up by about `log(N2/N2_kept)` per mode. The `re2_max` guard was defeated by it -- dropping unsupported draws *lowers* `re2` -- and the provenance string quoted pre-filter counts, describing a sample size the estimator never saw.

Per the user's decision: **refuse the mode** rather than quietly renormalize.

## The proposal side is not dropped, it is scored as zero

The optimal bridge function is `p~/(s1 p~ + s2 Z q)`, which is **exactly 0** where `p~ = 0`. So a proposal draw landing outside the target's support has a correct, known value; there is nothing to estimate and nothing to discard. Keeping it at `-inf` makes `N2` the number of draws actually taken, makes `lnZ` unbiased, and lets those zeros widen the bridge-function spread that `re2` measures -- which is the behaviour `re2` was always supposed to have.

The **posterior** side is different and is still discarded: a draw the sampler produced cannot have zero density, so a non-finite value there is a *failed evaluation*, not a demonstrated zero, and has no correct substitute. Those are now counted, and when material they refuse the mode **first**, because they diagnose themselves and also drive the proposal side non-finite.

## Threshold: 10%, and why `re2` could never gate it

The one systematic no error bar can carry is that a `nan` might be a failed evaluation rather than a true zero, so scoring the unsupported draws as zeros can move `lnZ` by up to `log(1/(1-f))`. At `f = 0.10` that is **0.105 nat** -- 5x tighter than the 0.5-nat bar `re2_max` already enforces, so it can never be the loose gate -- and ~2.5 percentage points on softmax weights.

It needed its own gate because **retaining the zeros barely moves `re2` at all**: the increase is `f/((1-f)*N2)`, i.e. 1.4e-4 at `f = 10%`, `N2 = 800`. Documented at the constant so nobody "simplifies" it away.

## Measured bias on real traces: 0.0000 nat

The bias is exactly `log(N2/N2_kept)`, verified analytically and in tests (0.051 nat at 5% dropped, 0.223 at 20%, 0.693 at 50%). On the traces available it is zero, because the unsupported fraction is:

| trace | dims | modes | unsupported / proposal draws |
|---|---|---|---|
| KELT-4 RV-only (fit fresh) | 15 | 4 | 0/1933, 0/275, 0/164, 0/108 |
| DC2018_128 Roman binary lens | 27 | 2 | 0/429, 0/424 |

So this is a correctness guard that costs nothing today, not a fix for a bias currently in anyone's numbers. The `f = 0.0` test passes pre-fix, which is the point: a clean mode's `lnZ` is bit-identical.

## Reporting

`bridge_lnZ` fills a caller-supplied `status` dict and `EvidenceResult` carries it plus an `EV_*` state (`ok` / `unsupported-proposal-mass` / `invalid-posterior-draws` / `not-converged` / `re2-too-large` / `too-few-draws` / `no-free-rvs`). Provenance quotes counts **as used**, with the unsupported count stated alongside rather than hidden, and **every** mode's outcome is rendered into `<prefix>_modes.txt` and the LaTeX provenance -- an accepted mode sitting next to a refused one is part of the picture.

Both conventions are #88's, reused deliberately: the `status=` in/out dict is `outputs.ledger.discover_hot_modes`'s verbatim, and `EV_*` is the `HOT_*` four-state idea applied per mode.

## Two findings beyond the assignment

**1. A shape bug that would have made the new refusal misdiagnose.** `_build_layout` took each point's shape from the *trace*. An EXOZIPPy Parameter with one element is a length-1 **vector** RV (`lens.t_0_raw`, `star.logmass_raw`, ...) that the trace stores **squeezed to 0-d**; the old `np.atleast_1d(seg)` fallback happened to reconstruct exactly that, so every shipped fit was right **by accident** -- and a genuinely 0-d RV was wrong in the other direction. pymc checks ndim exactly and `_ev_eval_block`'s broad `except` turns the mismatch into a `nan`, so the failure was invisible except as a mode refused for a reason that was not the real one. The shape now comes from the value variable, correct in both directions, pinned by a parametrized test.

**2. `test_evidence_refuses_heavy_tailed_mode` was a silent pass.** Its 1-D Cauchy model has a genuinely scalar RV, so it hit exactly the bug above: every evaluation raised, and the refusal it asserted had nothing to do with heavy tails. The optimal bridge in fact handles a Cauchy target easily (measured through the real path: `re2 ~ 0.01` at d=1, 0.05-0.08 at d=5). It now uses d=10, where the mismatch genuinely compounds (`re2 ~ 1.1-1.9`), and asserts the refusal **state** so it cannot pass for the wrong reason again. Not weakened -- a previously vacuous assertion is now real.

## Tests

`tests/test_mode_evidence.py`: **38 passed** (was 26). With `src/` reverted plus a non-behavioral shim so the module imports, **12 fail**: the bias at f = 5/20/50%, the status counts, the diagnostic seeing the unsupported draws, the posterior-side counting, the end-to-end refusal, the clean-mode invariance, the provenance counts, both shape directions, and the heavy-tail state. `tests/test_mode_report.py` and `tests/test_known_keys.py` also pass (78 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
