### PR TITLE
mkprior: refuse to seed the next fit from a trace with no valid draws

### DIFF
--- a/src/exozippy/mkparam.py
+++ b/src/exozippy/mkparam.py
@@ -10,6 +10,12 @@ import numpy as np
 import yaml
 
 from exozippy.config import validate_sigma_has_center
+from exozippy.outputs.modes import (
+    MODE_FAILED,
+    MODE_NO_VALID_DRAWS,
+    MODE_OK,
+    NoValidDrawsError,
+)
 from exozippy.samplers import convergence
 from exozippy.trace_meta import check_trace_freshness
 
@@ -129,7 +135,145 @@ def _mode_seed_quotas(weights, n):
     return quotas
 
 
-def _sample_seed_draws(idata, n, exclude, rng_seed=0):
+# Sentinel for "run the mode pass yourself" -- distinct from a genuine
+# ``None`` report, which means "the mode pass ran and produced nothing".
+_UNSET = object()
+
+
+def _identify_modes(idata, mode_status):
+    """Run the mode pass ONCE, recording its outcome in ``mode_status``.
+
+    Returns the ``outputs.modes.ModeReport``, or None when there is none.
+
+    ``mode_status`` is an in/out dict filled with a ``state`` from the
+    outputs.modes MODE_* vocabulary plus the invalid-draw bookkeeping,
+    exactly as ``report_pipeline.build_mode_reports`` fills it (which in
+    turn follows ``outputs/ledger.py``'s HOT_* and ``outputs/evidence.py``'s
+    EV_* status dicts).  A returned None is ambiguous on its own, and the
+    distinction the status carries is the whole point here:
+
+    * ``MODE_NO_VALID_DRAWS`` -- EVERY draw failed the numerical-validity
+      filter.  That is a statement about the DRAWS, and mkprior's output
+      seeds the NEXT fit, so it must not be turned into seed values.
+    * ``MODE_FAILED`` -- the mode pass could not tell us anything, for a
+      reason that says nothing about the draws (an unclusterable trace, a
+      crash, an ImportError).  Seed emission carries on unstratified, as it
+      always has: a broken mode pass must never break seed emission.
+
+    ``identify_modes`` itself is looked up per call rather than bound at
+    import time (the MODE_* vocabulary and the exception class are imported
+    at module level, so this cannot fail): it keeps the function
+    monkeypatchable in tests, which is how the "an ordinary mode-pass
+    failure still falls back" guarantee is pinned.
+    """
+    from exozippy.outputs.modes import identify_modes
+
+    try:
+        report = identify_modes(idata, attach=False)
+    except NoValidDrawsError as exc:
+        # The ONE mode-pass failure that is a statement about the DRAWS.
+        # Catching it in the broad clause below is what let a 100%-invalid
+        # trace emit a clean-looking restart file (this is the mkprior-side
+        # sibling of report_pipeline's review-3.17 fix).
+        mode_status.update(
+            state=MODE_NO_VALID_DRAWS,
+            n_draws=exc.n_draws,
+            n_invalid=exc.n_invalid,
+            invalid_frac=exc.invalid_frac,
+            reasons=exc.reason_counts,
+            per_chain_invalid=exc.per_chain_invalid,
+            detail=str(exc),
+        )
+        return None
+    except Exception as exc:  # never let mode analysis break seed emission
+        mode_status.update(state=MODE_FAILED, detail=repr(exc))
+        logger.warning(
+            f"mkprior: mode identification failed ({exc}); falling back to "
+            f"unstratified seed draws."
+        )
+        return None
+
+    mode_status.update(
+        state=MODE_OK,
+        n_draws=int(report.labels.size),
+        n_invalid=int(report.n_invalid),
+        invalid_frac=float(report.invalid_frac),
+        reasons=dict(report.invalid_reason_counts or {}),
+    )
+    return report
+
+
+def _all_draws_invalid(mode_status):
+    """True when the mode pass rejected EVERY draw (MODE_NO_VALID_DRAWS)."""
+    return bool(mode_status) and (
+        mode_status.get("state") == MODE_NO_VALID_DRAWS
+    )
+
+
+def _refuse_invalid_seed_draws(mode_status, trace_path, force=False):
+    """Refuse to emit restart seeds from a trace with NO valid draws.
+
+    mkprior's output IS the next fit's start, so this is the same argument
+    that makes a structurally stale trace a hard ``StaleTraceError`` a few
+    lines below -- and sharper.  Seeds taken from draws the numerical-
+    validity filter rejected in FULL are not a degraded starting point;
+    they are arbitrary numbers wearing the costume of a converged
+    posterior, and multi-seed emission then spreads them across the next
+    fit's chains as its starting basins.  They read as perfectly
+    reasonable: an all-NaN ``sample_stats['lp']`` over ordinary posterior
+    draws emits a restart file whose every value looks healthy.
+
+    Escape hatch: ``mkprior: {force: true}``, and deliberately NOT
+    ``modes: {force: true}``.  The two are different decisions.  The modes
+    key is documented as forensic RE-PROCESSING -- "emit the tables anyway
+    so I can look at them" -- which reads the trace; writing a restart file
+    writes into a fit that has not happened yet.  Honouring the modes key
+    here would also make this whole check a no-op on the one live path that
+    reaches it: under ``modes: {force: true}`` run.py sails past
+    build_mode_reports' identical gate and calls mkprior at the end of
+    wrap-up, so the same key that asks for forensic tables would silently
+    authorize a corrupt restart file as a side effect.
+
+    There is no ``max_invalid_frac`` counterpart, on purpose.  This gate is
+    binary -- either the mode pass could build a report or every single draw
+    was rejected -- so a fraction knob would have exactly two reachable
+    settings and be a second, obscurer spelling of ``force``.  A PARTIALLY
+    invalid trace is left alone here and is the reporting gate's business.
+    """
+    if not _all_draws_invalid(mode_status):
+        return
+
+    n_invalid = int(mode_status.get("n_invalid", 0))
+    frac = float(mode_status.get("invalid_frac", 0.0))
+    detail = (
+        f"ALL {n_invalid} draws ({frac:.2%}) in {trace_path} were rejected "
+        f"as numerically invalid (reasons={mode_status.get('reasons') or {}}, "
+        f"per-chain invalid counts={mode_status.get('per_chain_invalid')})"
+    )
+    if force:
+        logger.warning(
+            "mkprior: %s, but `mkprior: {force: true}` was set -- writing a "
+            "restart file whose seeds come from draws that were ALL "
+            "rejected. The next fit will start from them.",
+            detail,
+        )
+        return
+    raise RuntimeError(
+        f"mkprior: refusing to write a restart file. {detail}. "
+        "This file IS the next fit's start, so seeds taken from draws that "
+        "were all rejected would be spread across that fit's chains as its "
+        "starting basins while reading as a converged posterior -- the "
+        "values look perfectly reasonable. Fix the model or sampler bug "
+        "that produced the invalid draws and re-sample "
+        "(`sampler: {recompute_trace: true}`), or hand-write the restart "
+        "file. To emit it anyway from this known-bad trace, set "
+        "`mkprior: {force: true}` in the config (`modes: {force: true}` "
+        "deliberately does NOT enable this: it authorizes forensic "
+        "REPORTING, not seeding the next fit)."
+    )
+
+
+def _sample_seed_draws(idata, n, exclude, rng_seed=0, mode_report=_UNSET):
     """Pick ``n`` random JOINT (chain, draw) index pairs for multi-seed starts.
 
     When the trace is multimodal (outputs.modes.identify_modes finds more
@@ -152,6 +296,17 @@ def _sample_seed_draws(idata, n, exclude, rng_seed=0):
     Returns (pairs, good_mask, burnin) where ``good_mask`` and ``burnin``
     also describe the pool used, so a caller can compute statistics over
     exactly the same post-burn-in good draws.
+
+    ``mode_report`` lets the caller hand in an already-computed report so
+    the mode pass runs once per mkprior call rather than twice; left unset,
+    this runs it itself (and swallows any failure, as it always has).
+
+    NOTE this pool is NOT validity-filtered: ``find_burnin``'s good-chain
+    mask is a stuck-chain detector and its burn-in is an ESS knee, neither
+    of which is the numerical-validity filter.  Draws are taken blindly
+    from ``post``.  That is fine for a healthy trace and is precisely why
+    the all-invalid case has to be refused by the caller before we get
+    here: this path would otherwise emit rejected draws as seeds.
     """
     post = idata["posterior"]
     var_names = convergence.default_var_names(post)
