### PR TITLE
refactor: Instrument owns the load_data concatenation template (review 4.2)

### DIFF
--- a/src/exozippy/components/instrument.py
+++ b/src/exozippy/components/instrument.py
@@ -10,6 +10,15 @@ common machinery so it is written and tested once; the physics (RV curve vs
 transit light curve vs magnification vs astrometric position) stays in each
 child.
 
+Reading a file is ``_read_data``; turning the per-file blocks into this
+component's concatenated arrays is ``ConcatenatedData`` (below), the shared
+template the three single-observable children drive from their own
+``load_data``.  ``astrometryinstrument`` is deliberately not one of them: it
+models TWO observables per epoch (dE/dN or sep/PA) in different units, so it
+keeps one dict per file rather than concatenating -- the same asymmetry that
+makes it set ``supports_gp = False`` and ``supports_robust_likelihood =
+False``.
+
 This class is deliberately NOT a discoverable component: it declares none of
 ``Component``'s abstract methods (``prefix``, ``register_parameters``,
 ``build_likelihood``), so it stays abstract and ``factory.discover_components``
@@ -189,6 +198,190 @@ JITTER_RELATIONS = [
 ]
 
 
+class ConcatenatedData:
+    """Per-file accumulator for the arrays an instrument concatenates.
+
+    Every child that models ONE observable per epoch (rv, transit, mulens)
+    builds the same things in ``load_data``: one concatenated time /
+    observable / error array, the ``inst_map`` naming which file each row came
+    from, the block-diagonal detrend design matrix, and -- last -- the GP and
+    robust-likelihood indices derived from all of the above.  This class owns
+    that template so it exists once.
+
+    Usage (the child keeps only its own per-file physics)::
+
+        blocks = self._concat_blocks()
+        for i in range(self.n_elements):
+            df = self._read_data(i, roles=("time", "rv", "err"), detrend=True)
+            ...per-file work...
+            blocks.add(i, time=..., obs=..., err=..., df=df)
+        blocks.finalize("rv", user_factor=...)
+
+    WHY AN ACCUMULATOR AND NOT A TEMPLATE METHOD WITH A PER-FILE HOOK.  The
+    three children disagree about *when* the files are read:
+    ``mulensinstrument`` reads every file in a first pass because the Skowron
+    reference epoch (``t0_par``) is resolved from ALL the times before the
+    per-file observer positions can be computed in a second.  A template method
+    owning the loop would have to grow a "read everything first" mode for that
+    one caller; an accumulator the child feeds is indifferent to the loop
+    structure, which is the part that genuinely differs.
+
+    THE ROW-RANGE INVARIANT IS ENFORCED, NOT ASSUMED.  Each instrument's rows
+    must be a single contiguous block, in config order, in every concatenated
+    array simultaneously: ``Instrument._build_block_detrend`` lays its blocks
+    on the diagonal by walking the per-file row counts in order, and
+    ``mulensinstrument.observer_pos`` is addressed row-for-row against
+    ``time``.  Both break silently if a file is added out of order or a side
+    array disagrees in length, so ``add`` rejects both, and ``finalize``
+    publishes the resulting ``(start, stop)`` ranges as ``owner.row_ranges``
+    rather than leaving every consumer to re-derive them from ``inst_map``.
+    """
+
+    def __init__(self, owner, n_roles=3):
+        self.owner = owner
+        # Number of canonical (non-detrend) columns in the child's `roles`
+        # tuple: the detrend columns are whatever follows them.
+        self.n_roles = int(n_roles)
+        self.times = []
+        self.obs = []
+        self.errs = []
+        self.detrend = []
+        self.counts = []
+        self.sides = {}
+
+    # -- per file --------------------------------------------------------
+    def add(self, i, time, obs, err, df=None, detrend=None, **sides):
+        """Append file ``i``'s block to every array.
+
+        ``time``/``obs``/``err`` are the per-file arrays in the units the
+        child wants concatenated (any unit conversion is the child's, applied
+        before the call).  ``df`` is the DataFrame ``_read_data`` returned:
+        its columns past ``n_roles`` become this file's detrend block.  Pass
+        ``detrend`` explicitly to override that, or leave both unset for a
+        file with no detrend columns.  Extra keyword arguments are per-epoch
+        SIDE ARRAYS (mulensing's ``observer_pos``): they are concatenated
+        along axis 0 and set on the owner under their keyword name, so they
+        stay row-aligned with ``time`` by construction.
+        """
+        if i != len(self.counts):
+            raise ValueError(
+                f"[{self.owner.prefix}] data blocks must be added in config "
+                f"order: expected element {len(self.counts)}, got {i}. The "
+                f"concatenated arrays address each instrument as one "
+                f"contiguous row range (block-diagonal detrending, per-epoch "
+                f"side arrays), which out-of-order blocks break silently."
+            )
+        time = np.asarray(time)
+        n_obs = len(time)
+        for name, arr in (("obs", obs), ("err", err)):
+            if len(np.asarray(arr)) != n_obs:
+                raise ValueError(
+                    f"[{self.owner.prefix}[{self.owner.names[i]}]] "
+                    f"{name} has {len(np.asarray(arr))} rows but time has "
+                    f"{n_obs}."
+                )
+
+        if detrend is None:
+            if df is not None and df.shape[1] > self.n_roles:
+                detrend = df.iloc[:, self.n_roles :].values.astype(float)
+            else:
+                detrend = np.empty((n_obs, 0))
+        detrend = np.asarray(detrend)
+        if detrend.shape[0] != n_obs:
+            raise ValueError(
+                f"[{self.owner.prefix}[{self.owner.names[i]}]] detrend block "
+                f"has {detrend.shape[0]} rows but time has {n_obs}."
+            )
+
+        for name, arr in sides.items():
+            arr = np.asarray(arr)
+            if arr.shape[0] != n_obs:
+                raise ValueError(
+                    f"[{self.owner.prefix}[{self.owner.names[i]}]] per-epoch "
+                    f"array '{name}' has {arr.shape[0]} rows but time has "
+                    f"{n_obs}; side arrays must stay row-aligned with the "
+                    f"observations."
+                )
+            if i == 0:
+                self.sides[name] = []
+            elif name not in self.sides:
+                raise ValueError(
+                    f"[{self.owner.prefix}[{self.owner.names[i]}]] per-epoch "
+                    f"array '{name}' was not supplied for earlier files; a "
+                    f"side array must cover every element or none."
+                )
+            self.sides[name].append(arr)
+        missing = set(self.sides) - set(sides)
+        if missing:
+            raise ValueError(
+                f"[{self.owner.prefix}[{self.owner.names[i]}]] missing "
+                f"per-epoch array(s) {sorted(missing)} supplied by earlier "
+                f"files; a side array must cover every element or none."
+            )
+
+        self.times.append(time)
+        self.obs.append(obs)
+        self.errs.append(err)
+        self.detrend.append(detrend)
+        self.counts.append(n_obs)
+
+    # -- after the loop --------------------------------------------------
+    def finalize(self, observable, user_factor=1.0):
+        """Concatenate, publish on the owner, and run the optional hooks.
+
+        Sets ``time``, ``<observable>``, ``err``, ``inst_map``,
+        ``n_total_obs``, ``row_ranges``, every side array, and the
+        ``detrend_matrix`` / ``n_detrend_per_inst`` / ``total_detrend_cols``
+        triple; then calls ``_prepare_gp`` and ``_prepare_robust``, which are
+        no-ops unless a file set ``gp:`` / ``likelihood:``.
+
+        ``user_factor`` converts the concatenated error from the internal unit
+        it is held in to the user unit the GP amplitude and the robust
+        ``out_scale`` are declared in (both are declared in the same unit as
+        the data, so one factor serves both).
+        """
+        owner = self.owner
+        if len(self.counts) != owner.n_elements:
+            raise ValueError(
+                f"[{owner.prefix}] {len(self.counts)} of {owner.n_elements} "
+                f"elements contributed data blocks; every element must."
+            )
+
+        owner.time = np.concatenate(self.times).astype(float)
+        setattr(owner, observable, np.concatenate(self.obs).astype(float))
+        owner.err = np.concatenate(self.errs).astype(float)
+        # Named `inst_map` so Component.build_tensor_maps auto-generates
+        # `inst_map_tensor` in stage 4.
+        owner.inst_map = np.repeat(
+            np.arange(owner.n_elements), self.counts
+        ).astype(int)
+        owner.n_total_obs = int(owner.inst_map.size)
+        owner.row_ranges = self.row_ranges()
+
+        for name, blocks in self.sides.items():
+            setattr(owner, name, np.concatenate(blocks, axis=0).astype(float))
+
+        (
+            owner.detrend_matrix,
+            owner.n_detrend_per_inst,
+            owner.total_detrend_cols,
+        ) = owner._build_block_detrend(self.detrend, owner.n_total_obs)
+
+        owner._prepare_gp(
+            owner.time, owner.err, owner.inst_map, user_factor=user_factor
+        )
+        owner._prepare_robust(
+            owner.err, owner.inst_map, user_factor=user_factor
+        )
+
+    def row_ranges(self):
+        """``[(start, stop), ...]``: file ``i``'s rows in every array."""
+        edges = np.concatenate(([0], np.cumsum(self.counts))).astype(int)
+        return [
+            (int(edges[i]), int(edges[i + 1])) for i in range(len(self.counts))
+        ]
+
+
 class Instrument(Component):
     # Noise parameterization: "jitter_variance" (additive) or "err_scale"
     # (multiplicative).  Subclasses override; the default matches the majority
