### PR TITLE
mulensing: one q sanitizer, one alpha_deg, and no nan_to_num on q (review 4.5)

### DIFF
--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -16,9 +16,20 @@ from exozippy.potentials import soft_lower_bound
 from ..galacticmodel.physics import expected_proper_motion
 from . import mmexofast_support
 from .op import BinaryLensMagOp, MulensMagOp, VBMDirectMagOp
-from .physics import MU_REL_FLOOR, THETA_E_FLOOR
+from .physics import (
+    _Q_NAN_ADVICE,
+    MU_REL_FLOOR,
+    Q_MAX,
+    Q_MIN,
+    THETA_E_FLOOR,
+    clip_q,
+)
 
 logger = logging.getLogger(__name__)
+
+# alpha is stored in radians (lens.alpha's internal_unit) and consumed in
+# degrees by both magnification backends.
+_RAD_TO_DEG = 180.0 / np.pi
 
 
 def _parse_body_ref(ref):
@@ -396,10 +407,6 @@ class Lens(Component):
     def _primary_source(self, event_idx):
         """Return (comp_type, star_ndx) for the primary source of event i."""
         return self.source_bodies[event_idx][0]
-
-    def _body_mass(self, system, comp_type, ndx):
-        """Return the PyTensor mass node for a given body."""
-        return getattr(system, comp_type).mass.value[ndx]
 
     def _mass_initval(self, comp_type, ndx):
         """Best-effort mass initval (solMass) for a body at stage 2, from
@@ -783,7 +790,7 @@ class Lens(Component):
         if isinstance(sa, (list, tuple)):
             sa = sa[0] if sa else None
         if ca is not None and sa is not None:
-            alpha_deg = float(np.arctan2(float(sa), float(ca)) * 180.0 / np.pi)
+            alpha_deg = float(np.arctan2(float(sa), float(ca)) * _RAD_TO_DEG)
             self.config_manager.add_hint(f"lens.0.alpha", alpha_deg, rank=20)
 
         # Expected proper motions from the galactic model, for the seeds below.
@@ -1061,8 +1068,48 @@ class Lens(Component):
         )
         return float(v @ e_hat), float(v @ n_hat)
 
+    def _validate_q_start(self):
+        """Stage 6: check the START value of the mass ratio, loudly and once.
+
+        The magnification path clips q into [Q_MIN, Q_MAX] (physics.clip_q) --
+        a statement about where the backends are defined, not a licence to
+        invent a mass ratio.  The clip used to be preceded by
+        ``pt.nan_to_num(q, nan=Q_MIN)``, which silently turned a failed
+        computation into a healthy-looking likelihood.  That scrub is gone; a
+        NaN now reaches logp and the proposal is rejected.  What the scrub also
+        hid, though, was the *start*, and a bad start is the case that is worth
+        a message rather than a rejection -- so it is checked here, once, on
+        the inputs, where a raise costs nothing and can say what to do.
+
+        NaN is fatal: the fit cannot start.  Out of range (the infinities
+        included -- they at least carry a sign, the same split clip_q_value
+        makes) is a warning: the fit will silently begin at the clipped q
+        rather than at the seeded one, which is exactly the sort of "the number
+        I typed is not the number being fitted" that goes unnoticed for months.
+        """
+        if self.n_companions < 1 or self.q.initval is None:
+            return
+        q0 = np.atleast_1d(np.asarray(self.q.initval, dtype=float)).ravel()
+        if np.any(np.isnan(q0)):
+            raise ValueError(
+                f"{self.prefix}.q starts at {q0.tolist()}, which is not a "
+                f"number.  {_Q_NAN_ADVICE}"
+            )
+        out = (q0 < Q_MIN) | (q0 > Q_MAX)
+        if np.any(out):
+            logger.warning(
+                f"{self.prefix}.q starts at {q0[out].tolist()}, outside the "
+                f"[{Q_MIN:g}, {Q_MAX:g}] range the binary-lens magnification "
+                "backends are defined on, so the fit will actually START at "
+                "the clipped value.  Move the start inside the range (set "
+                f"{self.prefix}.q, or the companion/primary masses it is "
+                "derived from) rather than relying on the clip."
+            )
+
     def build_likelihood(self, model, system):
         """Stage 6: Observational penalties on the lensing geometry."""
+        self._validate_q_start()
+
         # GEOCENTRIC mu_rel: the event-rate selection is the sky-sweep rate
         # in the frame the event is observed in (rp.py used the geocentric
         # value at t0_par; Batista+2011's rate is in the frame of the
@@ -1111,6 +1158,20 @@ class Lens(Component):
     # Magnification
     # ------------------------------------------------------------------
 
+    def _alpha_deg(self, j=0):
+        """Trajectory angle of companion ``j`` in DEGREES -- the unit both
+        magnification backends take, while lens.alpha's internal unit is
+        radians.
+
+        Reads the alpha Parameter rather than re-deriving ``arctan2(yalpha,
+        xalpha)`` at each call site (it was open-coded twice; review item 4.5).
+        alpha's expression IS that arctan2 (physics.calc_alpha), so this is
+        bit-identical, and going through the Parameter means the angle handed
+        to the backend is by construction the same one the reports, priors and
+        plots see.
+        """
+        return self.alpha.value[j] * _RAD_TO_DEG
+
     def _get_safe_mm_params(self, index=0):
         """Sanitized single-source params.  ``index`` is the SOURCE slot: the
         per-source vector parameters (t_0, u_0, t_E, pi_E_*) hold one element
