### PR TITLE
modes: fire the validity gate when EVERY draw is invalid (review 3.17)

### DIFF
--- a/src/exozippy/cli_modes.py
+++ b/src/exozippy/cli_modes.py
@@ -32,6 +32,7 @@ import click
 import yaml
 
 from .logger import setup_logging
+from .outputs.modes import MODE_NO_VALID_DRAWS
 from .outputs.report_pipeline import build_mode_reports
 from .system import System
 from .trace_meta import check_trace_freshness
@@ -146,6 +147,7 @@ def main(config_file, min_weight, max_modes, feature_vars, seed, logger_level):
     # always complete: a high invalid-draw fraction is reported below as a
     # loud warning banner, not the raise build_mode_reports does for a live
     # fit (raise_on_invalid=True there).
+    mode_status = {}
     mode_report = build_mode_reports(
         system,
         idata,
@@ -155,9 +157,26 @@ def main(config_file, min_weight, max_modes, feature_vars, seed, logger_level):
         feature_vars=feature_var_list,
         seed=seed,
         raise_on_invalid=False,
+        mode_status=mode_status,
     )
 
-    if mode_report is None:
+    if mode_status.get("state") == MODE_NO_VALID_DRAWS:
+        # A live fit refuses outright here (check_invalid_frac); this tool
+        # completes by contract, so the banner has to carry what the raise
+        # would have said -- "the tables were written" is not the headline,
+        # "they describe draws that were all rejected" is.
+        logger.warning(
+            "!" * 60 + "\n"
+            f"NO VALID DRAWS: all {mode_status.get('n_invalid', 0)} draws "
+            f"({mode_status.get('invalid_frac', 0.0):.2%}) in this trace "
+            "were rejected as numerically invalid "
+            f"(reasons={mode_status.get('reasons')}). The tables written "
+            "below describe REJECTED draws and no summary of them is "
+            f"meaningful. See {prefix}_modes.txt. This is a model or "
+            "sampler bug: fix it and re-fit; there is nothing here to "
+            "reprocess.\n" + "!" * 60
+        )
+    elif mode_report is None:
         logger.warning(
             "!" * 60 + "\n"
             "MODE IDENTIFICATION FAILED: wrote combined-posterior tables "

--- a/src/exozippy/outputs/modes.py
+++ b/src/exozippy/outputs/modes.py
@@ -97,37 +97,208 @@ def _idx_to_words(n):
     return "".join(words[char] for char in str(n))
 
 
+# Outcome vocabulary for one mode-identification attempt, following the
+# status-dict pattern of outputs/ledger.py's hot-chain search (HOT_*) and
+# outputs/evidence.py's per-mode bridge estimates (EV_*).
+#
+# The distinction that matters is between the last two.  Both end with
+# ``mode_report = None`` at the call site, and until 2026-08-12 that was the
+# ONLY thing the caller could see -- so the numerical-validity gate below,
+# which returns immediately on a None report, was bypassed in exactly the
+# worst case: EVERY draw rejected.  A trace with 1.1% invalid draws refused
+# to emit tables while a trace with 100% invalid draws emitted a full set
+# that read as clean (review item 3.17).  MODE_NO_VALID_DRAWS is the signal
+# that separates "the draws are unusable" from "we could not tell you
+# anything, for some other reason"; it can only be set from
+# NoValidDrawsError, which identify_modes raises from one place.
+MODE_OK = "ok"
+MODE_NO_VALID_DRAWS = "no-valid-draws"
+MODE_FAILED = "failed"
+
+
+class NoValidDrawsError(ValueError):
+    """Every draw in the trace failed identify_modes' validity filter.
+
+    A ValueError subclass, so any pre-existing ``except ValueError`` around
+    identify_modes keeps behaving as before.
+
+    It carries the counts because it is the only channel through which the
+    all-invalid case can reach ``check_invalid_frac``: there is nothing to
+    cluster, so no ModeReport exists to read ``n_invalid``/``invalid_frac``
+    off, and a bare exception would leave the gate with nothing to gate on.
+    """
+
+    def __init__(self, n_invalid, n_draws, reason_counts=None, per_chain=None):
+        self.n_invalid = int(n_invalid)
+        self.n_draws = int(n_draws)
+        self.invalid_frac = (
+            self.n_invalid / self.n_draws if self.n_draws else 0.0
+        )
+        self.reason_counts = dict(reason_counts or {})
+        self.per_chain_invalid = (
+            list(per_chain) if per_chain is not None else []
+        )
+        # The leading clause is load-bearing: callers and tests match on
+        # "no valid draws".
+        super().__init__(
+            f"identify_modes: no valid draws in trace -- all "
+            f"{self.n_invalid} draws ({self.invalid_frac:.2%}) failed the "
+            f"numerical-validity filter (reasons={self.reason_counts}, "
+            f"per-chain invalid counts={self.per_chain_invalid})"
+        )
+
+
+def _invalid_reason_hint(reason_counts):
+    """One actionable sentence about the dominant rejection reason."""
+    if not reason_counts:
+        return ""
+    dominant = max(reason_counts, key=lambda r: reason_counts[r])
+    if dominant == "nonfinite-raw":
+        return (
+            " The sampled parameter values themselves are non-finite, so "
+            "the sampler never produced a usable point: check the model's "
+            "logp at the start point and the sampler's step-size adaptation."
+        )
+    if dominant in ("nonfinite-lp", "lp-ceiling"):
+        return (
+            " The stored log-posterior is non-finite (or beyond "
+            f"|lp| = {DEFAULT_LP_ABS_MAX:g}) for every draw. The parameter "
+            "values may still look perfectly reasonable in the tables, "
+            "which is exactly why this cannot be allowed to pass quietly: "
+            "check the model's logp for NaN/inf-producing terms."
+        )
+    return ""
+
+
 def check_invalid_frac(
     mode_report,
     max_invalid_frac=DEFAULT_MAX_INVALID_FRAC,
     force=False,
     trace_path=None,
     modes_path=None,
+    status=None,
 ):
-    """Raise if ``mode_report``'s invalid-draw fraction exceeds the threshold.
+    """Raise if the trace's invalid-draw fraction exceeds the threshold.
 
     A trace this numerically broken must not silently emit final tables.
     Call this only after the trace and mode report have already been
     written to disk, so the raise preserves that evidence for forensics.
     ``force=True`` (config ``modes: {force: true}``) or a higher
     ``max_invalid_frac`` re-enables processing of a known-bad trace.
+
+    ``mode_report`` may be None, which is ambiguous on its own and so is
+    disambiguated by ``status`` (the dict build_mode_reports fills in):
+
+    * ``state == MODE_NO_VALID_DRAWS`` -- identify_modes rejected EVERY
+      draw and could not build a report.  That is a 100% invalid fraction,
+      the most extreme form of exactly what this gate exists to catch, and
+      it is gated on the same comparison and honours the same overrides as
+      a partially-invalid report.  Passing it silently is review item 3.17.
+    * anything else (including no status at all) -- mode identification
+      produced no report for a reason that says nothing about the draws'
+      numerical validity (an unclustered trace, a crash in the mode pass).
+      There is nothing to gate on and this returns, unchanged.
     """
-    if force or mode_report is None or not mode_report.n_invalid:
+    if mode_report is not None:
+        n_invalid = int(mode_report.n_invalid)
+        frac = mode_report.invalid_frac
+        reason_counts = dict(mode_report.invalid_reason_counts or {})
+        per_chain = None
+        all_invalid = False
+    elif status and status.get("state") == MODE_NO_VALID_DRAWS:
+        n_invalid = int(status.get("n_invalid", 0))
+        frac = float(status.get("invalid_frac", 0.0))
+        reason_counts = dict(status.get("reasons") or {})
+        per_chain = status.get("per_chain_invalid")
+        all_invalid = True
+    else:
         return
-    if mode_report.invalid_frac <= max_invalid_frac:
+
+    if not n_invalid or frac <= max_invalid_frac:
         return
+    if force:
+        logger.warning(
+            "modes: %d draws (%.2f%%) are numerically invalid, above "
+            "max_invalid_frac=%.2f%%, but `modes: {force: true}` was set -- "
+            "emitting tables from a trace known to be broken. reasons=%s",
+            n_invalid,
+            100 * frac,
+            100 * max_invalid_frac,
+            reason_counts,
+        )
+        return
+
     where = ""
     if trace_path or modes_path:
         where = f" The trace ({trace_path}) and mode report ({modes_path}) have already been written."
+    override = (
+        " Override with config `modes: {force: true}` (or raise "
+        "`modes.max_invalid_frac`) to re-process forensically."
+    )
+    if all_invalid:
+        raise RuntimeError(
+            f"identify_modes: ALL {n_invalid} draws ({frac:.2%}) were "
+            "rejected as numerically invalid, so no posterior mode could be "
+            "identified and NO summary of this trace is meaningful -- the "
+            "tables would describe draws that were all rejected. "
+            f"reasons={reason_counts}, per-chain invalid counts={per_chain}."
+            + _invalid_reason_hint(reason_counts)
+            + where
+            + " Re-run `exozippy-modes <config>` to inspect the trace "
+            "without raising." + override
+        )
     raise RuntimeError(
-        f"identify_modes: {mode_report.n_invalid} draws "
-        f"({mode_report.invalid_frac:.2%}) rejected as numerically invalid, "
+        f"identify_modes: {n_invalid} draws "
+        f"({frac:.2%}) rejected as numerically invalid, "
         f"exceeding max_invalid_frac={max_invalid_frac:.2%}. This indicates "
         "a model or sampler bug -- investigate before trusting any output."
         + where
-        + " Override with config `modes: {force: true}` (or raise "
-        "`modes.max_invalid_frac`) to re-process forensically."
+        + override
     )
+
+
+def mode_status_to_text(status):
+    """Render a MODE_NO_VALID_DRAWS outcome for ``<prefix>_modes.txt``.
+
+    Mirrors ``ledger.hot_status_to_text``: returns "" for anything it has
+    nothing to say about, so callers can pass a status dict unconditionally.
+
+    Only the all-invalid state renders.  MODE_OK writes a real report (that
+    is ModeReport.to_text's job) and MODE_FAILED is deliberately left
+    byte-identical to its pre-3.17 behaviour -- a crash in the mode pass is
+    not evidence about the draws, and the file it would write here would be
+    the only place claiming otherwise.
+    """
+    if not status or status.get("state") != MODE_NO_VALID_DRAWS:
+        return ""
+    n_invalid = int(status.get("n_invalid", 0))
+    frac = float(status.get("invalid_frac", 0.0))
+    lines = [
+        "Posterior mode report",
+        "=====================",
+        "",
+        "*** NO VALID DRAWS ***",
+        "",
+        f"All {n_invalid} draws ({frac:.2%}) in this trace were rejected as",
+        "numerically invalid, so no mode could be identified and no mode",
+        "report exists. Any table or plot generated from this trace",
+        "describes draws that the validity filter rejected in full.",
+        "",
+        f"reasons: {status.get('reasons') or {}}",
+        f"per-chain invalid counts: {status.get('per_chain_invalid')}",
+    ]
+    hint = _invalid_reason_hint(status.get("reasons") or {})
+    if hint:
+        lines += ["", hint.strip()]
+    lines += [
+        "",
+        "This is a model or sampler bug, not a reporting problem. A live",
+        "fit refuses to write final tables in this state; this file was",
+        "written by a forensic re-processing run (exozippy-modes) or by a",
+        "run with `modes: {force: true}` set.",
+        "",
+    ]
+    return "\n".join(lines)
 
 
 def _fmt_pm(value, err, fmt="{:.4f}"):
@@ -833,7 +1004,15 @@ def identify_modes(
             invalid_per_chain.tolist(),
         )
     if not valid.any():
-        raise ValueError("identify_modes: no valid draws in trace")
+        # Carries the counts so the caller's validity gate has something to
+        # gate on: no ModeReport can exist here, and a bare exception is
+        # indistinguishable from any other mode-pass failure (review 3.17).
+        raise NoValidDrawsError(
+            n_invalid,
+            n_samples,
+            reason_counts=invalid_reason_counts,
+            per_chain=invalid_per_chain.tolist(),
+        )
 
     # ---- standardize + cluster ------------------------------------------
     Xv = X[valid]

--- a/src/exozippy/outputs/report_pipeline.py
+++ b/src/exozippy/outputs/report_pipeline.py
@@ -12,7 +12,16 @@ import logging
 from pathlib import Path
 
 from .latex import build_csv_output, build_latex_output
-from .modes import DEFAULT_MAX_INVALID_FRAC, check_invalid_frac, identify_modes
+from .modes import (
+    DEFAULT_MAX_INVALID_FRAC,
+    MODE_FAILED,
+    MODE_NO_VALID_DRAWS,
+    MODE_OK,
+    NoValidDrawsError,
+    check_invalid_frac,
+    identify_modes,
+    mode_status_to_text,
+)
 from .texutils import latex_escape
 
 logger = logging.getLogger(__name__)
@@ -34,6 +43,7 @@ def build_mode_reports(
     evidence_weights=False,
     seed_ledger=None,
     hot_status=None,
+    mode_status=None,
 ):
     """Identify posterior modes, distribute the posterior, write tables.
 
@@ -43,7 +53,10 @@ def build_mode_reports(
     Mode identification is wrapped in a broad try/except: a broken mode
     pass must never take down the rest of a fit's outputs, so a failure
     here is logged as a warning and the tables fall back to describing the
-    combined (unimodal) posterior.
+    combined (unimodal) posterior.  The one carve-out is
+    ``NoValidDrawsError`` -- every draw rejected by the numerical-validity
+    filter -- which is not a broken mode pass but a broken trace, and is
+    routed to ``check_invalid_frac`` instead of being absorbed.
 
     Parameters
     ----------
@@ -96,11 +109,22 @@ def build_mode_reports(
         ``seed_ledger``: "never searched" and "search failed" are exactly
         the states in which no ledger records exist, and they are precisely
         the states the report must not render as silence.
+    mode_status : dict, optional
+        In/out: filled in with the machine-readable outcome of the mode
+        pass -- a ``state`` from the outputs.modes MODE_* vocabulary plus
+        the invalid-draw bookkeeping -- following the status-dict pattern
+        of outputs/ledger.py's hot-chain search and outputs/evidence.py's
+        per-mode results.  It is what lets a caller tell a returned None
+        that means "the draws are unusable" (MODE_NO_VALID_DRAWS) from one
+        that means "the mode pass could not tell you anything"
+        (MODE_FAILED); the validity gate below reads exactly that
+        distinction.  A fresh dict is used when none is passed.
 
     Returns
     -------
     outputs.modes.ModeReport, or None if mode identification failed or
-    found no valid draws (see the warning logged in that case).
+    found no valid draws (see the warning logged in that case, and
+    ``mode_status`` for which of the two it was).
     """
     prefix = Path(prefix)
     mode_kwargs = {}
@@ -120,8 +144,17 @@ def build_mode_reports(
     # broad catch.
     mode_report = None
     modes_path = None
+    if mode_status is None:
+        mode_status = {}
     try:
         mode_report = identify_modes(idata, **mode_kwargs)
+        mode_status.update(
+            state=MODE_OK,
+            n_draws=int(mode_report.labels.size),
+            n_invalid=int(mode_report.n_invalid),
+            invalid_frac=float(mode_report.invalid_frac),
+            reasons=dict(mode_report.invalid_reason_counts or {}),
+        )
         modes_path = Path(str(prefix) + "_modes.txt")
         modes_path.write_text(mode_report.to_text(), encoding="utf-8")
         if mode_report.n_modes > 1:
@@ -131,7 +164,48 @@ def build_mode_reports(
                 f"({'weights validated' if mode_report.weights_reliable else 'weights UNRELIABLE'}); "
                 f"see {modes_path}"
             )
-    except Exception:
+    except NoValidDrawsError as exc:
+        # EVERY draw failed the numerical-validity filter.  This is the one
+        # mode-pass failure that IS a statement about the draws, so it gets
+        # its own state and is handed to the gate below -- catching it in
+        # the broad clause is what let a 100%-invalid trace emit a clean
+        # -looking table while a 1.1%-invalid one refused (review 3.17).
+        mode_status.update(
+            state=MODE_NO_VALID_DRAWS,
+            n_draws=exc.n_draws,
+            n_invalid=exc.n_invalid,
+            invalid_frac=exc.invalid_frac,
+            reasons=exc.reason_counts,
+            per_chain_invalid=exc.per_chain_invalid,
+            detail=str(exc),
+        )
+        logger.warning(
+            "Mode identification found NO VALID DRAWS: %s. Nothing computed "
+            "from this trace describes a posterior.",
+            exc,
+        )
+        # Leave the forensic record in the file the user is pointed at.
+        # Written before the gate raises (the raise is the point, but the
+        # evidence has to survive it) and before the hot-status/ledger
+        # sections append -- otherwise, on the non-raising paths, the only
+        # <prefix>_modes.txt a user gets is one whose visible content reads
+        # entirely normal.
+        try:
+            modes_path = Path(str(prefix) + "_modes.txt")
+            modes_path.write_text(
+                mode_status_to_text(mode_status), encoding="utf-8"
+            )
+        except Exception:
+            modes_path = None
+            logger.warning(
+                "Could not write the no-valid-draws mode report; the "
+                "failure is reported here and by the check below",
+                exc_info=True,
+            )
+    except Exception as exc:
+        # Any other mode-pass failure says nothing about whether the draws
+        # are usable, so it stays a warning and the gate below stays quiet.
+        mode_status.update(state=MODE_FAILED, detail=repr(exc))
         logger.warning(
             "Mode identification failed; reporting the combined "
             "posterior only",
@@ -142,13 +216,16 @@ def build_mode_reports(
         # The trace and mode report are already written at this point, so
         # evidence survives this raise; override via config
         # `modes: {max_invalid_frac: ..., force: true}` for forensic
-        # re-processing of old/known-bad traces.
+        # re-processing of old/known-bad traces.  mode_status is what makes
+        # the all-invalid case (no report at all) reach this gate instead
+        # of slipping through the None check.
         check_invalid_frac(
             mode_report,
             max_invalid_frac=max_invalid_frac,
             force=force,
             trace_path=trace_path,
             modes_path=modes_path,
+            status=mode_status,
         )
 
     # Optional per-mode evidence weighting (fallback / cross-check path).
@@ -257,6 +334,25 @@ def build_mode_reports(
 
         ledger_rows = bool(rejected_records(seed_ledger))
 
+    # latex.py already appends an invalid-draw note to \tablecomments, but
+    # it reads it off the mode report -- which does not exist when EVERY
+    # draw was invalid, so the one table that is entirely untrustworthy was
+    # the one table carrying no note at all (the same inversion as the gate
+    # itself).  Supply it from the status instead.  Only reachable on the
+    # non-raising paths (exozippy-modes, or `modes: {force: true}`): a live
+    # fit has already refused above.  The percentage MUST carry \%, or the
+    # bare % comments out the rest of the \tablecomments{} line.
+    table_comments = None
+    if mode_status.get("state") == MODE_NO_VALID_DRAWS:
+        table_comments = (
+            rf"ALL {mode_status.get('n_invalid', 0)} draws "
+            rf"({100 * mode_status.get('invalid_frac', 0.0):.2f}\%) in this "
+            "trace were rejected as numerically invalid, so no posterior "
+            "mode could be identified: every value in this table summarizes "
+            "REJECTED draws and none of it is meaningful. This indicates a "
+            "model or sampler bug."
+        )
+
     # Generate latex table and machine-readable CSV.  prefix.stem is a user
     # string on its way into \tablecaption{}: 'DC2018_128' and
     # 'KMT-2019-BLG-1806_nt8long' are both real prefixes here, and a raw
@@ -267,6 +363,7 @@ def build_mode_reports(
         template_filename=str(prefix) + "_template.tex",
         caption=r"Median and 68\% Confidence intervals for "
         + latex_escape(prefix.stem),
+        tablecomments=table_comments,
         mode_report=mode_report,
     )
     build_csv_output(

--- a/tests/test_mode_report.py
+++ b/tests/test_mode_report.py
@@ -20,15 +20,21 @@ from exozippy.components.parameter import Parameter
 from exozippy.outputs.latex import build_csv_output, build_latex_output
 from exozippy.outputs.modes import (
     DEFAULT_MAX_INVALID_FRAC,
+    MODE_FAILED,
+    MODE_NO_VALID_DRAWS,
+    MODE_OK,
     ModeInfo,
     ModeReport,
+    NoValidDrawsError,
     check_invalid_frac,
     identify_modes,
     markov_indicator_iact,
+    mode_status_to_text,
     mode_suffix,
     transition_stats,
     weight_ess,
 )
+from exozippy.outputs.report_pipeline import build_mode_reports
 
 N_CHAIN, N_DRAW = 8, 1500
 N = N_CHAIN * N_DRAW
@@ -996,3 +1002,276 @@ def test_ladder_round_trips_quoted_separately_from_mode_changes():
     assert "temperature round trips" in text
     assert "NOT mode changes" in text
     assert "77" in text
+
+
+# ----------------------------------------------------------------------
+# Review 3.17: the validity gate must not be bypassed by an ALL-invalid
+# trace.  identify_modes cannot return a report when every draw is
+# rejected, so before the fix the failure arrived at build_mode_reports as
+# a bare exception, was absorbed by the broad catch, and
+# check_invalid_frac(None) returned immediately -- a 1.1%-invalid trace
+# refused to emit tables while a 100%-invalid one emitted a clean-looking
+# set.
+# ----------------------------------------------------------------------
+
+
+class _PipelineStubSystem(_StubSystem):
+    """_StubSystem plus the one extra hook build_mode_reports calls."""
+
+    def __init__(self):
+        self.distributed = 0
+
+    def distribute_posterior(self, idata):
+        self.distributed += 1
+
+
+def _all_lp_nan_idata(rng):
+    """Ordinary-looking draws whose stored lp is entirely non-finite.
+
+    The dangerous shape: the parameter values are finite and perfectly
+    plausible, so every table built from them reads as a healthy fit.
+    """
+    return _make_idata({"a_raw": rng.normal(0, 1, N)}, np.full(N, np.nan))
+
+
+def test_no_valid_draws_error_carries_the_counts():
+    """
+    Given a trace in which every draw fails the validity filter,
+    When identify_modes runs,
+    Then it raises NoValidDrawsError (a ValueError) carrying the invalid
+      count, fraction, per-reason breakdown and per-chain counts -- the
+      only channel through which the all-invalid case can reach the gate,
+      since no ModeReport can exist to read them off.
+    """
+    rng = np.random.default_rng(1)
+    idata = _all_lp_nan_idata(rng)
+
+    with pytest.raises(NoValidDrawsError) as excinfo:
+        identify_modes(idata)
+
+    exc = excinfo.value
+    assert isinstance(exc, ValueError)  # pre-existing callers still work
+    assert exc.n_invalid == N
+    assert exc.n_draws == N
+    assert exc.invalid_frac == 1.0
+    assert exc.reason_counts == {"nonfinite-lp": N}
+    assert len(exc.per_chain_invalid) == N_CHAIN
+
+
+def _all_invalid_status(n=1000, n_chain=4):
+    return {
+        "state": MODE_NO_VALID_DRAWS,
+        "n_draws": n,
+        "n_invalid": n,
+        "invalid_frac": 1.0,
+        "reasons": {"nonfinite-lp": n},
+        "per_chain_invalid": [n // n_chain] * n_chain,
+    }
+
+
+def test_check_invalid_frac_raises_when_every_draw_is_invalid():
+    """
+    Given no mode report because EVERY draw was rejected as invalid,
+    When check_invalid_frac runs,
+    Then it raises, says all the draws were rejected, and tells the user
+      what to do next.
+
+    Regression for review 3.17: the absent report used to return early,
+    so 100% invalid was the one fraction the gate let through.
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        check_invalid_frac(
+            None,
+            max_invalid_frac=DEFAULT_MAX_INVALID_FRAC,
+            trace_path="foo_trace.nc",
+            modes_path="foo_modes.txt",
+            status=_all_invalid_status(),
+        )
+
+    msg = str(excinfo.value)
+    assert "ALL 1000 draws (100.00%)" in msg
+    assert "nonfinite-lp" in msg
+    assert "foo_trace.nc" in msg
+    assert "exozippy-modes" in msg  # what to do next
+    assert "modes: {force: true}" in msg
+
+
+def test_check_invalid_frac_silent_when_report_absent_for_other_reasons():
+    """
+    Given no mode report for a reason that says nothing about the draws'
+      numerical validity (the mode pass crashed, or no status was kept),
+    When check_invalid_frac runs,
+    Then it does not raise -- the gate fires on "the draws are unusable",
+      never on "there was nothing to report".
+    """
+    check_invalid_frac(None, max_invalid_frac=DEFAULT_MAX_INVALID_FRAC)
+    check_invalid_frac(None, max_invalid_frac=0.0, status={})
+    check_invalid_frac(
+        None, max_invalid_frac=0.0, status={"state": MODE_FAILED}
+    )
+    check_invalid_frac(None, max_invalid_frac=0.0, status={"state": MODE_OK})
+
+
+def test_check_invalid_frac_all_invalid_honours_the_same_overrides():
+    """
+    Given no mode report because every draw was rejected,
+    When check_invalid_frac runs with force=True, or with a
+      max_invalid_frac of 1.0,
+    Then it does not raise: the all-invalid case is the extreme end of the
+      same continuum and obeys the same documented escape hatches, rather
+      than becoming a second, stricter gate at 100%.
+    """
+    status = _all_invalid_status()
+    check_invalid_frac(None, max_invalid_frac=0.01, force=True, status=status)
+    check_invalid_frac(None, max_invalid_frac=1.0, status=status)
+
+
+def test_mode_status_to_text_renders_only_the_all_invalid_state():
+    """
+    Given a mode-pass status dict,
+    When mode_status_to_text renders it,
+    Then the all-invalid state produces a report saying so, and every
+      other state (including no status at all) renders nothing -- the
+      innocent cases keep writing exactly the files they wrote before.
+    """
+    text = mode_status_to_text(_all_invalid_status())
+
+    assert "NO VALID DRAWS" in text
+    assert "1000 draws (100.00%)" in text
+    assert "nonfinite-lp" in text
+    assert mode_status_to_text(None) == ""
+    assert mode_status_to_text({}) == ""
+    assert mode_status_to_text({"state": MODE_FAILED}) == ""
+    assert mode_status_to_text({"state": MODE_OK}) == ""
+
+
+def test_pipeline_refuses_to_write_tables_when_every_draw_is_invalid(
+    tmp_path,
+):
+    """
+    Given a live fit whose draws were all rejected as numerically invalid,
+    When build_mode_reports runs the reporting pipeline,
+    Then it raises before writing the LaTeX/CSV tables, and the
+      <prefix>_modes.txt it leaves behind says the draws were all rejected.
+
+    Regression for review 3.17: this run used to complete, writing a full
+    set of tables carrying finite values and error bars, with nothing on
+    disk saying the trace had been rejected in its entirety.
+    """
+    rng = np.random.default_rng(2)
+    prefix = tmp_path / "broken"
+    status = {}
+
+    with pytest.raises(RuntimeError, match="ALL 12000 draws"):
+        build_mode_reports(
+            _PipelineStubSystem(),
+            _all_lp_nan_idata(rng),
+            str(prefix),
+            trace_path=str(prefix) + "_trace.nc",
+            raise_on_invalid=True,
+            mode_status=status,
+        )
+
+    assert status["state"] == MODE_NO_VALID_DRAWS
+    assert status["invalid_frac"] == 1.0
+    assert not (tmp_path / "broken_results.csv").exists()
+    assert not (tmp_path / "broken_definitions.tex").exists()
+    assert not (tmp_path / "broken_template.tex").exists()
+    assert "NO VALID DRAWS" in (tmp_path / "broken_modes.txt").read_text()
+
+
+def test_pipeline_reports_all_invalid_without_raising_for_forensics(
+    tmp_path,
+):
+    """
+    Given the same all-invalid trace and the forensic reprocessing path
+      (raise_on_invalid=False, what exozippy-modes uses),
+    When build_mode_reports runs,
+    Then it completes as that tool's contract requires, but records the
+      all-invalid state in the status dict and writes a <prefix>_modes.txt
+      that says so -- the tables it goes on to write are never the only
+      thing on disk describing this trace.
+    """
+    rng = np.random.default_rng(3)
+    prefix = tmp_path / "forensic"
+    status = {}
+
+    report = build_mode_reports(
+        _PipelineStubSystem(),
+        _all_lp_nan_idata(rng),
+        str(prefix),
+        raise_on_invalid=False,
+        mode_status=status,
+    )
+
+    assert report is None
+    assert status["state"] == MODE_NO_VALID_DRAWS
+    assert "NO VALID DRAWS" in (tmp_path / "forensic_modes.txt").read_text()
+    # latex.py's own invalid-draw note reads off the mode report, which does
+    # not exist here, so the pipeline supplies it: the table it does write
+    # must not read as a clean result.
+    template = (tmp_path / "forensic_template.tex").read_text()
+    assert "rejected as numerically invalid" in template
+    assert r"100.00\%" in template
+
+
+def test_pipeline_unchanged_when_the_mode_pass_fails_for_another_reason(
+    tmp_path, monkeypatch
+):
+    """
+    Given a mode pass that fails for a reason unrelated to draw validity,
+    When build_mode_reports runs with raise_on_invalid=True,
+    Then it warns, returns None, and writes the combined-posterior tables
+      exactly as before -- no raise, and no <prefix>_modes.txt invented
+      for a state that carries no evidence about the draws.
+    """
+    import exozippy.outputs.report_pipeline as rp
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("clustering exploded")
+
+    monkeypatch.setattr(rp, "identify_modes", _boom)
+
+    rng = np.random.default_rng(4)
+    idata = _make_idata({"a_raw": rng.normal(0, 1, N)}, rng.normal(0, 1, N))
+    prefix = tmp_path / "innocent"
+    status = {}
+
+    report = build_mode_reports(
+        _PipelineStubSystem(),
+        idata,
+        str(prefix),
+        trace_path=str(prefix) + "_trace.nc",
+        raise_on_invalid=True,
+        mode_status=status,
+    )
+
+    assert report is None
+    assert status["state"] == MODE_FAILED
+    assert not (tmp_path / "innocent_modes.txt").exists()
+    assert (tmp_path / "innocent_results.csv").exists()
+    assert (tmp_path / "innocent_definitions.tex").exists()
+
+
+def test_pipeline_status_records_a_healthy_mode_pass(tmp_path):
+    """
+    Given a healthy trace,
+    When build_mode_reports runs,
+    Then the status dict reports MODE_OK with zero invalid draws, so a
+      caller reading the status can tell success from either failure mode.
+    """
+    rng = np.random.default_rng(5)
+    idata = _make_idata({"a_raw": rng.normal(0, 1, N)}, rng.normal(0, 1, N))
+    status = {}
+
+    report = build_mode_reports(
+        _PipelineStubSystem(),
+        idata,
+        str(tmp_path / "healthy"),
+        raise_on_invalid=True,
+        mode_status=status,
+    )
+
+    assert report is not None
+    assert status["state"] == MODE_OK
+    assert status["n_invalid"] == 0


### PR DESCRIPTION
Review item **3.17**, the last open item in section 3, and the same class as 3.12: the numerical-validity gate was bypassed **exactly when every draw was invalid**.

## What actually happened, reproduced

`identify_modes` raised a bare `ValueError` when `not valid.any()`. `build_mode_reports`'s broad `except Exception` caught it, logged "Mode identification failed; reporting the combined posterior only", and left `mode_report = None`; `check_invalid_frac(None)` returned on its first line.

The reproduction is worse than "the tables get written". With posterior draws from an ordinary N(0,1) and `sample_stats["lp"]` entirely NaN, all 1200 draws are rejected as `nonfinite-lp`, and the run then wrote `_definitions.tex`, `_template.tex` and `_results.csv` carrying finite values and error bars:

```
orbit.period,9.99999,0.00024,0.00021
```

...and **no `_modes.txt` at all**, because that file is only written on the success path. So the fraction the gate refuses at 1.1% was waved through at 100%, and the one artifact that would have said so was the one artifact missing.

`latex.py` has the identical inversion: its `\tablecomments` invalid-draw note reads `mode_report.n_invalid`, so the only entirely untrustworthy table was the only table with no note.

## Telling "unusable draws" from "nothing to report"

`mode_report is None` is reachable innocently, so the gate cannot key on it. The signal is a dedicated `modes.NoValidDrawsError` (a `ValueError` subclass, so any existing `except ValueError` is unaffected), raised from the single `not valid.any()` site and carrying `n_invalid`, `n_draws`, `invalid_frac`, per-reason counts and per-chain counts. `build_mode_reports` catches it **before** the broad clause and records `MODE_NO_VALID_DRAWS` in a `mode_status=` in/out dict (`MODE_OK` / `MODE_NO_VALID_DRAWS` / `MODE_FAILED`).

It cannot be confused with the innocent case: it is raised from exactly one line, guarded by the filter's own predicate, and the counts travel with it -- rather than being inferred from a `None` or from message text. Note the "genuinely unimodal" case never produces `None` at all (it returns a 1-mode report), so the only innocent `None` is a mode-pass crash, which is `MODE_FAILED` and gates nothing.

Both conventions are deliberately borrowed rather than invented: the `status=` in/out dict is `outputs/ledger.py`'s `discover_hot_modes` verbatim, and the `MODE_*` vocabulary follows its `HOT_*` states and #126's per-mode `EV_*`.

## Raise vs warn

Hard raise on the live path. This is the "the code would otherwise emit a number that is simply wrong" exception to the rope rule -- every published value would summarize draws the filter rejected in full.

But **not un-overridable**. It is gated on the same `frac <= max_invalid_frac` comparison and honours the same documented `modes: {force: true}` / `max_invalid_frac` escape hatches as a partially-invalid report; a 99.9%-invalid trace being forceable while a 100% one is not would be arbitrary. `force` now logs a warning through `logger` (so it reaches `<prefix>.log`, not `warnings.warn` -- item 3.12 found one of those that never did) naming what it suppressed. The stale-trace "no opt-out" precedent does not transfer: that gate never had an opt-out, this one already did, deliberately and documented.

## What a user sees

**Live fit**: `RuntimeError` before any table is written, naming the counts, the per-reason and per-chain breakdown, a reason-specific hint (`nonfinite-lp` -> "the parameter values may still look perfectly reasonable in the tables, which is exactly why this cannot pass quietly: check the model's logp for NaN/inf-producing terms"), the already-written trace and report paths, `exozippy-modes <config>` to inspect without raising, and the override key. `<prefix>_modes.txt` is written **first**, headed `*** NO VALID DRAWS ***`, so the evidence survives the raise.

**`exozippy-modes` / `force: true`**: still completes (that tool's contract is forensic re-processing), but writes the NO VALID DRAWS modes file, supplies the `\tablecomments` note from the status ("every value in this table summarizes REJECTED draws"), and the CLI prints a `NO VALID DRAWS` banner instead of the generic "MODE IDENTIFICATION FAILED". The percentage in that note carries `\%` -- a bare `%` would comment out the rest of the `\tablecomments{}` line.

## Byte-identity of the innocent paths, demonstrated

Same script run across the fix (`git checkout HEAD -- src/` -> run -> `git apply` -> run), output directories `diff -r`'d:

- innocent `MODE_FAILED` (mode pass raises for an unrelated reason): identical 3 files, identical bytes, and no `_modes.txt` invented.
- healthy `MODE_OK` 2-mode path: identical 4 files, identical bytes.

## Tests

8 new in `tests/test_mode_report.py`: the error's payload; the gate raising on all-invalid; the gate staying silent for `None` / `{}` / `MODE_FAILED` / `MODE_OK`; the overrides still applying; `mode_status_to_text` rendering only the guilty state; the pipeline refusing and writing no CSV/tex; the forensic path completing with the modes file and table note; the `MODE_FAILED` path unchanged.

Pre-fix: the repo test file fails at collection (`ImportError: cannot import name 'MODE_FAILED'`), so for per-test granularity the two behavioural tests were also run from a scratchpad copy using only pre-existing symbols -- both fail pre-fix (`DID NOT RAISE RuntimeError`, and `FileNotFoundError: .../forensic_modes.txt`) and pass after.

Post-fix: 111 passed across `test_mode_report`, `test_mode_report_cli`, `test_multimode_outputs`, `test_mode_evidence`, `test_mkparam`, plus `test_trace_plots`. `ruff check` / `ruff format --check` clean.

**No existing assertion weakened.** `test_all_invalid_raises`'s `match="no valid draws"` still passes because the new message keeps that leading clause -- deliberately, and commented as load-bearing.

## One follow-up, deliberately not folded in

`mkparam._sample_seed_draws` (`src/exozippy/mkparam.py:174`) also swallows this in a broad catch and falls back to unstratified seeds, so `mkprior` will still emit restart seeds from a 100%-invalid trace -- seeding a fit that has not happened yet, which is why `mkprior` got the stale-trace check in the first place. Its warning now prints the full counts, but the fallback itself is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