@@ -212,6 +405,10 @@ class Instrument(Component):
         # running observation count.
         self.files = [c.get("file") for c in self.config]
         self.n_total_obs = 0
+        # Per-element (start, stop) row ranges into the concatenated arrays,
+        # published by ConcatenatedData.finalize.  Empty for a child that does
+        # not concatenate (astrometryinstrument keeps per-file datasets).
+        self.row_ranges = []
         # Optional per-file exclusion mask (see _apply_mask). Parsed here so a
         # malformed spec fails at construction, not mid-load.
         self.mask_specs = [c.get("mask") for c in self.config]
@@ -287,6 +484,15 @@ class Instrument(Component):
     # ------------------------------------------------------------------
     # Shared data loading
     # ------------------------------------------------------------------
+    def _concat_blocks(self, n_roles=3):
+        """A fresh ``ConcatenatedData`` accumulator for this component.
+
+        ``n_roles`` is the number of canonical columns in the child's
+        ``_read_data(roles=...)`` tuple; anything past them is that file's
+        detrend block.
+        """
+        return ConcatenatedData(self, n_roles=n_roles)
+
     @staticmethod
     def _sort_by_time(df, time_col=0):
         """Return ``df`` sorted ascending by its time column.

--- a/src/exozippy/components/mulensing/mulensinstrument.py
+++ b/src/exozippy/components/mulensing/mulensinstrument.py
@@ -196,13 +196,11 @@ class MulensInstrument(Instrument):
         only event, so the event-0 source, t0_par, and magnification are used
         throughout.
         """
