### PR TITLE
CI: run the suite on every pull request, not only ones targeting master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,18 @@ name: Tests
 on:
   push:
     branches: [master]
+  # NO `branches:` filter here, deliberately. With `branches: [master]` a pull
+  # request targeting anything else got NO CI AT ALL -- and retargeting it to
+  # master afterwards did not start one, because GitHub dispatches on opened /
+  # reopened / synchronize and a base change is none of those. Such a PR sat
+  # at "no checks reported", which reads as "not finished yet" rather than
+  # "never tested", and the only way to start it was to close and reopen the
+  # PR by hand. That is a footgun aimed squarely at stacked pull requests.
+  #
+  # The cost is running the suite on PRs between topic branches too, which is
+  # the point: a stacked PR is exactly where a bad merge hides, since its diff
+  # is read against its parent rather than against master.
   pull_request:
-    branches: [master]
   # Nightly, for the unlocked-resolution job below -- it catches an upstream
   # release breaking us, which has nothing to do with when we push.
   schedule:


### PR DESCRIPTION
`pull_request: branches: [master]` meant a PR targeting any other branch got **no CI at all**.

Worse, retargeting it to master afterwards did not start a run either: GitHub dispatches `pull_request` on `opened` / `reopened` / `synchronize`, and a base change is none of those.

## Hit twice today, on stacked review PRs

#133 and then #136/#137 all sat at `no checks reported on the '<branch>' branch`. That reads as "still running", not "never tested" -- and the auto-merge loop treats an empty check list as not-yet-ready, so nothing flagged it either. The only way to start CI was to close and reopen each PR by hand.

The failure mode is quiet in the worst way: a stacked PR looks like it is waiting for CI forever, and if anyone had merged it on the strength of "the parent was green", nothing would have tested the combination.

## The trade

The suite now runs on PRs between topic branches too. That is the point rather than the cost: a stacked PR is exactly where a bad merge hides, because its diff is read against its parent rather than against master.

The `push` trigger keeps its `branches: [master]` filter. Topic-branch pushes are already covered by the `pull_request` run, and dropping it there would double every run.

## Verified

The workflow still parses, and the trigger set is now `push: {branches: [master]}`, `pull_request: <no filter>`, `schedule`, `workflow_dispatch`, `workflow_call` -- the last three untouched. Nothing about the jobs, the matrix, or the required `test` gate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)