@@ -1139,7 +1200,7 @@ class Lens(Component):
             "pi_E": pt.switch(is_physical, pi_E_scrubbed, 0.0),
         }
 
-    def _get_binary_mm_params(self, system, index=0):
+    def _get_binary_mm_params(self, index=0):
         """Params for a binary lens.  ``index`` is the SOURCE slot; the lens
         bodies are shared by all sources (single event ⇒ event index 0).
 
@@ -1147,26 +1208,21 @@ class Lens(Component):
         the TOTAL lens mass via mlens_total, so the safe single-source params
         pass straight through — only the companion geometry (s, q, alpha) is
         added here.
+
+        It no longer takes ``system``: q used to be recomputed here from the
+        two body mass nodes, which is what needed it.  It now reads the q
+        Parameter, which is that same ratio (physics.calc_q) and is what every
+        other consumer already uses.
         """
         s = self._get_safe_mm_params(index)
 
-        l2_type, l2_idx = self.lens_bodies[0][1]
-        m1 = self._body_mass(system, *self.lens_bodies[0][0])
-        m2 = self._body_mass(system, l2_type, l2_idx)
-        q = m2 / pt.maximum(m1, 1e-10)
-        q_safe = pt.clip(pt.nan_to_num(q, nan=1e-9), 1e-9, 100.0)
-
-        # s/xalpha/yalpha are indexed by companion (binary = companion 0),
-        # not by event or source.
-        alpha_deg = pt.arctan2(self.yalpha.value[0], self.xalpha.value[0]) * (
-            180.0 / np.pi
-        )
-
+        # s/q/alpha are indexed by companion (binary = companion 0), not by
+        # event or source.
         return {
             **s,
             "s": self.s.value[0],
-            "q": q_safe,
-            "alpha": alpha_deg,
+            "q": clip_q(self.q.value[0]),
+            "alpha": self._alpha_deg(0),
         }
 
     def get_magnification(self, times, obs_pos, system, index=0):
@@ -1357,13 +1413,13 @@ class Lens(Component):
             if use_rho:
                 param_list.append(self.rho.value[index])
             for j in range(self.n_companions):
-                q_j = pt.clip(
-                    pt.nan_to_num(self.q.value[j], nan=1e-9), 1e-9, 100.0
+                param_list.extend(
+                    [
+                        self.s.value[j],
+                        clip_q(self.q.value[j]),
+                        self._alpha_deg(j),
+                    ]
                 )
-                alpha_deg_j = pt.arctan2(
-                    self.yalpha.value[j], self.xalpha.value[j]
-                ) * (180.0 / np.pi)
-                param_list.extend([self.s.value[j], q_j, alpha_deg_j])
             if effective_bandpass is not None:
                 param_list.append(u1)
             mag_op = VBMDirectMagOp(
@@ -1373,7 +1429,7 @@ class Lens(Component):
                 bandpass=effective_bandpass,
             )
         elif n_lenses == 2:
-            bp = self._get_binary_mm_params(system, index)
+            bp = self._get_binary_mm_params(index)
             param_list = [bp["t0"], bp["u0"], bp["tE"], bp["pi_N"], bp["pi_E"]]
             if use_rho:
                 param_list.append(self.rho.value[index])

--- a/src/exozippy/components/mulensing/mulensinstrument.py
+++ b/src/exozippy/components/mulensing/mulensinstrument.py
@@ -16,6 +16,7 @@ from exozippy.config import RANK_DERIVED_DATA
 from exozippy.ephemeris import get_observer_position
 
 from . import mmexofast_support
+from .physics import clip_q_value
 
 
 def _raw_initval(data, default=None):
@@ -682,7 +683,7 @@ class MulensInstrument(Instrument):
                     "u_0": float(np.sign(u0) * max(abs(u0), 1e-9)),
                     "t_E": max(float(tE), 1e-4),
                     "s": max(float(s_val), 1e-6),
-                    "q": float(np.clip(q_val, 1e-9, 100.0)),
+                    "q": clip_q_value(q_val, "lens.0.q (flux bootstrap)"),
                     "alpha": float(alpha),
                 }
                 rho = _get(f"lens.{j}.rho")

--- a/src/exozippy/components/mulensing/op.py
+++ b/src/exozippy/components/mulensing/op.py
@@ -9,6 +9,8 @@ from astropy.coordinates import SkyCoord
 from pytensor.gradient import DisconnectedType
 from pytensor.graph import Apply, Op
 