-        all_times, all_flux, all_errs, inst_indices = [], [], [], []
-        all_detrend = []
         self.fs_init = []
         self.q_source_init = []
         self.q_flux_init = []  # per-instrument f_s2/f_s1 (binary source)
         self._raw_time_list = []
-        all_obspos = []
+        blocks = self._concat_blocks()
 
         self._n_sources = int(system.lens.n_sources)
 
@@ -285,7 +283,6 @@ class MulensInstrument(Instrument):
             self.inst_ref_pos.append(np.median(xyz_abs, axis=0))
 
             xyz_delta = self._abs_to_delta(t, xyz_abs)
-            all_obspos.append(xyz_delta)
 
             f_total, q_source, q_flux = self._estimate_flux_components(
                 t, f, xyz_delta, ra_rad, dec_rad, i
@@ -305,54 +302,38 @@ class MulensInstrument(Instrument):
                 data_format=self.config[i].get("data_format", "magnitude"),
             )
 
-            all_times.append(t)
-            all_flux.append(f)
-            all_errs.append(e)
-            inst_indices.append(np.full(len(t), i))
             self._raw_time_list.append(t)
 
             # Optional detrending against extra data columns (columns 4+ of
             # the file), exactly as rvinstrument/transit do: one coefficient
             # per column per instrument, kept from mixing across instruments
-            # by the block-diagonal design matrix built below.  A column is a
-            # magnitude-space trend (airmass, seeing, ...), i.e. it enters the
-            # flux model MULTIPLICATIVELY as 10**(-0.4 * X.c) -- algebraically
-            # identical to the additive magnitude detrending this component
-            # used before it moved to a flux likelihood, and the right form
-            # for a throughput/extinction trend either way.
-            if df.shape[1] > 3:
-                all_detrend.append(df.iloc[:, 3:].values.astype(float))
-            else:
-                all_detrend.append(np.empty((len(t), 0)))
+            # by the block-diagonal design matrix the accumulator builds.  A
+            # column is a magnitude-space trend (airmass, seeing, ...), i.e.
+            # it enters the flux model MULTIPLICATIVELY as 10**(-0.4 * X.c) --
+            # algebraically identical to the additive magnitude detrending
+            # this component used before it moved to a flux likelihood, and
+            # the right form for a throughput/extinction trend either way.
+            #
+            # observer_pos rides along as a per-epoch side array, so the
+            # Skowron geocentric deviations (used by both magnification
+            # paths) stay row-aligned with the photometry by construction.
+            blocks.add(i, time=t, obs=f, err=e, df=df, observer_pos=xyz_delta)
 
         self.inst_ref_pos = np.array(
             self.inst_ref_pos
         )  # (n_inst, 3) absolute AU
-        self.time = np.concatenate(all_times).astype(float)
-        # The modeled observable, in the file's own flux system.  Magnitude
-        # files were converted above; flux files are untouched, negatives and
-        # all.  There is deliberately no `self.mag`: nothing downstream may
-        # reintroduce a magnitude-space likelihood.
-        self.flux = np.concatenate(all_flux).astype(float)
-        self.err = np.concatenate(all_errs).astype(float)
-        self.inst_map = np.concatenate(inst_indices).astype(int)
-        self.observer_pos = np.vstack(all_obspos).astype(
-            float
-        )  # Skowron geocentric deviations (both magnification paths)
-        self.n_total_obs = len(self.time)
 