@@ -160,6 +315,19 @@ def _sample_seed_draws(idata, n, exclude, rng_seed=0):
     ss = idata.get("sample_stats") if hasattr(idata, "get") else None
     if ss is not None and "lp" in ss.data_vars:
         lp = ss["lp"].values
+        if not np.isfinite(lp).any():
+            # An all-non-finite lp is a degenerate input, not a ranking:
+            # good_chain_mask's np.nanargmax raises "All-NaN slice
+            # encountered" on it, which used to abort mkprior with an
+            # opaque numpy error naming nothing.  Only reachable under
+            # `mkprior: {force: true}` (the validity gate refuses first);
+            # treat it as "no lp", which is the same degenerate-input
+            # answer find_burnin gives for a single chain.
+            logger.warning(
+                "mkprior: every lp in the trace is non-finite; treating it "
+                "as absent for the burn-in/good-chain diagnostics."
+            )
+            lp = None
 
     diag = convergence.find_burnin(arrays, lp=lp, var_names=var_names)
     burnin, good_mask = diag["burnin"], diag["good_mask"]
@@ -169,19 +337,16 @@ def _sample_seed_draws(idata, n, exclude, rng_seed=0):
     draw_lo = min(burnin, max(0, n_draws - 1))
 
     # ---- mode-stratified path -------------------------------------------