+from .physics import clip_q_value
+
 
 def _clear_mm_satellite_cache():
     """Drop MulensModel's class-level satellite-delta cache before each call.
@@ -113,7 +115,7 @@ def _build_binary_model(p, coords, mag_method, use_rho=False):
         mm_params["rho"] = _safe_rho(p[idx])
         idx += 1
     mm_params["s"] = float(max(float(p[idx]), 1e-6))
-    mm_params["q"] = float(np.clip(float(p[idx + 1]), 1e-9, 100.0))
+    mm_params["q"] = clip_q_value(p[idx + 1], "lens.q")
     mm_params["alpha"] = float(p[idx + 2])
 
     model = mm.Model(parameters=mm_params, coords=coords)
@@ -463,6 +465,15 @@ class VBMDirectMagOp(Op):
         outputs[0][0] = np.asarray(A, dtype=np.float64)
 
     def _compute(self, p, times_np, obs_pos_np):
+        # Non-finite check FIRST: it is the explicit handler for a NaN
+        # parameter vector (return NaN magnifications -> logp = -inf ->
+        # proposal rejected), and running it before the unpacking below means
+        # clip_q_value never has to be the one to notice.  It used to sit
+        # after the unpacking, which only worked because np.clip passed NaN
+        # through silently.
+        if not np.all(np.isfinite(p)):
+            return np.full(len(times_np), np.nan)
+
         base = _base_mm_params(p)
         idx = 5
         rho = 0.0
@@ -470,19 +481,16 @@ class VBMDirectMagOp(Op):
             rho = _safe_rho(p[idx])
             idx += 1
         companions = []
-        for _ in range(self.n_companions):
+        for j in range(self.n_companions):
             companions.append(
                 (
                     float(max(float(p[idx]), 1e-6)),
-                    float(np.clip(float(p[idx + 1]), 1e-9, 100.0)),
+                    clip_q_value(p[idx + 1], f"lens.q[{j}]"),
                     float(np.radians(float(p[idx + 2]))),
                 )
             )
             idx += 3
         u1 = float(p[-1]) if self.bandpass is not None else None
-
-        if not np.all(np.isfinite(p)):
-            return np.full(len(times_np), np.nan)
 
         dN, dE = self._deltas(obs_pos_np)
         tau = (

--- a/src/exozippy/components/mulensing/physics.py
+++ b/src/exozippy/components/mulensing/physics.py
@@ -124,6 +124,91 @@ def calc_q(*masses):
     return pt.concatenate([pt.atleast_1d(c) for c in companions]) / primary
 
 
+# --- Mass-ratio sanitization ------------------------------------------------
+# Validity range of the binary/multiple-lens magnification backends.  Both
+# MulensModel and VBMicrolensing require a strictly positive, finite q, and the
+# caustic solvers stop converging well before these limits.  Q_MIN sits a decade
+# below lens.q's own defaults.yaml `lower: 1e-8` soft barrier, so on a fit that
+# is behaving the clip is never active: the barrier turns the sampler around
+# first.  Q_MAX is exactly lens.q's `upper` (q > 1 is legal -- it is the same
+# geometry with the two bodies relabelled).
+#
+# This is a RANGE decision and ONLY a range decision.  It must never be paired
+# with a NaN substitution -- see clip_q.
+Q_MIN = 1e-9
+Q_MAX = 100.0
+
+_Q_NAN_ADVICE = (
+    "q = M_companion / M_primary, so a non-finite q means one of the lens "
+    "body masses is already non-finite.  Check the initval (and any "
+    "'sigma: 0' link expression) on star.<primary lens>.logmass and on the "
+    "companion's mass -- planet.<name>.log_q in log_q mode, "
+    "planet.<name>.mass in linear mode, star.<name>.logmass for a stellar "
+    "companion."
+)
+
+
+def clip_q(q):
+    """Clip a symbolic mass ratio into the magnification model's valid range.
+
+    Deliberately NOT paired with ``pt.nan_to_num``, which is what this used to
+    be -- ``pt.clip(pt.nan_to_num(q, nan=Q_MIN), Q_MIN, Q_MAX)``, copied to
+    five sites (review item 4.5).  Dropping the scrub is safe *and* strictly
+    better:
+
+    * It was unreachable.  ``q`` is ``m_companion / m_primary``; every mass in
+      the chain descends from a logit-bounded sampled coordinate (star.logmass
+      in [-9, 2.5] dex, planet.log_q, or a linear planet.mass with finite hard
+      bounds -- and user bounds may only be tightened), so both operands are
+      finite and the denominator, a stellar mass, has a hard floor of 1e-9
+      solMass.  Measured on examples/DC2018_128 and examples/ob161003: q stays
+      finite over the entire raw support out to raw = +/-1e12, and 2400 random
+      raw points per event produced no NaN and no inf.  A 300-tune/300-draw
+      PTDE fit of DC2018_128 (2 rungs x 36 chains, plus the whitening probe,
+      the DE polish and the seed polish) never once entered the branch.
+    * If it *were* reached it could only do harm.  q is NaN only when an input
+      is already NaN, i.e. the raw vector itself carries a NaN -- and that raw
+      variable's own N(0, 1) prior term already makes the total logp NaN, so
+      the proposal is rejected whatever q does (verified: setting
+      ``star.logmass_raw`` or ``planet.log_q_raw`` to NaN gives logp = nan).
+      Substituting Q_MIN could therefore never rescue a sample; it only
+      invented a mass ratio -- with a *zero* gradient, since nan_to_num is a
+      switch -- in place of the one quantity that would have named the
+      failure.
+
+    So a NaN now propagates to logp, which is the sampler's own reject signal,
+    and no gradient is poisoned.  A finite-but-out-of-range q is a different
+    thing entirely and is still clipped, because that is a genuine modelling
+    decision about where the backends are defined.
+    """
+    return pt.clip(q, Q_MIN, Q_MAX)
+
+
+def clip_q_value(q, label="lens.q"):
+    """Numeric counterpart of :func:`clip_q` for the backend Op and bootstrap
+    paths, which see concrete floats rather than tensors.
+
+    Raises ``ValueError`` on a NaN ``q`` instead of handing it to
+    MulensModel/VBMicrolensing.  Every caller already has an error path that
+    turns this into the right thing: the magnification Ops catch it and return
+    NaN magnifications (logp = -inf, proposal rejected) after warning once with
+    this message, and the flux bootstrap catches it, warns, and falls back to
+    the PSPL columns.  The point is that the message names the parameter --
+    ``np.clip(nan, ...)`` returned nan and let MulensModel report the generic
+    "Wrong number of solutions to the lens equation" three frames away.
+
+    The infinities are NOT an error: they carry a sign, so they are ordinary
+    out-of-range values and are clipped to the bound exactly as np.clip -- and
+    as the symbolic clip_q -- does.  NaN is the case with no value at all.
+    """
+    q = float(q)
+    if np.isnan(q):
+        raise ValueError(
+            f"{label} is nan: a mass ratio must be a number.  {_Q_NAN_ADVICE}"
+        )
+    return float(np.clip(q, Q_MIN, Q_MAX))
+
+
 @register_physics
 def calc_mlens_total(*masses):
     # Total lens mass: sum over all lens bodies.  theta_E, t_E, rho, and pi_E

--- a/tests/test_q_sanitization.py
+++ b/tests/test_q_sanitization.py
@@ -1,0 +1,482 @@
+"""Mass-ratio (q) sanitization and the alpha_deg consolidation.
+
+Review item 4.5: ``clip(nan_to_num(q), 1e-9, 100)`` was copied to five sites
+and ``arctan2(yalpha, xalpha) * 180/pi`` to two.  Both now have exactly one
+implementation -- ``physics.clip_q`` / ``physics.clip_q_value`` and
+``Lens._alpha_deg`` -- and the ``nan_to_num`` half is gone, because it could
+only ever invent a mass ratio for a computation that had already failed.
+"""
+
+import inspect
+import warnings
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+
+from exozippy.components.mulensing import lens as lens_mod
+from exozippy.components.mulensing.lens import Lens
+from exozippy.components.mulensing.op import (
+    BinaryLensMagOp,
+    VBMDirectMagOp,
+    _build_binary_model,
+)
+from exozippy.components.mulensing.physics import (
+    Q_MAX,
+    Q_MIN,
+    calc_alpha,
+    clip_q,
+    clip_q_value,
+)
+from exozippy.system import System
+
+_COORDS = "268.0d -29.0d"
+
+
+def _binary_config():
+    """A minimal 2L1S topology: star.0 + planet.0 lens, star.1 source."""
+    config = {
+        "star": [{"name": "Lens"}, {"name": "Source"}],
+        "planet": [{"name": "Companion"}],
+        "lens": [
+            {
+                "name": "Lens",
+                "lenses": ["star.0", "planet.0"],
+                "sources": ["star.1"],
+                "finite_source": False,
+            }
+        ],
+    }
+    user_params = {
+        "lens.Lens.t_0": {"initval": 2458554.89},
+        "lens.Lens.u_0": {"initval": 0.1},
+        "lens.Lens.t_E": {"initval": 18.2},
+        "lens.Lens.s": {"initval": 0.98},
+        "lens.Lens.alpha": {"initval": -52.0},
+        "lens.Lens.q": {"initval": 1.1e-3},
+        "star.Lens.ra": {"initval": 268.0, "sigma": 0},
+        "star.Lens.dec": {"initval": -29.0, "sigma": 0},
+        "star.Source.ra": {"initval": 268.0, "sigma": 0},
+        "star.Source.dec": {"initval": -29.0, "sigma": 0},
+    }
+    return config, user_params
+
+
+@pytest.fixture(scope="module")
+def binary_system():
+    config, user_params = _binary_config()
+    system = System(config, user_params=user_params)
+    system.prepare()
+    model = system.build_model()
+    return system, model
+
+
+# ---------------------------------------------------------------------------
+# The consolidated helper: in-range behaviour is unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [Q_MIN, 1e-8, 1.1e-3, 0.5, 1.0, 1.188, 99.0, Q_MAX],
+)
+def test_clip_q_is_the_identity_inside_the_valid_range(value):
+    """
+    Given a finite mass ratio inside [Q_MIN, Q_MAX],
+    When clip_q (symbolic) or clip_q_value (numeric) is applied,
+    Then the value passes through bit-identically -- the consolidation must
+      not perturb any working fit.
+    """
+    assert float(clip_q(pt.as_tensor_variable(value)).eval()) == value
+    assert clip_q_value(value) == value
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0.0, Q_MIN),
+        (-1.0, Q_MIN),
+        (1e-30, Q_MIN),
+        (1e5, Q_MAX),
+        (np.inf, Q_MAX),
+        (-np.inf, Q_MIN),
+    ],
+)
+def test_clip_q_clamps_out_of_range_but_finite_input(value, expected):
+    """
+    Given a mass ratio outside the range the magnification backends are
+      defined on (including the infinities, which the old nan_to_num mapped
+      to +/-float64.max before the clip caught them),
+    When the helper is applied,
+    Then it is clamped to the bound -- unchanged from the old expression, on
+      both the symbolic and the numeric path.  An infinity carries a sign, so
+      it is an ordinary out-of-range value and clipping it is the same
+      modelling decision; NaN (below) has no value at all and is not.
+    """
+    assert float(clip_q(pt.as_tensor_variable(value)).eval()) == expected
+    assert clip_q_value(value) == expected
+
+
+def test_clip_q_symbolic_and_numeric_agree():
+    """
+    Given the same finite mass ratios,
+    When both the symbolic and the numeric helper are applied,
+    Then they agree exactly -- the Op path (numeric) and the graph path
+      (symbolic) must not sanitize q differently.
+    """
+    for v in (1e-12, Q_MIN, 1e-4, 1.0, 50.0, Q_MAX, 1e4):
+        assert float(clip_q(pt.as_tensor_variable(v)).eval()) == clip_q_value(
+            v
+        )
+
+
+# ---------------------------------------------------------------------------
+# The NaN path: propagate (symbolic) / raise by name (numeric), never invent
+# ---------------------------------------------------------------------------
+
+
+def test_clip_q_propagates_nan_instead_of_inventing_a_mass_ratio():
+    """
+    Given a NaN mass ratio,
+    When clip_q is applied,
+    Then the result is NaN, NOT Q_MIN.
+
+    This is the substance of review item 4.5.  The old expression was
+    ``clip(nan_to_num(q, nan=1e-9), 1e-9, 100)``, which reported q = 1e-9 --
+    a fabricated mass ratio -- and, because nan_to_num is a switch, a zero
+    gradient, so a failed computation produced a healthy-looking likelihood.
+    q is NaN only when one of the masses it divides is already NaN, and that
+    already makes the total logp NaN (test below), so nothing was ever
+    rescued: the scrub only deleted the evidence.
+    """
+    assert np.isnan(float(clip_q(pt.as_tensor_variable(np.nan)).eval()))
+
+
+def test_clip_q_value_raises_naming_the_parameter():
+    """
+    Given a NaN mass ratio on the numeric (Op / bootstrap) path,
+    When clip_q_value is applied,
+    Then it raises ValueError naming q and the parameters to check, rather
+      than handing NaN to MulensModel -- which used to report the generic
+      "Wrong number of solutions to the lens equation" three frames away.
+    """
+    with pytest.raises(ValueError) as exc:
+        clip_q_value(np.nan, "lens.q")
+    msg = str(exc.value)
+    assert "lens.q" in msg
+    assert "logmass" in msg and "log_q" in msg
+    assert "must be a number" in msg
+
+
+def test_binary_op_reports_a_nan_q_by_name_and_still_rejects_the_proposal():
+    """
+    Given a param vector whose q is NaN,
+    When BinaryLensMagOp.perform runs,
+    Then it still returns all-NaN magnifications (logp = -inf, proposal
+      rejected -- byte-identical to the old behaviour), but the warn-once
+      message now names lens.q instead of quoting a MulensModel internal.
+    """
+    p = np.array([2458554.89, 0.1, 18.2, 0.02, -0.01, 0.98, np.nan, -52.0])
+    t = np.linspace(2458554.89 - 5, 2458554.89 + 5, 21)
+    obs = np.zeros((len(t), 3))
+    out = [[None]]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        BinaryLensMagOp(
+            coords=_COORDS, mag_method="auto_vbbl", use_rho=False
+        ).perform(None, [p, t, obs], out)
+
+    assert np.all(np.isnan(out[0][0]))
+    assert any("lens.q" in str(w.message) for w in caught)
+
+
+def test_vbm_direct_still_short_circuits_a_non_finite_param_vector():
+    """
+    Given a param vector containing a NaN,
+    When VBMDirectMagOp.perform runs,
+    Then it returns all-NaN via its own explicit non-finite guard.  That
+      guard was hoisted above the per-companion unpacking so it, not
+      clip_q_value, is what notices -- previously it sat *after* a
+      np.clip that silently passed NaN through.
+    """
+    p = np.array([2458554.89, 0.1, 18.2, 0.02, -0.01, 0.98, np.nan, -52.0])
+    t = np.linspace(2458554.89 - 5, 2458554.89 + 5, 21)
+    obs = np.zeros((len(t), 3))
+    out = [[None]]
+    VBMDirectMagOp(coords=_COORDS, n_companions=1, use_rho=False).perform(
+        None, [p, t, obs], out
+    )
+    assert np.all(np.isnan(out[0][0]))
+
+
+def test_build_binary_model_clips_a_finite_out_of_range_q():
+    """
+    Given a finite q above Q_MAX,
+    When the MulensModel binary model is built,
+    Then q is clamped to Q_MAX -- the range decision survives the removal of
+      the NaN scrub.
+    """
+    p = np.array([2458554.89, 0.1, 18.2, 0.0, 0.0, 0.98, 1e6, -52.0])
+    model = _build_binary_model(p, _COORDS, "auto_vbbl", use_rho=False)
+    assert float(model.parameters.q) == Q_MAX
+
+
+# ---------------------------------------------------------------------------
+# Why the NaN branch is unreachable, pinned
+# ---------------------------------------------------------------------------
+
+
+def test_q_stays_finite_over_the_whole_sampled_support(binary_system):
+    """
+    Given a binary-lens model,
+    When q is evaluated at raw coordinates far beyond anything a sampler
+      reaches (+/-1e12 on every raw variable at once),
+    Then it is always finite: both masses descend from logit-bounded
+      coordinates and the denominator is a stellar mass with a hard 1e-9
+      solMass floor.  This is the premise the nan_to_num removal rests on.
+    """
+    system, model = binary_system
+    ip = model.initial_point()
+    rvs = list(model.value_vars)
+    q_node = model.replace_rvs_by_values([system.lens.q.value])[0]
+    fn = pytensor.function(rvs, q_node, on_unused_input="ignore")
+
+    base = [np.asarray(ip[v.name], dtype=float) for v in rvs]
+    for extreme in (-1e12, -1e4, -50.0, 0.0, 50.0, 1e4, 1e12):
+        vals = fn(*[np.full(np.shape(b), extreme) for b in base])
+        assert np.all(np.isfinite(vals)), f"q not finite at raw={extreme}"
+
+    rng = np.random.default_rng(0)
+    for scale in (1.0, 1e3, 1e6):
+        for _ in range(50):
+            vals = fn(
+                *[b + rng.normal(scale=scale, size=np.shape(b)) for b in base]
+            )
+            assert np.all(np.isfinite(vals))
+
+
+def test_a_nan_raw_coordinate_already_makes_logp_nan(binary_system):
+    """
+    Given a NaN in a mass-carrying raw coordinate -- the only way q can go
+      NaN,
+    When the model logp is evaluated,
+    Then it is NaN regardless of what q does, because that raw variable's own
+      N(0, 1) prior term is NaN.  The proposal is rejected either way, so
+      scrubbing q could never have rescued a sample; it could only hide which
+      quantity failed.
+    """
+    _, model = binary_system
+    ip = model.initial_point()
+    logp = model.compile_logp()
+    assert np.isfinite(logp(ip))
+
+    mass_raws = [
+        v.name
+        for v in model.value_vars
+        if "logmass" in v.name or "log_q" in v.name or ".mass" in v.name
+    ]
+    assert mass_raws, "expected a sampled mass coordinate in this topology"
+    for name in mass_raws:
+        point = dict(ip)
+        point[name] = np.full(np.shape(np.asarray(ip[name])), np.nan)
+        assert np.isnan(logp(point)), f"{name}=NaN did not poison logp"
+
+
+# ---------------------------------------------------------------------------
+# One implementation, used by both magnification paths
+# ---------------------------------------------------------------------------
+
+
+def test_binary_mm_params_q_is_the_q_parameter_clipped(binary_system):
+    """
+    Given the MulensModel-backend param builder,
+    When it reports q,
+    Then it is clip_q(lens.q), bit-identical to the mass ratio it used to
+      recompute inline as ``m_companion / max(m_primary, 1e-10)``.  The
+      pt.maximum floor was provably dead (star.mass = 10**logmass with
+      logmass >= -9 dex is never below 1e-9), and going through the Parameter
+      means the backend, the priors and the reports all see one q.
+    """
+    system, model = binary_system
+    lens = system.lens
+
+    built = lens._get_binary_mm_params(index=0)["q"]
+    expected = clip_q(lens.q.value[0])
+
+    m1 = system.star.mass.value[lens.lens_bodies[0][0][1]]
+    l2_type, l2_idx = lens.lens_bodies[0][1]
+    m2 = getattr(system, l2_type).mass.value[l2_idx]
+    legacy = pt.clip(
+        pt.nan_to_num(m2 / pt.maximum(m1, 1e-10), nan=1e-9), 1e-9, 100.0
+    )
+
+    rvs = list(model.value_vars)
+    ip = model.initial_point()
+    outs = model.replace_rvs_by_values([built, expected, legacy])
+    fn = pytensor.function(rvs, outs, on_unused_input="ignore")
+    got, want, old = fn(*[np.asarray(ip[v.name]) for v in rvs])
+
+    assert np.asarray(got).tobytes() == np.asarray(want).tobytes()
+    assert (
+        np.asarray(got).ravel().tobytes() == np.asarray(old).ravel().tobytes()
+    )
+
+
+def test_alpha_deg_has_one_implementation(binary_system):
+    """
+    Given Lens._alpha_deg,
+    When it is compared with the open-coded arctan2 the two call sites used,
+    Then they are bit-identical -- lens.alpha's expression IS that arctan2
+      (physics.calc_alpha), so reading the Parameter changes nothing except
+      that there is now one spelling.
+    """
+    system, model = binary_system
+    lens = system.lens
+
+    consolidated = lens._alpha_deg(0)
+    legacy = pt.arctan2(lens.yalpha.value[0], lens.xalpha.value[0]) * (
+        180.0 / np.pi
+    )
+    from_params = lens._get_binary_mm_params(index=0)["alpha"]
+
+    rvs = list(model.value_vars)
+    ip = model.initial_point()
+    outs = model.replace_rvs_by_values([consolidated, legacy, from_params])
+    fn = pytensor.function(rvs, outs, on_unused_input="ignore")
+    a, b, c = fn(*[np.asarray(ip[v.name]) for v in rvs])
+
+    assert np.asarray(a).tobytes() == np.asarray(b).tobytes()
+    assert np.asarray(a).tobytes() == np.asarray(c).tobytes()
+
+
+def test_alpha_parameter_expression_is_the_arctan2():
+    """
+    Given calc_alpha, the expression behind lens.alpha,
+    When evaluated,
+    Then it is arctan2(yalpha, xalpha) in radians -- the invariant
+      _alpha_deg relies on to be a pure unit conversion.
+    """
+    x, y = pt.dscalar("x"), pt.dscalar("y")
+    f = pytensor.function([x, y], calc_alpha(x, y))
+    for xv, yv in ((0.6, -0.8), (-1.0, 0.0), (0.3, 0.4)):
+        assert f(xv, yv) == np.arctan2(yv, xv)
+
+
+def test_no_call_site_re_derives_q_or_alpha():
+    """
+    Given the two magnification param builders,
+    When their source is inspected,
+    Then neither scrubs q with nan_to_num nor re-derives alpha with arctan2:
+      the duplication review item 4.5 named is gone, and cannot creep back by
+      copy-paste without failing here.
+    """
+    for fn in (Lens._get_binary_mm_params, Lens.get_magnification_op):
+        src = inspect.getsource(fn)
+        assert "nan_to_num" not in src, (
+            f"{fn.__name__} re-introduced the scrub"
+        )
+        assert "arctan2" not in src, f"{fn.__name__} re-derives alpha_deg"
+        assert "1e-9" not in src, f"{fn.__name__} open-codes the q range"
+
+
+def test_alpha_deg_reads_the_shared_rad_to_deg_constant():
+    """
+    Given Lens._alpha_deg,
+    When its source is inspected,
+    Then it converts through the module-level constant rather than spelling
+      180/pi inline, which is how the two call sites drifted apart in the
+      first place.
+    """
+    assert lens_mod._RAD_TO_DEG == 180.0 / np.pi
+    src = inspect.getsource(Lens._alpha_deg)
+    assert "_RAD_TO_DEG" in src
+    assert "np.pi" not in src
+
+
+# ---------------------------------------------------------------------------
+# The build-time guard on the start value
+# ---------------------------------------------------------------------------
+
+
+def test_out_of_range_q_start_warns_and_says_what_to_do(binary_system, caplog):
+    """
+    Given a mass-ratio start above Q_MAX,
+    When the lens builds its likelihood,
+    Then it warns that the fit will actually START at the clipped value and
+      names the parameter -- silently starting somewhere other than the seed
+      is exactly what the runtime clip used to hide.
+    """
+    system, _ = binary_system
+    lens = system.lens
+    saved = lens.q.initval
+    try:
+        lens.q.initval = np.array([1e6])
+        with caplog.at_level("WARNING"):
+            lens._validate_q_start()
+    finally:
+        lens.q.initval = saved
+
+    text = caplog.text
+    assert "lens.q" in text or f"{lens.prefix}.q" in text
+    assert "START" in text
+
+
+def test_nan_q_start_raises(binary_system):
+    """
+    Given a NaN mass-ratio start (a broken seed, or a hard link whose
+      expression went NaN),
+    When the lens builds its likelihood,
+    Then it raises, naming q and the masses to check.  This is the one place
+      a raise is free: it is a check on the inputs at build time, not a
+      mid-graph assert that would kill a run over a proposal the sampler
+      already rejects on its own.
+    """
+    system, _ = binary_system
+    lens = system.lens
+    saved = lens.q.initval
+    try:
+        lens.q.initval = np.array([np.nan])
+        with pytest.raises(ValueError) as exc:
+            lens._validate_q_start()
+    finally:
+        lens.q.initval = saved
+
+    msg = str(exc.value)
+    assert ".q" in msg and "not a number" in msg
+    assert "logmass" in msg
+
+
+def test_infinite_q_start_warns_rather_than_raising(binary_system, caplog):
+    """
+    Given an infinite mass-ratio start,
+    When the guard runs,
+    Then it takes the out-of-range WARNING branch, not the raise -- the same
+      NaN/infinity split clip_q_value makes, so the build-time guard and the
+      runtime helper cannot disagree about what is fatal.
+    """
+    system, _ = binary_system
+    lens = system.lens
+    saved = lens.q.initval
+    try:
+        lens.q.initval = np.array([np.inf])
+        with caplog.at_level("WARNING"):
+            lens._validate_q_start()
+    finally:
+        lens.q.initval = saved
+    assert ".q starts at" in caplog.text
+
+
+def test_a_healthy_binary_start_neither_warns_nor_raises(
+    binary_system, caplog
+):
+    """
+    Given an ordinary binary-lens start,
+    When the guard runs,
+    Then it is silent -- the guard must not fire on working configs.
+    """
+    system, _ = binary_system
+    with caplog.at_level("WARNING"):
+        system.lens._validate_q_start()
+    assert ".q starts at" not in caplog.text


### PR DESCRIPTION
Review item **4.5**: `clip(nan_to_num(q), 1e-9, 100)` appeared five times, and the duplicated `alpha_deg` arctan2 twice. Per the user's instruction, the deduplication was the easy half -- the real question was *"isn't `nan_to_num(q)` the kind of dangerous paper that masks what should be a fatal error?"*

It is. Here is the evidence.

## Every site

| File | Line | Expression |
|---|---|---|
| `mulensing/lens.py` | 1157 | `pt.clip(pt.nan_to_num(q, nan=1e-9), 1e-9, 100.0)` -- symbolic, `_get_binary_mm_params` |
| `mulensing/lens.py` | 1374-1376 | same -- symbolic, `get_magnification_op` vbm_direct branch |
| `mulensing/op.py` | 116 | `float(np.clip(float(p[idx+1]), 1e-9, 100.0))` -- `_build_binary_model` |
| `mulensing/op.py` | 477 | same -- `VBMDirectMagOp._compute` |
| `mulensing/mulensinstrument.py` | 704 | same -- `_binary_magnification_columns` (flux bootstrap) |
| `lens.py` | 1161-3, 1377-9 | `pt.arctan2(yalpha, xalpha) * (180/pi)` x2 |

Note the three **numeric** sites never had `nan_to_num` at all -- `np.clip` passes NaN straight through. So the five "copies" were already two different behaviours wearing one shape.

## How `q` can actually go NaN -- measured, not assumed

`q = m_companion / m_primary`. Every mass descends from a logit-bounded sampled coordinate (`star.logmass` in [-9, 2.5] dex, `planet.log_q`, or a linear `planet.mass` with finite hard bounds -- and user bounds may only be tightened), so both operands are finite and the denominator is a stellar mass with a hard floor of 1e-9 solMass. No `0/0`, no overflow, no `sqrt`.

- **Raw-support sweep** on `examples/DC2018_128` (planet companion, `log_q`) and `examples/ob161003` (stellar companion): q finite at every raw coordinate out to **+/-1e12**; 2400 random raw points per event -> **0 NaN, 0 inf**. At the extremes q saturates at its own bound, never NaN.
- **Does the branch ever fire?** The scrub itself was instrumented with a pass-through `Print` Op writing from every worker process, and a real 300-tune/300-draw `ptde_async` fit of DC2018_128 was run (2 rungs x 36 chains, ~43k proposals, plus the whitening probe, MAP, DE polish, seed polish and mode reporting). **The file was never created. Zero hits.**
- **What a NaN would have meant**: q is NaN only if an input already is, i.e. the raw vector carries a NaN -- and that raw variable's own `N(0,1)` prior term already makes the total logp NaN. Verified directly: `star.logmass_raw = NaN` -> `logp = nan`; `planet.log_q_raw = NaN` -> `logp = nan`. The proposal is rejected **whatever q does**.

So the scrub could never rescue a sample. It invented a mass ratio -- with a **zero gradient**, since `nan_to_num` is a `switch` -- in place of the one quantity that would have named the failure.

## What shipped

**Deleted the `nan_to_num`; kept the clip; made the numeric path name the parameter; added one build-time check on the start.**

- `physics.Q_MIN`/`Q_MAX` + `clip_q` (symbolic, pure `pt.clip`) and `clip_q_value` (numeric, **raises `ValueError` naming `lens.q`** on NaN). Infinities still clip on both paths -- they carry a sign, so they are ordinary out-of-range values; a NaN has no value at all. That distinction is the whole point, and it is now one line in one place rather than fused into five expressions.
- **No mid-graph assert and no `-inf`**, deliberately. A NaN reaching logp *is* the sampler's reject signal, so a `CheckAndRaise` would kill an entire run over a proposal that was already being rejected; and `-inf` has no gradient (plus the JAX where-trap).
- The raise lands in handlers that already exist. `BinaryLensMagOp`'s warn-once now says `lens.q is nan: a mass ratio must be a number. q = M_companion/M_primary ... check star.<primary lens>.logmass ...` instead of MulensModel's `Wrong number of solutions to the lens equation`; the returned magnifications are still all-NaN. `VBMDirectMagOp`'s own non-finite guard was hoisted **above** the unpacking so it, not `clip_q_value`, is what notices there.
- `Lens._validate_q_start()` at stage 6: a NaN start **raises**; an out-of-range start **warns that the fit will actually begin at the clipped value** -- a separate silent failure the runtime clip was hiding (a seed of `q = 500` started at 100 and said nothing).
- `_get_binary_mm_params` now reads the **`q` Parameter** instead of recomputing `m2 / maximum(m1, 1e-10)`. That floor was provably dead (`10**logmass` with `logmass >= -9` is never below 1e-9) and it made the two magnification paths disagree about what `q` even was. It no longer needs `system`; `Lens._body_mass` had no other caller and is gone.
- `Lens._alpha_deg(j)` reads `lens.alpha`, whose expression **is** that arctan2 (`physics.calc_alpha`) -- so backend, priors, reports and plots now see one angle.

## Byte-identity

Bitwise identical pre/post on start-point logp and magnification curve for `examples/ob08092` (PSPL), `examples/DC2018_128` (planet companion), `examples/ob161003` (stellar companion), and for both Ops driven directly on in-range / out-of-range / NaN-q parameter vectors.

One caveat found and run down: **ob161003's logp differs by exactly 1 ulp between two runs of identical code** -- pre-existing float reassociation, not this change. Everything this change touches is bit-identical there.

## numpyro / JAX

Both q sites are binary-lens-only, hence Op-only, hence PTDE-only regardless -- but verified rather than argued, per the house rule. `clip_q` funcifies to `jnp.clip` and returns `[Q_MIN, 1e-3, Q_MAX, nan, Q_MAX, Q_MIN]`, i.e. it propagates NaN under JAX too, and `pm.sample(nuts_sampler="numpyro")` ran `examples/ob08092` end to end with an all-finite lp.

## Tests

`tests/test_q_sanitization.py`, 30 tests. **15 new assertions verified failing on pre-fix code**, including the two that matter: the old expression returns `1e-09` for a NaN q (so `assert np.isnan(...)` fails), and the old numeric path raises nothing.

Green: `test_q_sanitization` (30), `test_microlensing_physics`, `test_mulens_review_fixes`, `test_vbm_direct_vs_mulensmodel`, `test_pspl_symbolic_vs_op`, `test_log_s`, `test_planet_log_q`, `test_nsnl`, `test_mulens_flux_likelihood` (142 total), plus `test_examples_prepare`, `test_mmexofast_support`, `test_multiseed_mmexofast`, `test_silent_bandaids`, `test_hot_chains`, `test_runaway_logp_regression` (91). ruff clean.

## The same defect, five more times -- found, not fixed here

`Lens._get_safe_mm_params` does this to **five** further quantities: `t_E -> 100`, `u_0 -> 1`, `theta_E -> 0`, `pi_E_N -> 0`, `pi_E_E -> 0`. A fully-NaN parameter vector gets a **fabricated PSPL model**. It is saved from being a live bug by the same argument as `q` (the raw prior term NaNs the logp first), and git history shows those scrubs date from an era when `theta_E = sqrt(...)` genuinely could go NaN -- which `calc_theta_E` now fixes properly, at the radicand. Dead paper too, but removing it is outside 4.5 and wants its own byte-identity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