-        # Block Diagonal Matrix (shared builder keeps coeffs per-instrument)
-        (
-            self.detrend_matrix,
-            self.n_detrend_per_inst,
-            self.total_detrend_cols,
-        ) = self._build_block_detrend(all_detrend, self.n_total_obs)
-
-        # Optional per-file Gaussian process (no-op unless a file sets `gp:`).
-        # Errors are already in the amplitude parameter's unit (flux, in each
-        # file's own flux system).
-        self._prepare_gp(self.time, self.err, self.inst_map)
-        self._prepare_robust(self.err, self.inst_map)
+        # Shared accumulator: concatenation (time/flux/err/observer_pos),
+        # inst_map, the per-file row ranges, the block-diagonal detrend
+        # matrix, and the optional GP / robust-likelihood hooks.  No
+        # user_factor: the errors are already in the amplitude parameters'
+        # unit (flux, in each file's own flux system).
+        #
+        # `flux` is the modeled observable, in the file's own flux system.
+        # Magnitude files were converted above; flux files are untouched,
+        # negatives and all.  There is deliberately no `self.mag`: nothing
+        # downstream may reintroduce a magnitude-space likelihood.
+        blocks.finalize("flux")
 
     def _resolve_t0_par_final(self, system, all_times):
         """Final t0_par: the reference epoch anchoring the Skowron+2011 frame.

--- a/src/exozippy/components/rvinstrument/rvinstrument.py
+++ b/src/exozippy/components/rvinstrument/rvinstrument.py
@@ -126,27 +126,16 @@ class RVInstrument(Instrument):
 
     def load_data(self, system):
         """Stage 1a: Load CSVs and generate data-driven bounds/inits."""
-        all_times, all_rvs, all_errs, inst_indices, all_detrend = (
-            [],
-            [],
-            [],
-            [],
-            [],
-        )
         self.gamma_init = [0.0] * self.n_elements
         self.jittervar_lower = [0.0] * self.n_elements
 
+        blocks = self._concat_blocks()
         for i in range(self.n_elements):
             # Shared reader: columns:, mask:, time_* conversion, then one
             # sort per file before anything is derived from it, keeping the
             # RVs, errors and detrend columns aligned by construction.
             df = self._read_data(i, roles=("time", "rv", "err"), detrend=True)
-            n_obs = len(df)
             factor = self.units[i].to(u.solRad / u.d)
-            all_times.append(df.iloc[:, 0].values)
-            all_rvs.append(df.iloc[:, 1].values * factor)
-            all_errs.append(df.iloc[:, 2].values * factor)
-            inst_indices.append(np.full(n_obs, i))
 
             m_s_factor = self.units[i].to(u.m / u.s)
             self.gamma_init[i] = np.mean(df.iloc[:, 1].values) * m_s_factor
@@ -154,43 +143,22 @@ class RVInstrument(Instrument):
                 df.iloc[:, 2].values, factor=m_s_factor
             )
 
-            if df.shape[1] > 3:
-                all_detrend.append(df.iloc[:, 3:].values.astype(float))
-            else:
-                all_detrend.append(np.empty((n_obs, 0)))
+            blocks.add(
+                i,
+                time=df.iloc[:, 0].values,
+                obs=df.iloc[:, 1].values * factor,
+                err=df.iloc[:, 2].values * factor,
+                df=df,
+            )
 
-        self.time = np.concatenate(all_times).astype(float)
-        self.rv = np.concatenate(all_rvs).astype(float)
-        self.err = np.concatenate(all_errs).astype(float)
+        # Shared accumulator: concatenation (time/rv/err), inst_map, the
+        # per-file row ranges, the block-diagonal detrend matrix, and the
+        # optional GP / robust-likelihood hooks.  self.err ends up in
+        # solRad/d while the GP amplitude and out_scale are declared in m/s,
+        # hence user_factor.
+        blocks.finalize("rv", user_factor=(u.solRad / u.d).to(u.m / u.s))
 
-        # By naming this `inst_map`, the base class auto-generates `inst_map_tensor`
-        self.inst_map = np.concatenate(inst_indices).astype(int)
-
-        self.n_total_obs = len(self.time)
         self.k_init = self._estimate_k_init()
-
-        # Block Diagonal Matrix (shared builder keeps coeffs per-instrument)
-        (
-            self.detrend_matrix,
-            self.n_detrend_per_inst,
-            self.total_detrend_cols,
-        ) = self._build_block_detrend(all_detrend, self.n_total_obs)
-
-        # Optional per-file Gaussian process (no-op unless a file sets `gp:`).
-        # self.err is in solRad/d; the amplitude parameter is declared in m/s.
-        self._prepare_gp(
-            self.time,
-            self.err,
-            self.inst_map,
-            user_factor=(u.solRad / u.d).to(u.m / u.s),
-        )
-        # Optional per-file robust likelihood (no-op unless `likelihood:` is
-        # set).  Same unit conversion: out_scale is declared in m/s.
-        self._prepare_robust(
-            self.err,
-            self.inst_map,
-            user_factor=(u.solRad / u.d).to(u.m / u.s),
-        )
 
     def _estimate_k_init(self):
         """Seed for the planetary RV semi-amplitude, in m/s.

--- a/src/exozippy/components/transit/transit.py
+++ b/src/exozippy/components/transit/transit.py
@@ -116,13 +116,6 @@ class Transit(Instrument):
 
     def load_data(self, system):
         """Stage 1a: Load CSVs and generate data-driven bounds/inits."""
-        all_times, all_fluxes, all_errs, inst_indices, all_detrend = (
-            [],
-            [],
-            [],
-            [],
-            [],
-        )
         self.baseline_init = [1.0] * self.n_elements
         self.jittervar_lower = [0.0] * self.n_elements
 