+    # A mode-pass failure must never break seed emission (_identify_modes
+    # keeps the broad catch that guarantees it); the ONE outcome that is not
+    # a mode-pass failure but a broken trace -- every draw invalid -- is
+    # refused by the caller before this function is reached.
+    if mode_report is _UNSET:
+        mode_report = _identify_modes(idata, {})
     labels = None
-    try:
-        from exozippy.outputs.modes import identify_modes
-
-        report = identify_modes(idata, attach=False)
-        if report.n_modes > 1:
-            labels = report.labels  # (chain, draw); -1 = invalid/unassigned
-            weights = [m.weight for m in report.modes]
-    except Exception as e:  # never let mode analysis break seed emission
-        logger.warning(
-            f"mkprior: mode identification failed ({e}); falling back to "
-            f"unstratified seed draws."
-        )
+    if mode_report is not None and mode_report.n_modes > 1:
+        labels = mode_report.labels  # (chain, draw); -1 = invalid/unassigned
+        weights = [m.weight for m in mode_report.modes]
 
     if labels is not None:
         quotas = _mode_seed_quotas(weights, n)
@@ -245,6 +410,14 @@ def mkprior(
     ``init_scale`` is written: whitening scales are measured from the data at
     startup and the key would be warn-ignored.
 
+    Raises ``RuntimeError`` if EVERY draw in the trace fails the numerical-
+    validity filter -- see ``_refuse_invalid_seed_draws`` for why that is a
+    refusal rather than a warning, and for the ``mkprior: {force: true}``
+    escape hatch.  This check covers the DEFAULT single-seed path too, and
+    has to: seed 0 is the MAP draw, and with an all-NaN lp ``np.argmax``
+    returns index 0, so the emitted "MAP" is silently the first draw of
+    chain 0.
+
     Parameters
     ----------
     config : dict or str or Path
@@ -281,9 +454,11 @@ def mkprior(
     else:
         base_dir = Path(base_dir or ".")
 
+    mkprior_cfg = config.get("mkprior") or {}
     if n_seeds is None:
-        n_seeds = (config.get("mkprior") or {}).get("n_seeds", 1)
+        n_seeds = mkprior_cfg.get("n_seeds", 1)
     n_seeds = max(1, int(n_seeds))
+    force_invalid = bool(mkprior_cfg.get("force", False))
 
     prefix = config.get("prefix", "fitresults/model")
     run_name = Path(prefix).stem  # e.g. "KELT-4A" from "fitresults/KELT-4A"
@@ -352,6 +527,24 @@ def mkprior(
         trace_path,
     )
 
+    # Same argument as the freshness check above, one step further in: a
+    # trace whose draws are ALL numerically invalid cannot seed the next fit
+    # either.  Run the mode pass ONCE here, before the MAP is chosen, and
+    # hand the report down to _sample_seed_draws so multi-seed runs pay for
+    # it exactly once.  It has to run before the MAP selection because the
+    # MAP is seed 0 on EVERY path including the default single-seed one --
+    # gating only inside _sample_seed_draws would leave the default
+    # untouched -- and because an all-non-finite lp otherwise reaches
+    # find_burnin's np.nanargmax and aborts with an opaque numpy error.
+    #
+    # Recomputed here rather than accepted from run.py's live mode pass, for
+    # the same reason the structural fingerprint above is recomputed: what
+    # this function is handed is what its output is built from, and the
+    # standalone entry points have no live System to be handed anything by.
+    mode_status = {}
+    mode_report = _identify_modes(idata, mode_status)
+    _refuse_invalid_seed_draws(mode_status, trace_path, force=force_invalid)
+
     # Find the MAP draw. lp is present for NUTS and for Metropolis traces saved
     # after the fix that persists it right after pm.sample(). Fall back to the
     # posterior median for old Metropolis trace files without lp.
@@ -396,7 +589,10 @@ def mkprior(
     seed_pairs = [(map_chain, map_draw)]
     if n_seeds > 1:
         extra, _pool_mask, _pool_burnin = _sample_seed_draws(
-            idata, n_seeds - 1, exclude=(map_chain, map_draw)
+            idata,
+            n_seeds - 1,
+            exclude=(map_chain, map_draw),
+            mode_report=mode_report,
         )
         seed_pairs += extra
         if len(seed_pairs) < n_seeds:
@@ -554,6 +750,24 @@ def mkprior(
                 f"# Multi-seed: initval is a length-{K} list of joint posterior\n"
                 f"# draws (seed 0 = MAP; 1..{K - 1} = random post-burn-in draws\n"
                 f"# from the good chains). Bounds are scalar (seed 0).\n"
+            )
+        # Only reachable under `mkprior: {force: true}` -- otherwise the gate
+        # above already refused.  The warning it logged scrolls away; this
+        # file is the artifact that outlives it and gets fed to the next fit,
+        # so the provenance has to travel with it.
+        if _all_draws_invalid(mode_status):
+            f.write(
+                "#\n"
+                "# *** WARNING: NO VALID DRAWS ***\n"
+                f"# All {mode_status.get('n_invalid', 0)} draws "
+                f"({100 * mode_status.get('invalid_frac', 0.0):.2f}%) in this "
+                f"trace were rejected as\n"
+                f"# numerically invalid "
+                f"(reasons={mode_status.get('reasons') or {}}). These seeds\n"
+                f"# were emitted only because `mkprior: {{force: true}}` was "
+                f"set. They do NOT\n"
+                f"# describe a posterior -- do not start a production fit "
+                f"from this file.\n"
             )
         yaml.dump(output, f, default_flow_style=False, sort_keys=True)
 

--- a/src/exozippy/system.py
+++ b/src/exozippy/system.py
@@ -42,7 +42,11 @@ can generally construct any model containing arbitrary components.
 #   logger_level   -- run.py, cli.py, cli_modes.py.
 #   sampler        -- run.py (see run.KNOWN_SAMPLER_KEYS for its own block).
 #   modes          -- run.py: {ledger, max_invalid_frac, force, weights}.
-#   mkprior        -- mkparam.mkprior: {n_seeds}.
+#   mkprior        -- mkparam.mkprior: {n_seeds, force}.  `force` is
+#                     deliberately NOT `modes: {force: true}`: that one
+#                     authorizes forensic REPORTING off a known-bad
+#                     trace, this one authorizes seeding the NEXT fit
+#                     from one.  See mkparam._refuse_invalid_seed_draws.
 #   gui            -- gui.status.gui_enabled: {snapshot}.
 #
 # tests/test_known_keys.py cross-checks this set against the top-level-config

--- a/tests/test_mkprior_multiseed.py
+++ b/tests/test_mkprior_multiseed.py
@@ -202,3 +202,229 @@ def test_multi_seed_stratifies_across_modes(tmp_path):
     assert in_majority.any(), f"no majority-mode seeds: {t0_seeds}"
     # seed 0 is the global MAP, which lives in the better-lp minority basin
     assert t0_seeds[0] > 2004.0
+
+
+# ---------------------------------------------------------------------------
+# A trace whose draws are ALL numerically invalid must not seed the next fit.
+#
+# Sibling of the outputs.modes validity gate (review 3.17 / PR #130): there,
+# a 100%-invalid trace slipped past the reporting gate because identify_modes
+# raised instead of returning a report.  Here the same NoValidDrawsError was
+# swallowed by _sample_seed_draws' broad "never let mode analysis break seed
+# emission" catch -- and the single-seed path never even reached it, because
+# with an all-NaN lp np.argmax returns 0 and the "MAP" is silently draw 0 of
+# chain 0.  The values that lands in the restart file look perfectly
+# reasonable, which is exactly why it cannot pass quietly: the file IS the
+# next fit's start.
+# ---------------------------------------------------------------------------
+
+
+def _make_all_invalid_trace(
+    tmp_path, kind="nonfinite-lp", nchain=4, ndraw=400
+):
+    """A trace whose draws are all rejected by identify_modes' filter, over
+    perfectly ordinary-looking posterior values.
+
+    ``nonfinite-lp`` is PR #130's own fixture shape (all-NaN
+    ``sample_stats['lp']``).  ``nonfinite-raw`` keeps lp healthy and makes
+    the raw-space values non-finite instead -- the shape that actually
+    reached the swallowed catch, since find_burnin is happy with it.
+    """
+    rng = np.random.default_rng(0)
+    t0_raw = rng.standard_normal((nchain, ndraw))
+    post = {
+        "lens.t_0": 2000.0 + t0_raw,
+        "lens.t_0_raw": t0_raw,
+        "star.mass": 1.0 + 0.1 * rng.standard_normal((nchain, ndraw, 2)),
+        "star.mass_raw": rng.standard_normal((nchain, ndraw, 2)),
+    }
+    lp = -0.5 * t0_raw**2
+    if kind == "nonfinite-lp":
+        lp = np.full((nchain, ndraw), np.nan)
+    elif kind == "nonfinite-raw":
+        for name in list(post):
+            if name.endswith("_raw"):
+                post[name] = np.full_like(post[name], np.nan)
+    else:  # pragma: no cover - guard against a typo'd parametrization
+        raise ValueError(kind)
+    idata = az.from_dict({"posterior": post, "sample_stats": {"lp": lp}})
+    trace_path = tmp_path / f"{kind}_trace.nc"
+    idata.to_netcdf(str(trace_path))
+    return trace_path
+
+
+@pytest.mark.parametrize("kind", ["nonfinite-lp", "nonfinite-raw"])
+@pytest.mark.parametrize("n_seeds", [1, 4])
+def test_all_invalid_trace_refuses_to_write_a_restart_file(
+    tmp_path, kind, n_seeds
+):
+    """
+    Given a trace in which EVERY draw fails the numerical-validity filter,
+    When mkprior is asked for a restart file (single- or multi-seed),
+    Then it raises instead of writing one, and nothing is written.
+
+    Parametrized over both seed counts on purpose: the single-seed path is
+    the default and the one run.py fires post-fit, and it never calls
+    _sample_seed_draws at all -- so a gate that lived only there would leave
+    it wide open.
+    """
+    trace_path = _make_all_invalid_trace(tmp_path, kind)
+    out = tmp_path / "out.params.yaml"
+
+    with pytest.raises(RuntimeError) as excinfo:
+        mkprior(
+            _config(),
+            base_dir=tmp_path,
+            trace_path=trace_path,
+            output_path=out,
+            n_seeds=n_seeds,
+        )
+
+    assert not out.exists(), "a restart file was written despite the refusal"
+    msg = str(excinfo.value)
+    assert "1600" in msg, f"counts not named: {msg}"
+    assert "100.00%" in msg, f"invalid fraction not named: {msg}"
+    assert str(trace_path) in msg, f"trace path not named: {msg}"
+    assert kind in msg, f"rejection reason not named: {msg}"
+    # What to do next, and the escape hatch -- which is deliberately the
+    # mkprior key, not the modes one.
+    assert "recompute_trace" in msg
+    assert "mkprior: {force: true}" in msg
+
+
+def test_all_invalid_refusal_is_not_enabled_by_the_modes_force_key(tmp_path):
+    """
+    Given an all-invalid trace and `modes: {force: true}` in the config,
+    When mkprior runs,
+    Then it STILL refuses.
+
+    `modes: {force: true}` authorizes forensic RE-PROCESSING -- emitting
+    tables so a broken run can be inspected -- and under it run.py sails
+    past build_mode_reports' identical gate and goes on to call mkprior at
+    the end of wrap-up.  If that key also unlocked seed emission, this check
+    would be a no-op on the one live path that reaches it, and asking for
+    forensic tables would silently authorize a corrupt restart file as a
+    side effect.
+    """
+    trace_path = _make_all_invalid_trace(tmp_path)
+    out = tmp_path / "out.params.yaml"
+    config = dict(_config(), modes={"force": True, "max_invalid_frac": 1.0})
+
+    with pytest.raises(RuntimeError, match="refusing to write a restart file"):
+        mkprior(
+            config,
+            base_dir=tmp_path,
+            trace_path=trace_path,
+            output_path=out,
+            n_seeds=4,
+        )
+    assert not out.exists()
+
+
+@pytest.mark.parametrize("n_seeds", [1, 4])
+def test_mkprior_force_emits_seeds_and_stamps_the_file(tmp_path, n_seeds):
+    """
+    Given an all-invalid trace and `mkprior: {force: true}`,
+    When mkprior runs,
+    Then it writes the restart file, and the FILE itself carries the
+      no-valid-draws warning.
+
+    The log line scrolls away; this file is the artifact that outlives it
+    and gets handed to the next fit, so the provenance has to travel with
+    it.  (The single-seed case also pins that the all-NaN lp no longer
+    aborts inside find_burnin's np.nanargmax with an opaque
+    "All-NaN slice encountered" naming nothing.)
+    """
+    trace_path = _make_all_invalid_trace(tmp_path)
+    out = tmp_path / "out.params.yaml"
+
+    mkprior(
+        dict(_config(), mkprior={"force": True}),
+        base_dir=tmp_path,
+        trace_path=trace_path,
+        output_path=out,
+        n_seeds=n_seeds,
+    )
+
+    text = out.read_text()
+    assert "NO VALID DRAWS" in text
+    assert "All 1600 draws (100.00%)" in text
+    assert "mkprior: {force: true}" in text
+    params = yaml.safe_load(text)
+    assert "lens.L.t_0" in params  # seeds were in fact emitted
+
+
+def test_an_ordinary_mode_pass_failure_still_falls_back_unchanged(
+    tmp_path, monkeypatch
+):
+    """
+    Given a HEALTHY trace and a mode pass that crashes for an unrelated
+      reason,
+    When mkprior runs,
+    Then it still emits seeds, byte-identically to the no-crash run.
+
+    The broad "never let mode analysis break seed emission" catch is right
+    and must keep working; only the all-draws-invalid case is carved out of
+    it.
+    """
+    import exozippy.outputs.modes as modes_mod
+
+    trace_path = _make_trace(tmp_path)
+    control = tmp_path / "control.params.yaml"
+    mkprior(
+        _config(),
+        base_dir=tmp_path,
+        trace_path=trace_path,
+        output_path=control,
+        n_seeds=4,
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("synthetic mode-pass crash")
+
+    monkeypatch.setattr(modes_mod, "identify_modes", boom)
+    crashed = tmp_path / "crashed.params.yaml"
+    mkprior(
+        _config(),
+        base_dir=tmp_path,
+        trace_path=trace_path,
+        output_path=crashed,
+        n_seeds=4,
+    )
+
+    assert crashed.read_text() == control.read_text()
+
+
+def test_a_partially_invalid_trace_is_left_alone(tmp_path):
+    """
+    Given a trace with SOME invalid draws but not all,
+    When mkprior runs,
+    Then it emits the restart file as before.
+
+    This gate is binary by design: either identify_modes could build a
+    report or it rejected every single draw.  A partial invalid fraction is
+    the REPORTING gate's business (`modes: {max_invalid_frac}`), and mkprior
+    deliberately has no fraction knob of its own -- with only two reachable
+    settings it would just be an obscurer spelling of `force`.
+    """
+    rng = np.random.default_rng(0)
+    nchain, ndraw = 4, 400
+    t0_raw = rng.standard_normal((nchain, ndraw))
+    lp = -0.5 * t0_raw**2
+    lp[0, :50] = np.nan  # 3.1% invalid
+    post = {"lens.t_0": 2000.0 + t0_raw, "lens.t_0_raw": t0_raw}
+    trace_path = tmp_path / "partial_trace.nc"
+    az.from_dict({"posterior": post, "sample_stats": {"lp": lp}}).to_netcdf(
+        str(trace_path)
+    )
+
+    out = tmp_path / "out.params.yaml"
+    mkprior(
+        {"prefix": "run", "lens": [{"name": "L"}]},
+        base_dir=tmp_path,
+        trace_path=trace_path,
+        output_path=out,
+        n_seeds=4,
+    )
+    params = yaml.safe_load(out.read_text())
+    assert len(params["lens.L.t_0"]["initval"]) == 4


### PR DESCRIPTION
Follow-up to #130, which noted that `mkparam._sample_seed_draws` swallows `NoValidDrawsError` in a broad catch. **Stacked on #130** -- it needs that PR's error type and `MODE_*` vocabulary. Retarget to `master` once #130 merges.

## What actually landed in a restart file

Built #130's own fixture shape -- ordinary posterior draws, `sample_stats["lp"]` entirely NaN, 4 chains x 400 draws. `identify_modes` correctly raised `NoValidDrawsError` (1600/1600, `reasons={'nonfinite-lp': 1600}`). `mkprior` then wrote, without complaint:

```
# Generated by mkprior from bad_trace.nc  (MAP lp=nan)
lens.L.alpha:  {initval: 73.8857451}
lens.L.t_0:    {initval: 2000.12573022}
star.A.mass:   {initval: 1.04043598}
star.B.mass:   {initval: 1.13253231}
```

Every number reads like a converged fit. All four are chain 0, draw 0: **`np.argmax` of an all-NaN array returns index 0**, so the "MAP" was silently the trace's very first draw.

## The catch named in #130 was not the whole bug

`_sample_seed_draws` is only called when `n_seeds > 1`; seed 0 is always the MAP. So **the default single-seed path never reached that catch at all**, and a gate placed only there would have left the default -- and `run.py`'s post-fit call -- wide open. The gate goes in `mkprior` itself, before MAP selection.

Two other all-invalid shapes:

- **`nonfinite-raw`** (raw values NaN, lp healthy) is the one that really did hit the named catch: `n_seeds=4` logged "mode identification failed (...no valid draws...); falling back to unstratified seed draws" and emitted 4 seeds. The emitted values are the *physical* vars, which are finite, so the file again reads perfectly normal.
- **all-NaN lp with `n_seeds > 1`** never reached the catch either -- `find_burnin` -> `good_chain_mask` -> `np.nanargmax` raised `ValueError: All-NaN slice encountered` *outside* the try. Loud, but an opaque numpy message naming nothing.

## The unstratified fallback does not filter

It samples blindly: `rng.choice(good_chains)` x `rng.integers(draw_lo, n_draws)`. `find_burnin`'s good-chain mask is a stuck-chain detector and its burn-in is an ESS knee -- neither is the numerical-validity filter (finite raw / |lp| ceiling / robust-z). In the `nonfinite-raw` case lp is a healthy Gaussian, so every chain passes and burn-in is chosen normally. Falling back was not fine.

`find_burnin`'s call site is now guarded (`lp = None` when nothing in it is finite, with a warning), since under `force` that path becomes reachable; `good_chain_mask` already documents degenerate input as "all chains good".

## Escape hatch: `mkprior: {force: true}`, deliberately NOT `modes: {force: true}`

`modes: {force: true}` is documented as forensic re-processing -- "emit the tables anyway so I can look at them" -- which **reads** a trace. Writing a restart file writes into a fit that has not happened yet.

Honouring the modes key would also have made this fix a no-op on the one live path that reaches it. `run.py:777` is reachable **only** under `modes: {force: true}` or a loosened `max_invalid_frac` (otherwise #130 aborts wrap-up first), so asking for forensic tables would silently authorize a corrupt restart file as a side effect.

mkprior's own precedent, `StaleTraceError`, has no opt-out at all -- so a separate explicit key is strictly *more* permissive than the neighbour, not a new hard gate. There is no `max_invalid_frac` counterpart: this gate is binary (either a report exists or every draw was rejected), so a fraction knob would have two reachable settings and be an obscurer spelling of `force`. A partially-invalid trace is left alone, which is the reporting gate's business -- pinned by a test.

Under force the **emitted file** carries the banner (`*** WARNING: NO VALID DRAWS *** / All 1600 draws (100.00%) ... do not start a production fit from this file`), because the log line scrolls away and the file is what feeds the next fit.

## Byte-identical evidence

`mkprior` run before and after on two real traces, four configurations, md5-compared:

| trace | n_seeds | path | md5 same |
|---|---|---|---|
| `DC2018_128_2_trace.nc` (2 modes, weights 0.969/0.031, quotas [2,1]) | 4 | mode-stratified | `8179957c...` yes |
| same | 1 | MAP-only | `1e1774b4...` yes |
| `KELT-4A_trace.nc` (unimodal) | 4 | unstratified | `2ae5f622...` yes |
| same | 1 | MAP-only | `df4024be...` yes |

`diff -r` on the whole directory is empty. A synthetic mode-pass crash on a healthy trace also produced a restart file byte-identical to the no-crash control (a test).

Cost: single-seed `mkprior` now runs one `identify_modes` pass it did not before -- 0.6 s (KELT-4A), 1.6 s (DC2018_128), 6.7 s (OGLE-2016-BLG-1003, 120 chains). Multi-seed is unchanged; the report is passed down rather than recomputed.

## A dead script found in passing, not fixed

`scripts/mkprior.py` does `from exozippy.mkprior import backup_params, mkprior`, and there is no `exozippy/mkprior.py` -- the module is `mkparam`. It raises `ModuleNotFoundError` on every invocation. Pre-existing and out of scope; it is a one-word fix plus checking whether `backup_params` still exists.

## Tests

9 parametrized tests in `tests/test_mkprior_multiseed.py`: refusal over {`nonfinite-lp`, `nonfinite-raw`} x {n_seeds 1, 4}, asserting the trace path, counts, fraction, reason, `recompute_trace` and the escape-hatch key all appear in the message and that nothing was written; `modes: {force: true}` does **not** unlock it; `mkprior: {force: true}` emits and stamps the file; an ordinary mode-pass failure still falls back byte-identically; a partially-invalid trace is untouched.

Pre-fix: **7 of 9 fail**; the 2 that pass are the unchanged-behaviour guards, which is correct.

Post-fix: 108 passed across `test_mkprior_multiseed`, `test_mkparam`, `test_mode_report`, `test_trace_staleness`, `test_known_keys`, `test_mkprior_in_memory`. `ruff` clean. No existing assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)