### PR TITLE
CI: point the Zenodo spectra cache at the path the code actually reads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,10 +110,27 @@ jobs:
       # the paths it was SAVED with. Repointing `path:` alone would still hit
       # the old entry and still unpack it at the old location; the key has to
       # change for a new entry to be written at the new one.
+      #
+      # The path names the two DOWNLOADED files, not their directory. Both
+      # land in models/NextGen/BCs/ next to 68 TRACKED BC tables, and a cache
+      # is restored after checkout and overwrites what it finds. Caching the
+      # directory would therefore let a stale entry silently revert a tracked
+      # table -- and the key, being the spectra md5, would not change when a
+      # table did, so it would never self-heal. That is not hypothetical: the
+      # "sed: fix Av bug in shipped 2MASS/WISE/GAIA BC tables" commit is
+      # exactly the change that would have been reverted under CI while
+      # passing locally.
+      #
+      # The other Zenodo asset, the 128 MB MIST EEP grid (models/MIST/eep_grid
+      # .py, same fetch_assets core), is deliberately not cached: the only
+      # test that touches it monkeypatches _EEP_GRID_ASSETS and EEP_GRID_DIR,
+      # so CI never downloads it. Add it here if that ever changes.
       - name: Cache the Zenodo model spectra
         uses: actions/cache@v6
         with:
-          path: src/exozippy/models/NextGen
+          path: |
+            src/exozippy/models/NextGen/BCs/NextGen.spectra.csv
+            src/exozippy/models/NextGen/BCs/NextGen.wavelength.csv
           key: nextgen-spectra-p2-7a2b81333f6a5bfccd4cbc07bdea6648
 
       # The mulensing component sets astropy's solar-system ephemeris to
@@ -199,7 +216,9 @@ jobs:
       - name: Cache the Zenodo model spectra
         uses: actions/cache@v6
         with:
-          path: src/exozippy/models/NextGen
+          path: |
+            src/exozippy/models/NextGen/BCs/NextGen.spectra.csv
+            src/exozippy/models/NextGen/BCs/NextGen.wavelength.csv
           key: nextgen-spectra-p2-7a2b81333f6a5bfccd4cbc07bdea6648
 
       # Same astropy ephemeris-kernel cache as the matrix job -- see the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,11 +89,32 @@ jobs:
       # The key embeds the md5 already pinned in make_bc._MODEL_DATA, so it is
       # correct by construction: change the data, change the key. Keep it in
       # sync if that pin ever moves.
+      #
+      # The PATH is NOT correct by construction, and has to be kept in sync by
+      # hand with bc_grid.DEFAULT_MODEL_ROOT (= src/exozippy/models). It was
+      # not. This block originally read src/exozippy/components/sed/models/
+      # NextGen, correct when it was written (#29, 2026-07-28 13:46) and
+      # stranded three hours later when the "Changed models/filters directory
+      # structure" branch merged and moved the tree (2026-07-28 16:36).
+      #
+      # Nothing caught it, and the failure mode is worth understanding because
+      # it looks healthy from the outside. actions/cache neither warns nor
+      # fails on a path the code does not read: the pre-restructure entry kept
+      # reporting "Cache hit ... not saving cache" on every job, restoring
+      # 132 MB into a directory nothing opens, while the SED tests downloaded
+      # the spectra from Zenodo again -- exactly the load this block exists to
+      # remove. Restoring also refreshes the entry's last-accessed time, so it
+      # never aged out either: a self-sustaining zombie.
+      #
+      # The key carries a `p2` generation marker because a cache entry stores
+      # the paths it was SAVED with. Repointing `path:` alone would still hit
+      # the old entry and still unpack it at the old location; the key has to
+      # change for a new entry to be written at the new one.
       - name: Cache the Zenodo model spectra
         uses: actions/cache@v6
         with:
-          path: src/exozippy/components/sed/models/NextGen
-          key: nextgen-spectra-7a2b81333f6a5bfccd4cbc07bdea6648
+          path: src/exozippy/models/NextGen
+          key: nextgen-spectra-p2-7a2b81333f6a5bfccd4cbc07bdea6648
 
       # The mulensing component sets astropy's solar-system ephemeris to
       # "jpl", which downloads the ~115 MB de430 kernel into ~/.astropy/cache
@@ -171,13 +192,15 @@ jobs:
           pip install ".[gui]"
           pip install pytest pytest-timeout pytest-xdist httpx
 
-      # Same Zenodo spectra cache as the other jobs -- see the comment there.
-      # Shares their key, so this job is usually a cache hit populated by them.
+      # Same Zenodo spectra cache as the other jobs -- see the comment there,
+      # including why this path has to be kept in sync with
+      # bc_grid.DEFAULT_MODEL_ROOT by hand. Shares their key, so this job is
+      # usually a cache hit populated by them.
       - name: Cache the Zenodo model spectra
         uses: actions/cache@v6
         with:
-          path: src/exozippy/components/sed/models/NextGen
-          key: nextgen-spectra-7a2b81333f6a5bfccd4cbc07bdea6648
+          path: src/exozippy/models/NextGen
+          key: nextgen-spectra-p2-7a2b81333f6a5bfccd4cbc07bdea6648
 
       # Same astropy ephemeris-kernel cache as the matrix job -- see the
       # comment there.


### PR DESCRIPTION
**The spectra cache has never worked.** Found while diagnosing PR #124's `ubuntu-3.12` failure:

```
FAILED tests/test_build_bc_grid_raises_for_nonexistent_facility
  Failed: Timeout (>300.0s) from pytest-timeout
```

That test reaches `generate_missing_facility` -> `ensure_model_data`, so it pays for the ~250 MB download before it can raise -- which is precisely the load #29's cache exists to remove.

## What happened

#29 added the cache on **2026-07-28 13:46**, reading `src/exozippy/components/sed/models/NextGen` -- correct against the tree its author saw. The models/filters restructure branch merged **three hours later, 16:36**, moving the tree to `src/exozippy/models`. Two parallel branches, one afternoon.

`bc_grid.DEFAULT_MODEL_ROOT` is `source_code_dir / "models"` = `src/exozippy/models`; there are **zero tracked files** under `src/exozippy/components/sed/models` and the directory does not exist in a fresh checkout.

## Why two weeks of CI logs looked fine

This is the part worth understanding, because the failure presents as success. `actions/cache` neither warns nor fails on a path the code does not read, so every job has been reporting

```
Cache hit for: nextgen-spectra-7a2b81333f6a5bfccd4cbc07bdea6648
Cache restored successfully
Cache hit occurred on the primary key ..., not saving cache
```

while restoring 132 MB into a directory nothing opens -- and the SED tests then downloaded the spectra from Zenodo anyway. Restoring also refreshes the entry's last-accessed time, so it never aged out of the 7-day eviction window either: a self-sustaining zombie whose logs read exactly like a working cache.

## The key had to move too

A cache entry stores the paths it was **saved** with, so repointing `path:` alone would still hit the pre-restructure entry and still unpack it at the old location. The key therefore carries a `p2` generation marker, keeping the md5-from-`_MODEL_DATA` convention (change the data, change the key) that makes the rest of it correct by construction.

The comment now says plainly that the path is *not* correct by construction and names `bc_grid.DEFAULT_MODEL_ROOT` as the thing to keep it in sync with.

## Verification

YAML parses; both cache blocks (the matrix job and `pytest-latest-deps`, which shares the key) are updated together. The real check is the CI run on this PR: the first job to reach the step should report a **miss**, then `Cache saved`, and the reruns after it should hit and be measurably faster through `tests/test_sed.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)