@@ -157,6 +150,7 @@ class Transit(Instrument):
             self.exptime_min[i] = exptime
             self.ninterp[i] = ninterp
 
+        blocks = self._concat_blocks()
         for i in range(self.n_elements):
             # Shared reader: columns:, mask:, time_* conversion, then one
             # sort per file before anything is derived from it, keeping the
@@ -164,39 +158,24 @@ class Transit(Instrument):
             df = self._read_data(
                 i, roles=("time", "flux", "err"), detrend=True
             )
-            n_obs = len(df)
-            all_times.append(df.iloc[:, 0].values)
-            all_fluxes.append(df.iloc[:, 1].values)
-            all_errs.append(df.iloc[:, 2].values)
-            inst_indices.append(np.full(n_obs, i))
-
             self.baseline_init[i] = np.median(df.iloc[:, 1].values)
             self.jittervar_lower[i] = self._jitter_floor(df.iloc[:, 2].values)
 
-            if df.shape[1] > 3:
-                all_detrend.append(df.iloc[:, 3:].values.astype(float))
-            else:
-                all_detrend.append(np.empty((n_obs, 0)))
+            blocks.add(
+                i,
+                time=df.iloc[:, 0].values,
+                obs=df.iloc[:, 1].values,
+                err=df.iloc[:, 2].values,
+                df=df,
+            )
 
-        self.time = np.concatenate(all_times).astype(float)
-        self.flux = np.concatenate(all_fluxes).astype(float)
-        self.err = np.concatenate(all_errs).astype(float)
-        self.inst_map = np.concatenate(inst_indices).astype(int)
-        self.n_total_obs = len(self.time)
+        # Shared accumulator: concatenation (time/flux/err), inst_map, the
+        # per-file row ranges, the block-diagonal detrend matrix, and the
+        # optional GP / robust-likelihood hooks.  No user_factor: the errors
+        # are already in the amplitude parameters' unit (relative flux).
+        blocks.finalize("flux")
 
         self._build_oversample_grid()
-
-        # Block Diagonal Matrix (shared builder keeps coeffs per-instrument)
-        (
-            self.detrend_matrix,
-            self.n_detrend_per_inst,
-            self.total_detrend_cols,
-        ) = self._build_block_detrend(all_detrend, self.n_total_obs)
-
-        # Optional per-file Gaussian process (no-op unless a file sets `gp:`).
-        # Errors are already in the amplitude parameter's unit (relative flux).
-        self._prepare_gp(self.time, self.err, self.inst_map)
-        self._prepare_robust(self.err, self.inst_map)
 
     def _build_oversample_grid(self):
         """

--- a/tests/test_examples_prepare.py
+++ b/tests/test_examples_prepare.py
@@ -23,9 +23,11 @@ reason, never dropped silently.
 import os
 from pathlib import Path
 
+import numpy as np
 import pytest
 import yaml
 
+from exozippy.components.instrument import Instrument
 from exozippy.system import System
 
 _EXAMPLES = Path(__file__).parent.parent / "examples"
@@ -109,6 +111,39 @@ def test_shipped_example_prepares(path, rel, monkeypatch, caplog):
         if "does not match any registered component" in r.getMessage()
     ]
     assert not ignored, f"{rel} has stale top-level YAML key(s): {ignored}"
+
+    # Every instrument that concatenates its files must hand each element ONE
+    # contiguous row range, in config order, in every concatenated array at
+    # once: Instrument._build_block_detrend lays the detrend blocks on the
+    # diagonal by walking the per-file counts in order, and mulensing's
+    # observer_pos is addressed row-for-row against `time`. Both break
+    # silently otherwise, so the shared accumulator's published row_ranges are
+    # checked against inst_map on every shipped config -- for free, since the
+    # systems are already prepared here.
+    for key, comp in system.active_components.items():
+        if not isinstance(comp, Instrument):
+            continue
+        if not getattr(comp, "row_ranges", None):
+            continue  # per-file datasets (astrometryinstrument), not rows
+        assert len(comp.row_ranges) == comp.n_elements
+        assert comp.row_ranges[0][0] == 0, f"{rel}: {key} row_ranges"
+        assert comp.row_ranges[-1][1] == comp.n_total_obs, (
+            f"{rel}: {key} row_ranges do not cover n_total_obs"
+        )
+        for i, (lo, hi) in enumerate(comp.row_ranges):
+            if i:
+                assert lo == comp.row_ranges[i - 1][1], (
+                    f"{rel}: {key} element {i} is not contiguous with {i - 1}"
+                )
+            assert np.array_equal(
+                np.flatnonzero(comp.inst_map == i), np.arange(lo, hi)
+            ), f"{rel}: {key} element {i} rows disagree with inst_map"
+        for name in ("time", "err", "observer_pos", "detrend_matrix"):
+            arr = getattr(comp, name, None)
+            if arr is not None:
+                assert len(arr) == comp.n_total_obs, (
+                    f"{rel}: {key}.{name} is not row-aligned with time"
+                )
 
 
 def test_every_example_directory_has_a_config():

--- a/tests/test_instrument_base.py
+++ b/tests/test_instrument_base.py
@@ -151,6 +151,228 @@ def test_build_block_detrend_handles_no_detrend_columns():
 
 
 # ---------------------------------------------------------------------------
+# The shared concatenation template (ConcatenatedData)
+#
+# rvinstrument, transit and mulensinstrument all build their concatenated
+# arrays through this accumulator, so the per-file row-range/contiguity
+# invariant that _build_block_detrend and mulensing's observer_pos both depend
+# on is a contract of the base class, and is pinned here rather than being
+# re-derived (or assumed) per child.
+# ---------------------------------------------------------------------------
+_BLOCKS_CONFIG = [
+    {"name": "A", "file": "a.dat"},
+    {"name": "B", "file": "b.dat"},
+    {"name": "C", "file": "c.dat"},
+]
+_BLOCK_ROWS = (4, 3, 5)
+
+
+def _filled_blocks(inst, sides=False):
+    """Feed inst's accumulator three files of 4/3/5 rows and return it."""
+    blocks = inst._concat_blocks()
+    start = 0
+    for i, n in enumerate(_BLOCK_ROWS):
+        rows = np.arange(start, start + n, dtype=float)
+        extra = (
+            {"observer_pos": np.column_stack([rows, rows + 0.5, rows + 0.25])}
+            if sides
+            else {}
+        )
+        blocks.add(
+            i,
+            time=rows,
+            obs=rows * 10.0,
+            err=np.full(n, 0.5),
+            detrend=rows[:, None] + 100.0,
+            **extra,
+        )
+        start += n
+    return blocks
+
+
+def test_concatenated_row_ranges_are_contiguous_and_in_config_order():
+    """
+    Given three files of 4, 3 and 5 observations fed to the shared
+    accumulator,
+    When finalize publishes the concatenated arrays,
+    Then each element owns exactly one contiguous row range, the ranges are
+    in config order and tile the arrays with no gap or overlap, and inst_map
+    agrees with them row for row.
+    """
+    inst = _make(_BLOCKS_CONFIG)
+    _filled_blocks(inst).finalize("rv")
+
+    assert inst.row_ranges == [(0, 4), (4, 7), (7, 12)]
+    assert inst.n_total_obs == 12
+    assert inst.time.shape == (12,)
+    assert inst.rv.shape == (12,)
+    assert inst.err.shape == (12,)
+    # Contiguous, ordered, gapless, and exactly what inst_map says.
+    assert inst.row_ranges[0][0] == 0
+    assert inst.row_ranges[-1][1] == inst.n_total_obs
+    for i, (lo, hi) in enumerate(inst.row_ranges):
+        if i:
+            assert lo == inst.row_ranges[i - 1][1]
+        assert np.array_equal(
+            np.flatnonzero(inst.inst_map == i), np.arange(lo, hi)
+        )
+
+
+def test_concatenated_detrend_blocks_land_in_their_own_row_range():
+    """
+    Given per-file detrend columns,
+    When finalize builds the block-diagonal design matrix,
+    Then each file's block occupies exactly its own row range and its own
+    column range -- the property _build_block_detrend relies on the loop
+    order for, and which an out-of-order block would break silently.
+    """
+    inst = _make(_BLOCKS_CONFIG)
+    _filled_blocks(inst).finalize("rv")
+
+    assert inst.n_detrend_per_inst == [1, 1, 1]
+    assert inst.total_detrend_cols == 3
+    assert inst.detrend_matrix.shape == (12, 3)
+    for i, (lo, hi) in enumerate(inst.row_ranges):
+        block = inst.detrend_matrix[lo:hi, i]
+        assert np.array_equal(block, inst.time[lo:hi] + 100.0)
+        # Nothing of this file leaks into another file's rows/columns.
+        assert np.all(inst.detrend_matrix[:lo, i] == 0.0)
+        assert np.all(inst.detrend_matrix[hi:, i] == 0.0)
+
+
+def test_concatenated_side_arrays_stay_row_aligned():
+    """
+    Given a per-epoch side array (mulensing's observer_pos),
+    When finalize concatenates it,
+    Then it is published on the owner with one row per observation, aligned
+    with `time` inside every element's row range.
+    """
+    inst = _make(_BLOCKS_CONFIG)
+    _filled_blocks(inst, sides=True).finalize("flux")
+
+    assert inst.observer_pos.shape == (12, 3)
+    assert np.array_equal(inst.observer_pos[:, 0], inst.time)
+    for lo, hi in inst.row_ranges:
+        assert np.array_equal(
+            inst.observer_pos[lo:hi, 1], inst.time[lo:hi] + 0.5
+        )
+
+
+def test_concatenated_data_rejects_out_of_order_files():
+    """
+    Given a child that adds its files out of config order,
+    When add is called,
+    Then it raises -- the contiguous-block invariant cannot be restored
+    afterwards and would corrupt the detrend matrix and side arrays silently.
+    """
+    inst = _make(_BLOCKS_CONFIG)
+    blocks = inst._concat_blocks()
+    blocks.add(0, time=[1.0], obs=[1.0], err=[1.0])
+    with pytest.raises(ValueError, match="config order"):
+        blocks.add(2, time=[1.0], obs=[1.0], err=[1.0])
+
+
+@pytest.mark.parametrize("bad", ["obs", "err", "detrend", "side"])
+def test_concatenated_data_rejects_ragged_blocks(bad):
+    """
+    Given a per-file array whose length disagrees with that file's times,
+    When add is called,
+    Then it raises rather than concatenating a misaligned block.
+    """
+    inst = _make(_BLOCKS_CONFIG)
+    blocks = inst._concat_blocks()
+    kwargs = {
+        "time": np.zeros(3),
+        "obs": np.zeros(3),
+        "err": np.zeros(3),
+    }
+    if bad == "side":
+        kwargs["observer_pos"] = np.zeros((2, 3))
+    elif bad == "detrend":
+        kwargs["detrend"] = np.zeros((2, 1))
+    else:
+        kwargs[bad] = np.zeros(2)
+
+    with pytest.raises(ValueError, match="rows but time has"):
+        blocks.add(0, **kwargs)
+
+
+def test_concatenated_data_rejects_a_side_array_on_only_some_files():
+    """
+    Given a side array supplied for the first file but not the second,
+    When add is called,
+    Then it raises: a per-epoch array must cover every element or none, or
+    the concatenated array would silently stop being row-aligned.
+    """
+    inst = _make(_BLOCKS_CONFIG)
+    blocks = inst._concat_blocks()
+    blocks.add(
+        0,
+        time=np.zeros(3),
+        obs=np.zeros(3),
+        err=np.zeros(3),
+        observer_pos=np.zeros((3, 3)),
+    )
+    with pytest.raises(ValueError, match="missing per-epoch array"):
+        blocks.add(1, time=np.zeros(2), obs=np.zeros(2), err=np.zeros(2))
+
+
+def test_concatenated_data_requires_every_element_to_contribute():
+    """
+    Given only two of three elements fed to the accumulator,
+    When finalize runs,
+    Then it raises: inst_map must address every configured instrument.
+    """
+    inst = _make(_BLOCKS_CONFIG)
+    blocks = inst._concat_blocks()
+    for i in range(2):
+        blocks.add(i, time=np.zeros(3), obs=np.zeros(3), err=np.zeros(3))
+    with pytest.raises(ValueError, match="contributed data blocks"):
+        blocks.finalize("rv")
+
+
+def test_concatenated_data_takes_detrend_columns_past_the_roles():
+    """
+    Given a DataFrame with columns past the three canonical roles,
+    When add receives it as `df`,
+    Then those columns become this file's detrend block (and a DataFrame with
+    only the roles yields an empty one).
+    """
+    pd = pytest.importorskip("pandas")
+    inst = _make(_BLOCKS_CONFIG[:2])
+    blocks = inst._concat_blocks()
+    df = pd.DataFrame(
+        {
+            0: [1.0, 2.0],
+            1: [3.0, 4.0],
+            2: [0.1, 0.1],
+            3: [7.0, 8.0],
+            4: [9.0, 10.0],
+        }
+    )
+    blocks.add(
+        0,
+        time=df.iloc[:, 0].values,
+        obs=df.iloc[:, 1].values,
+        err=df.iloc[:, 2].values,
+        df=df,
+    )
+    blocks.add(
+        1,
+        time=np.zeros(2),
+        obs=np.zeros(2),
+        err=np.zeros(2),
+        df=df.iloc[:, :3],
+    )
+    blocks.finalize("rv")
+
+    assert inst.n_detrend_per_inst == [2, 0]
+    assert np.array_equal(
+        inst.detrend_matrix[:2, :2], np.array([[7.0, 9.0], [8.0, 10.0]])
+    )
+
+
+# ---------------------------------------------------------------------------
 # Noise registration into a manifest
 # ---------------------------------------------------------------------------
 def test_register_noise_additive_adds_jitter_variance_and_jitter():


### PR DESCRIPTION
Review item **4.2**: the `load_data` concatenation loop was near-identical in `rvinstrument`, `transit` and `mulensinstrument` -- `Instrument` should own the template.

## Confirmed still live, but narrower than when it was scoped

`_read_data` has since absorbed the per-file *read* (columns / mask / time-system / sort), so that part is already shared. Everything *after* the read was still copy-pasted three ways. Verbatim from `rvinstrument`, with transit and mulens differing only in the observable's name and the unit factor:

```python
all_times, all_rvs, all_errs, inst_indices, all_detrend = ([], [], [], [], [])
...
    all_times.append(df.iloc[:, 0].values)
    all_rvs.append(df.iloc[:, 1].values * factor)
    all_errs.append(df.iloc[:, 2].values * factor)
    inst_indices.append(np.full(n_obs, i))
    if df.shape[1] > 3:
        all_detrend.append(df.iloc[:, 3:].values.astype(float))
    else:
        all_detrend.append(np.empty((n_obs, 0)))

self.time = np.concatenate(all_times).astype(float)
self.rv = np.concatenate(all_rvs).astype(float)
self.err = np.concatenate(all_errs).astype(float)
self.inst_map = np.concatenate(inst_indices).astype(int)
self.n_total_obs = len(self.time)
(self.detrend_matrix, self.n_detrend_per_inst, self.total_detrend_cols) = \
    self._build_block_detrend(all_detrend, self.n_total_obs)
self._prepare_gp(self.time, self.err, self.inst_map, user_factor=...)
self._prepare_robust(self.err, self.inst_map, user_factor=...)
```

## An accumulator, not a template method

`ConcatenatedData` on `instrument.py`, plus `Instrument._concat_blocks()`. Children become:

```python
blocks = self._concat_blocks()
for i in range(self.n_elements):
    df = self._read_data(i, roles=..., detrend=True)
    ...per-file physics...
    blocks.add(i, time=..., obs=..., err=..., df=df)      # mulens adds observer_pos=...
blocks.finalize("rv", user_factor=...)
```

An accumulator rather than a template method owning the loop, because **the loop is what genuinely differs**: mulens reads every file in a first pass so `t0_par` can be resolved from all the times before the per-file observer positions are computed in a second. A template method would need a "read everything first" mode for that one caller; an accumulator is indifferent to loop structure.

## The row-range invariant is now enforced rather than conventional

CLAUDE.md states twice that each instrument's rows must stay contiguous -- `_build_block_detrend`'s block-diagonal ranges and mulens's row-aligned `observer_pos` both break silently otherwise. That was a convention held up by three separate copies doing the same thing.

`add` now rejects an out-of-order file index, a ragged obs/err/detrend block, and a per-epoch side array that disagrees in length or does not cover every element. `finalize` rejects a partial element set and publishes `owner.row_ranges`, so consumers stop re-deriving it from `inst_map`. mulens's `observer_pos` is one of those side arrays, so its row alignment with `time` is now structural.

Net: **-123 lines across the three children, +206 in the base** (mostly the design docstring).

## Proof the loaded data is unchanged

A dump script prepared **every shipped example config** -- 19 of them (rv x7, transit x5, mulens x5, astrometry x4): `kelt4/{kelt4,kelt4_rvonly,kelt4_rv+transit+sed}`, `gj1214`, `hat3`, `kelt17`, `wasp18`, `hd80606`, `GaiaBH1`, `ob08092`, `ob140939`, `ob161003`, `DC2018_128/{,_hpc}`, `KMT-2019-BLG-1806`, `astrometry_sim`, `HIP1349`, `galactic_model`, `hat3_staronly`.

Recorded per example: sha256 of the **raw bytes** plus shape and dtype of `time` / `rv` / `flux` / `err` / `inst_map` / `observer_pos` / `detrend_matrix` / `inst_ref_pos`; the per-file init lists (`gamma_init`, `jittervar_lower`, `baseline_init`, `fs_init`, `q_source_init`, `q_flux_init`, `k_init`, `_t0_par`, `exptime_min`/`ninterp`, `epoch`); the `_gp_obs_index` / `_robust_obs_index` arrays; astrometry's whole per-file `datasets` list; and per-file row ranges recomputed independently from `inst_map`.

Before vs after: **identical on all 19, zero differing fields.**

Start logp bit-identical: `kelt4_rvonly` `-601.0870104036266`, `wasp18` `83568.76956780997`, `ob08092` `6187.7111017152465`, `astrometry_sim` `-251.53335873698006`.

## astrometryinstrument: deliberately not brought in

It does not share the shape. It builds one `datasets` dict per file, concatenates nothing, and has no `inst_map`, no detrend and no GP/robust hooks -- because it models two observables per epoch (dE/dN or sep/PA) in different units, the same asymmetry behind `supports_gp = False`. There is no concatenation template there to share. It is still covered by the new `test_examples_prepare` invariant, which skips on an empty `row_ranges` -- that skip is itself the assertion that it does not concatenate. The reasoning is recorded in the module docstring.

## Two things worth knowing

- **One ordering change**, both halves verified inert by the byte-identity check above: transit's `_build_oversample_grid()` and rv's `_estimate_k_init()` now run after the detrend/GP setup instead of before, so `finalize` can own the tail. Both read only `time` / `inst_map` / `ninterp`.
- **Finding, not folded in**: `MulensInstrument._raw_time_list` is written (initialized, appended per file) and **never read** -- nowhere in `src/`, `tests/`, `scripts/` or the GUI frontend. Dead state, preserved exactly rather than deleted, since removing it is a separate call.

## Tests

New: 222 lines in `test_instrument_base.py` covering the accumulator's contract (out-of-order index, ragged block, side-array length and coverage, partial element set, published row ranges), and 35 in `test_examples_prepare.py` pinning the row-range/contiguity invariant across every shipped example -- the thing that was implicit before.

Green, none weakened: `test_instrument_base` (29), `test_instrument_mask`, `test_instrument_time_columns`, `test_examples_prepare` (83 total), `test_gp`, `test_robust_likelihood`, `test_rv_unit_and_k_seed`, `test_transit_exptime_ninterp`, `test_mulens_flux_likelihood` (116), `test_rv_integration`, `test_rv_model`, `test_mulens_review_fixes`, `test_astrometry` (95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
