### PR TITLE
plots: a flat variable no longer takes down the whole trace PDF

### DIFF
--- a/src/exozippy/corner_utils.py
+++ b/src/exozippy/corner_utils.py
@@ -105,6 +105,75 @@ def collect_parameter_corner_samples(param_specs):
     return _flatten_arrays(items)
 
 
+def _label_at(labels, j):
+    return labels[j] if j < len(labels) else f"column {j}"
+
+
+def _drop_undrawable(samples, labels, filename):
+    """Drop what corner.corner() cannot draw, naming every omission.
+
+    corner builds its panels from np.histogram, so it raises outright -- and
+    takes the WHOLE corner plot down -- on a column with no dynamic range
+    ("It looks like the parameter(s) in column(s) N have no dynamic range")
+    and on one holding any non-finite value at all ("Axis limits cannot be
+    NaN or Inf", since its default range is the column's raw min/max).  Both
+    shapes are things a real fit produces: an element pinned with
+    ``sigma: 0`` inside an otherwise sampled vector is exactly constant
+    across every draw, and a short or stopped run leaves variables that never
+    moved.
+
+    Three passes, in this order so each terminates:
+
+      1. columns with no finite draw at all -- else pass 2 would delete
+         every row;
+      2. rows (draws) still carrying a non-finite value -- such a draw
+         cannot be placed in any 2-D panel involving that column anyway;
+      3. columns that are constant over the surviving rows.
+
+    Dropping beats passing an artificial ``range``: corner's ``range``
+    argument also sets ``force_range``, which changes the axis limits of the
+    panels that were fine, and a widened range around a constant would draw
+    a spike that reads as a measured posterior.
+    """
+    finite = np.isfinite(samples)
+    keep = [j for j in range(samples.shape[1]) if finite[:, j].any()]
+    for j in range(samples.shape[1]):
+        if j not in keep:
+            logger.warning(
+                f"corner plot ({filename}): omitting "
+                f"{_label_at(labels, j)} (no finite draws); the remaining "
+                "parameters are still plotted"
+            )
+    samples = samples[:, keep]
+    labels = [_label_at(labels, j) for j in keep]
+    if samples.shape[1] == 0:
+        return samples, labels
+
+    good_rows = np.isfinite(samples).all(axis=1)
+    n_bad = int((~good_rows).sum())
+    if n_bad:
+        logger.warning(
+            f"corner plot ({filename}): dropping {n_bad} of "
+            f"{samples.shape[0]} draws that hold a non-finite value"
+        )
+        samples = samples[good_rows]
+    if samples.shape[0] == 0:
+        return samples, labels
+
+    keep = []
+    for j in range(samples.shape[1]):
+        col = samples[:, j]
+        if col.min() == col.max():
+            logger.warning(
+                f"corner plot ({filename}): omitting {labels[j]} (constant "
+                f"at {float(col.min()):.10g}); the remaining parameters are "
+                "still plotted"
+            )
+        else:
+            keep.append(j)
+    return samples[:, keep], [labels[j] for j in keep]
+
+
 def save_corner_plot(samples, labels, filename, max_samples=1000):
     """Render a corner plot of ``samples`` (n_samples, n_dims) to ``filename``.
 
@@ -125,6 +194,14 @@ def save_corner_plot(samples, labels, filename, max_samples=1000):
         idx = rng.choice(samples.shape[0], size=max_samples, replace=False)
         idx.sort()
         samples = samples[idx]
+
+    samples, labels = _drop_undrawable(samples, labels, filename)
+    if samples.shape[0] == 0 or samples.shape[1] == 0:
+        logger.warning(
+            f"save_corner_plot: nothing left to plot for {filename} after "
+            "dropping flat / non-finite parameters and draws; skipping"
+        )
+        return
 
     minrank = 0.5 - math.erf(1.0 / math.sqrt(2)) / 2.0
     maxrank = 0.5 + math.erf(1.0 / math.sqrt(2)) / 2.0

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -1,5 +1,6 @@
 import gc
 import importlib
+import itertools
 import logging
 import multiprocessing as mp
 import os
@@ -1336,29 +1337,244 @@ def _compute_lp_from_model(model, idata):
         return None
 
 
-def _n_trace_rows(idata, var_names, group="posterior"):
-    """Total rows az.plot_trace needs: 1 row per element (shape product) per var."""
-    rows = 0
-    dataset = idata[group]
-    for v in var_names:
-        shape = dataset[v].shape[2:]  # drop (chain, draw) dims
-        rows += int(np.prod(shape)) if shape else 1
-    return rows
+def _chunk_by_rows(specs, rows_per_page):
+    """Yield (chunk, n_rows) pairs sized so each page needs <= rows_per_page rows.
 
-
-def _chunk_by_rows(idata, var_names, rows_per_page):
-    """Yield (chunk, n_rows) pairs sized so each page needs <= rows_per_page rows."""
+    ``specs`` is a list of (var_name, coords, n_rows) triples as produced by
+    _split_degenerate_vars.  A spec carrying a non-None ``coords`` element
+    selection gets a page to itself: ArviZ takes ONE coords mapping for the
+    whole call, so two variables sharing a dimension name but needing
+    different element subsets would silently cross-contaminate.
+    """
     chunk, chunk_rows = [], 0
-    for v in var_names:
-        r = _n_trace_rows(idata, [v])
-        if chunk_rows + r > rows_per_page and chunk:
+    for name, coords, r in specs:
+        solo = coords is not None
+        if chunk and (solo or chunk_rows + r > rows_per_page):
             yield chunk, chunk_rows
-            chunk, chunk_rows = [v], r
-        else:
-            chunk.append(v)
-            chunk_rows += r
+            chunk, chunk_rows = [], 0
+        chunk.append((name, coords))
+        chunk_rows += r
+        if solo:
+            yield chunk, chunk_rows
+            chunk, chunk_rows = [], 0
     if chunk:
         yield chunk, chunk_rows
+
+
+# arviz_stats builds its KDE on a fixed 512-interval grid spanning exactly
+# [min, max] of the finite draws (bound_correction=True, so the grid is NOT
+# widened by a bandwidth).  np.histogram then raises
+#   ValueError: Too many bins for data range. Cannot create 512 finite-sized bins.
+# whenever np.linspace(min, max, 513) cannot produce 513 strictly increasing
+# float64 edges -- i.e. whenever the entire range spans fewer than ~512 ULPs.
+# That kills the whole page, and with it the rest of the PDF and all of
+# wrap-up, for one variable that did not move.
+_KDE_GRID_LEN = 512
+
+
+def _dist_degeneracy(values):
+    """Why no density can be drawn for ``values``, or None if one can.
+
+    Returns a short human-readable reason string.  Three shapes qualify, and
+    all three are things a real fit produces:
+
+    * no finite draws at all (a Deterministic whose physics went NaN);
+    * exactly constant (an element pinned with ``sigma: 0`` inside an
+      otherwise-sampled vector -- GP and robust-likelihood hyperparameters
+      are full-length vectors with the non-opted-in files pinned, and such a
+      vector IS tracked as a Deterministic, so its pinned elements reach the
+      plot as constants);
+    * finite but spanning fewer than _KDE_GRID_LEN float64 steps -- a chain
+      that never moved except in the last few bits, which is what a
+      gracefully stopped, unmixed run produces and what actually crashed CI.
+
+    The third test is the exact condition numpy itself raises on, so it
+    tracks the failure rather than approximating it.
+    """
+    x = np.asarray(values, dtype=float).ravel()
+    x = x[np.isfinite(x)]
+    if x.size == 0:
+        return "no finite draws"
+    lo, hi = float(x.min()), float(x.max())
+    if lo == hi:
+        return f"constant at {lo:.10g}"
+    if np.any(np.diff(np.linspace(lo, hi, _KDE_GRID_LEN + 1)) <= 0):
+        return (
+            f"range {hi - lo:.3g} around {lo:.10g} spans fewer than "
+            f"{_KDE_GRID_LEN} float64 steps"
+        )
+    return None
+
+
+class _DegenerateRow:
+    """One (variable, element) row whose density cannot be drawn."""
+
+    __slots__ = ("label", "reason", "values")
+
+    def __init__(self, label, reason, values):
+        self.label = label
+        self.reason = reason
+        self.values = values
+
+
+def _element_rows(dataset, var):
+    """Yield (selection, label, values) for every plotted row of ``var``.
+
+    One row per element, matching _render_trace_page's compact=False layout
+    (the row count that used to come from a separate _n_trace_rows helper is
+    just len(list(_element_rows(...))) now).  ``selection`` is the label
+    mapping that isolates the element -- ``{}`` for a scalar variable, and
+    None when a dimension carries no coordinates and so cannot be
+    label-selected at all; ``values`` is the element's (chain, draw) array.
+    """
+    da = dataset[var]
+    extra = [d for d in da.dims if d not in ("chain", "draw")]
+    if not extra:
+        yield {}, var, np.asarray(da.values)
+        return
+    labelled = all(d in da.coords for d in extra)
+    for combo in itertools.product(*(range(da.sizes[d]) for d in extra)):
+        pos = dict(zip(extra, combo))
+        # .isel, not .sel: a dimension without coordinates cannot be
+        # label-selected, and only a label-selectable one can be handed back
+        # to ArviZ as a ``coords`` mapping (see _split_degenerate_vars).
+        vals = np.asarray(da.isel(pos).values)
+        if labelled:
+            sel = {
+                d: np.asarray(da.coords[d].values)[i] for d, i in pos.items()
+            }
+        else:
+            sel = None
+        shown = sel if sel is not None else pos
+        label = f"{var}[{', '.join(str(shown[d]) for d in extra)}]"
+        yield sel, label, vals
+
+
+def _split_degenerate_vars(idata, var_names, group="posterior"):
+    """Split plot rows into ArviZ-renderable ones and density-less ones.
+
+    Returns ``(specs, degenerate)``:
+
+    * ``specs`` -- list of (var_name, coords, n_rows) for _chunk_by_rows.
+      ``coords`` is None when the whole variable renders normally (so a fit
+      with no degenerate element takes byte-identical code to before), and a
+      {dim: [kept values]} mapping when only some elements of a vector do.
+    * ``degenerate`` -- list of _DegenerateRow, rendered on their own pages.
+
+    Each degenerate row is logged as a warning naming the variable element
+    and the reason: a missing density is reported, never swallowed.
+    """
+    dataset = idata[group]
+    specs, degenerate = [], []
+    for v in var_names:
+        if v not in dataset.data_vars:
+            # Unknown name: pass it straight through so ArviZ raises the same
+            # error it always did rather than having it silently disappear.
+            specs.append((v, None, 1))
+            continue
+        rows = list(_element_rows(dataset, v))
+        bad = [
+            i
+            for i, (_, _, vals) in enumerate(rows)
+            if _dist_degeneracy(vals) is not None
+        ]
+        if not bad:
+            specs.append((v, None, len(rows)))
+            continue
+        for i in bad:
+            _, label, vals = rows[i]
+            reason = _dist_degeneracy(vals)
+            logger.warning(
+                f"trace plot: no density for {label} ({reason}); its trace "
+                "panel is still drawn"
+            )
+            degenerate.append(_DegenerateRow(label, reason, vals))
+        good = [i for i in range(len(rows)) if i not in set(bad)]
+        if not good:
+            continue
+        extra = [d for d in dataset[v].dims if d not in ("chain", "draw")]
+        if len(extra) == 1 and rows[good[0]][0] is not None:
+            dim = extra[0]
+            kept = [rows[i][0][dim] for i in good]
+            specs.append((v, {dim: kept}, len(kept)))
+        else:
+            # >= 2 element dimensions (a coords mapping would select the
+            # CROSS PRODUCT of the per-dimension survivors, which can readmit
+            # a degenerate element) or an unlabelled dimension ArviZ cannot be
+            # given a coords mapping for.  No EXOZIPPy Parameter is shaped
+            # either way (Parameter vectors are 1-D and ArviZ always names
+            # their dimension), so rather than risk a re-crash the surviving
+            # elements go on the annotated pages too, saying so.
+            for i in good:
+                _, label, vals = rows[i]
+                degenerate.append(
+                    _DegenerateRow(
+                        label,
+                        f"density omitted: other elements of {v} are "
+                        "degenerate and this variable's element layout "
+                        "cannot be split",
+                        vals,
+                    )
+                )
+    return specs, degenerate
+
+
+def _render_degenerate_page(idata, rows, title, group="posterior"):
+    """One page of rows whose density cannot be drawn.
+
+    Same two-column geometry as _render_trace_page (dist column then trace
+    column, one row per element), so the page reads continuously with the
+    ArviZ ones and _shade_trace_axes_by_mode's even/odd axis convention still
+    holds.  The trace panel is drawn for real -- a flat chain is exactly what
+    the reader needs to see -- and the dist panel carries the reason and the
+    value instead of a density.
+
+    Annotating beats the alternatives: a skipped panel looks like a plotting
+    bug, and a single-bin histogram looks like a real (if uninformative)
+    density while conveying neither the value nor why it is the only bin.
+    """
+    dataset = idata[group]
+    draw_coord = np.asarray(dataset["draw"].values)
+    n = len(rows)
+    fig, axes = plt.subplots(n, 2, figsize=(12, 3 * n), squeeze=False)
+    for r, row in enumerate(rows):
+        ax_dist, ax_trace = axes[r]
+        ax_dist.set_title(row.label)
+        ax_dist.text(
+            0.5,
+            0.5,
+            f"no density\n{row.reason}",
+            ha="center",
+            va="center",
+            transform=ax_dist.transAxes,
+            fontsize=9,
+            color="0.25",
+        )
+        ax_dist.set_xticks([])
+        ax_dist.set_yticks([])
+
+        vals = np.atleast_2d(np.asarray(row.values, dtype=float))
+        finite = np.isfinite(vals)
+        if finite.any():
+            for c in range(vals.shape[0]):
+                ax_trace.plot(draw_coord, vals[c], lw=0.8)
+        else:
+            ax_trace.text(
+                0.5,
+                0.5,
+                "no finite draws",
+                ha="center",
+                va="center",
+                transform=ax_trace.transAxes,
+                fontsize=9,
+                color="0.25",
+            )
+        ax_trace.set_xlabel("Draw")
+        ax_trace.set_ylabel(row.label)
+    fig.suptitle(title, fontsize=14)
+    _shade_trace_axes_by_mode(fig, idata)
+    plt.tight_layout(rect=[0, 0.03, 1, 0.95])
+    return fig
 
 
 def save_multipage_trace(
@@ -1431,29 +1647,67 @@ def save_multipage_trace(
         # into its own floating figure, leaving our fig blank.  Let ArviZ
         # own the figure and retrieve it from the returned axes instead.
         if lp_var and lp_idata is not None:
-            fig_lp = _render_trace_page(
+            for fig in _trace_page_figures(
                 lp_idata,
                 [lp_var],
-                n_rows=1,
-                title="Trace Plots: log-posterior (lp)",
+                rows_per_page=1,
                 group="sample_stats",
-            )
-            pdf.savefig(fig_lp)
-            plt.close(fig_lp)
-            gc.collect()
+                title_fn=lambda _i: "Trace Plots: log-posterior (lp)",
+            ):
+                pdf.savefig(fig)
+                plt.close(fig)
+                gc.collect()
 
-        for page_num, (chunk, n_rows) in enumerate(
-            _chunk_by_rows(idata, var_names, rows_per_page), start=1
+        for fig in _trace_page_figures(
+            idata,
+            var_names,
+            rows_per_page=rows_per_page,
+            group="posterior",
+            title_fn=lambda i: f"Trace Plots: Page {i}",
         ):
-            fig = _render_trace_page(
-                idata, chunk, n_rows, title=f"Trace Plots: Page {page_num}"
-            )
             pdf.savefig(fig)
             plt.close(fig)
             gc.collect()
 
 
-def _render_trace_page(idata, var_names, n_rows, title, group="posterior"):
+def _trace_page_figures(idata, var_names, rows_per_page, group, title_fn):
+    """Yield one figure per page, ArviZ pages first then annotated ones.
+
+    Variables (or single vector elements) whose draws admit no density are
+    routed to _render_degenerate_page instead of being handed to ArviZ, whose
+    KDE grid is what raises on them.  With no such element the split is the
+    identity and the ArviZ call is exactly the one made before this existed.
+    """
+    specs, degenerate = _split_degenerate_vars(idata, var_names, group=group)
+
+    page_num = 0
+    for chunk, n_rows in _chunk_by_rows(specs, rows_per_page):
+        page_num += 1
+        names = [name for name, _ in chunk]
+        coords = next((c for _, c in chunk if c is not None), None)
+        yield _render_trace_page(
+            idata,
+            names,
+            n_rows,
+            title=title_fn(page_num),
+            group=group,
+            coords=coords,
+        )
+
+    for start in range(0, len(degenerate), max(1, rows_per_page)):
+        page_num += 1
+        rows = degenerate[start : start + max(1, rows_per_page)]
+        yield _render_degenerate_page(
+            idata,
+            rows,
+            title=f"{title_fn(page_num)} (no density)",
+            group=group,
+        )
+
+
+def _render_trace_page(
+    idata, var_names, n_rows, title, group="posterior", coords=None
+):
     """One trace-plot page: dist column + trace column, one row per element.
 
     plot_trace_dist (not plot_trace) is the ArviZ 1.0 equivalent of the old
@@ -1466,11 +1720,16 @@ def _render_trace_page(idata, var_names, n_rows, title, group="posterior"):
     whenever a chain carries fewer than 100 draws -- the dist column then plots
     a cumulative curve that plateaus at 1.0, which reads as a posterior clipped
     at its maximum.  A density is always what this column is meant to show.
+
+    ``coords`` restricts which elements of a vector variable are drawn; it is
+    set only when some of that vector's elements have no density (see
+    _split_degenerate_vars) and is None for every ordinary page.
     """
     pc = az.plot_trace_dist(
         idata,
         var_names=var_names,
         group=group,
+        coords=coords,
         compact=False,
         kind="kde",
         figure_kwargs={"figsize": (12, 3 * n_rows)},

--- a/tests/test_corner_degenerate.py
+++ b/tests/test_corner_degenerate.py
@@ -1,0 +1,168 @@
+"""
+Corner plots must survive flat / non-finite parameters.
+
+corner.corner() builds every panel from np.histogram, so it raises outright
+on a column with no dynamic range and on one holding a non-finite value --
+and the caller then loses the WHOLE corner plot for one flat parameter.  Both
+shapes come out of real fits: an element pinned with ``sigma: 0`` inside an
+otherwise sampled vector is exactly constant across every draw (four of
+examples/gj1214's band.thermal elements are), and a short or stopped run
+leaves variables that never moved.
+"""
+
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+import pytest
+
+from exozippy.corner_utils import _drop_undrawable, save_corner_plot
+
+
+@pytest.fixture
+def healthy():
+    rng = np.random.default_rng(11)
+    return rng.normal(size=(200, 3)), ["x", "y", "z"]
+
+
+def test_healthy_samples_pass_through_untouched(healthy):
+    """
+    Given samples with no flat or non-finite column,
+    When the drop pass runs,
+    Then nothing is removed -- a normal fit's corner plot is byte-identical
+      to what it was before degeneracy handling existed.
+    """
+    # ARRANGE
+    samples, labels = healthy
+
+    # ACT
+    out, out_labels = _drop_undrawable(samples, labels, "f.png")
+
+    # ASSERT
+    assert out.shape == samples.shape
+    assert np.array_equal(out, samples)
+    assert out_labels == labels
+
+
+def test_constant_column_is_dropped_and_named(healthy, caplog):
+    """
+    Given one exactly constant column (a sigma: 0 pinned vector element),
+    When the drop pass runs,
+    Then only that column goes, and the warning names the parameter -- the
+      other parameters are still plotted.
+    """
+    # ARRANGE
+    samples, labels = healthy
+    samples[:, 1] = 4.25
+
+    # ACT
+    with caplog.at_level("WARNING", logger="exozippy.corner_utils"):
+        out, out_labels = _drop_undrawable(samples, labels, "f.png")
+
+    # ASSERT
+    assert out_labels == ["x", "z"]
+    assert out.shape == (200, 2)
+    msgs = " ".join(r.getMessage() for r in caplog.records)
+    assert "y" in msgs and "constant at 4.25" in msgs
+
+
+def test_all_nan_column_is_dropped_without_deleting_every_draw(
+    healthy, caplog
+):
+    """
+    Given a column with no finite value at all,
+    When the drop pass runs,
+    Then the column is removed but every draw survives -- dropping
+      non-finite ROWS first would have deleted the entire sample.
+    """
+    # ARRANGE
+    samples, labels = healthy
+    samples[:, 0] = np.nan
+
+    # ACT
+    with caplog.at_level("WARNING", logger="exozippy.corner_utils"):
+        out, out_labels = _drop_undrawable(samples, labels, "f.png")
+
+    # ASSERT
+    assert out_labels == ["y", "z"]
+    assert out.shape == (200, 2)
+    assert "no finite draws" in " ".join(
+        r.getMessage() for r in caplog.records
+    )
+
+
+def test_partially_non_finite_column_drops_only_those_draws(healthy, caplog):
+    """
+    Given a column with a handful of non-finite draws,
+    When the drop pass runs,
+    Then those draws are dropped and the column is kept -- corner's default
+      range is the raw min/max, so a single NaN raised "Axis limits cannot be
+      NaN or Inf" and killed the whole plot.
+    """
+    # ARRANGE
+    samples, labels = healthy
+    samples[3, 1] = np.nan
+    samples[7, 2] = np.inf
+
+    # ACT
+    with caplog.at_level("WARNING", logger="exozippy.corner_utils"):
+        out, out_labels = _drop_undrawable(samples, labels, "f.png")
+
+    # ASSERT
+    assert out_labels == labels
+    assert out.shape == (198, 3)
+    assert np.isfinite(out).all()
+
+
+@pytest.mark.parametrize(
+    "spoil",
+    [
+        pytest.param(
+            lambda s: s.__setitem__((slice(None), 1), 0.0), id="flat"
+        ),
+        pytest.param(
+            lambda s: s.__setitem__((slice(None), 1), np.nan), id="all-nan"
+        ),
+        pytest.param(lambda s: s.__setitem__((3, 1), np.nan), id="one-nan"),
+    ],
+)
+def test_save_corner_plot_still_writes_the_file(spoil, tmp_path):
+    """
+    Given samples spoiled by a flat or non-finite column,
+    When save_corner_plot runs,
+    Then the PNG is written anyway -- corner used to raise and the caller's
+      except-branch turned the whole plot into a log line.
+    """
+    # ARRANGE
+    rng = np.random.default_rng(12)
+    samples = rng.normal(size=(120, 3))
+    spoil(samples)
+    out = tmp_path / "corner.png"
+
+    # ACT
+    save_corner_plot(samples, ["x", "y", "z"], str(out))
+
+    # ASSERT
+    assert out.exists()
+    assert out.stat().st_size > 5000
+
+
+def test_everything_flat_skips_with_a_warning(tmp_path, caplog):
+    """
+    Given samples in which nothing can be drawn at all,
+    When save_corner_plot runs,
+    Then it skips and says so rather than raising or writing a broken file.
+    """
+    # ARRANGE
+    samples = np.zeros((50, 2))
+    out = tmp_path / "corner.png"
+
+    # ACT
+    with caplog.at_level("WARNING", logger="exozippy.corner_utils"):
+        save_corner_plot(samples, ["x", "y"], str(out))
+
+    # ASSERT
+    assert not out.exists()
+    assert "nothing left to plot" in " ".join(
+        r.getMessage() for r in caplog.records
+    )

--- a/tests/test_trace_plots.py
+++ b/tests/test_trace_plots.py
@@ -14,6 +14,7 @@ import arviz as az
 import matplotlib.pyplot as plt
 import pytest
 
+import exozippy.run as run_mod
 from exozippy.run import _render_trace_page, save_multipage_trace
 
 
@@ -263,3 +264,231 @@ def test_dist_column_is_density_not_ecdf(many_chain_idata):
         assert not all(np.all(np.diff(y) >= -1e-12) for y in ys)
     finally:
         plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Degenerate (density-less) variables
+#
+# arviz_stats' KDE builds a fixed 512-interval grid spanning exactly the
+# [min, max] of the finite draws, so np.histogram raises
+#   ValueError: Too many bins for data range. Cannot create 512 finite-sized
+#   bins.
+# whenever that range spans fewer than ~512 float64 steps.  That took down the
+# whole PDF -- and, since save_multipage_trace runs inside _run_fit's wrap-up,
+# every other output of a gracefully stopped fit with it.
+# ---------------------------------------------------------------------------
+
+
+def _idata_with(a_values, other=None, n_chain=2, n_draw=60):
+    """Posterior with variable 'a' set to a_values and a healthy 'b'."""
+    rng = np.random.default_rng(3)
+    post = {
+        "a": np.asarray(a_values, dtype=float),
+        "b": rng.normal(size=(n_chain, n_draw)) if other is None else other,
+    }
+    return az.from_dict({"posterior": post})
+
+
+def _constant_but_one_ulp(value=1.0, shape=(2, 60)):
+    """Finite, not constant, but spanning a single float64 step.
+
+    This is the shape a stopped, unmixed run leaves behind: a chain that never
+    really moved, but whose last bits differ -- the exact condition that
+    crashed CI (n_draws=137, max_rhat=6.42).
+    """
+    arr = np.full(shape, value)
+    arr[0, 0] = np.nextafter(value, value + 1.0)
+    return arr
+
+
+@pytest.mark.parametrize(
+    "label, values",
+    [
+        ("one float64 step", _constant_but_one_ulp()),
+        ("exactly constant", np.full((2, 60), 3.5)),
+        ("no finite draws", np.full((2, 60), np.nan)),
+        ("all infinite", np.full((2, 60), np.inf)),
+        (
+            "hundred float64 steps",
+            1.0
+            + np.random.default_rng(1).integers(0, 100, size=(2, 60))
+            * np.spacing(1.0),
+        ),
+    ],
+)
+def test_degenerate_variable_does_not_kill_the_pdf(label, values, tmp_path):
+    """
+    Given a posterior in which one variable admits no density (it is
+      constant, non-finite, or spans fewer float64 steps than the KDE grid
+      has points),
+    When save_multipage_trace runs,
+    Then a complete PDF is still written -- the whole of wrap-up used to die
+      with numpy's "Too many bins for data range".
+    """
+    # ARRANGE
+    idata = _idata_with(values)
+    out = tmp_path / "trace.pdf"
+
+    # ACT
+    save_multipage_trace(idata, ["a", "b"], str(out))
+
+    # ASSERT
+    assert out.exists(), label
+    assert out.stat().st_size > 5000, label
+
+
+def test_degenerate_variable_is_reported_not_swallowed(caplog, tmp_path):
+    """
+    Given a variable with no density,
+    When save_multipage_trace runs,
+    Then it says so per variable, naming the variable and the reason -- a
+      missing panel must never be silent.
+    """
+    # ARRANGE
+    idata = _idata_with(np.full((2, 60), 3.5))
+
+    # ACT
+    with caplog.at_level("WARNING", logger="exozippy.run"):
+        save_multipage_trace(idata, ["a", "b"], str(tmp_path / "t.pdf"))
+
+    # ASSERT
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("a" in m and "constant at 3.5" in m for m in messages), messages
+    assert not any("b" in m and "constant" in m for m in messages), messages
+
+
+def test_degenerate_variable_keeps_its_trace_panel(tmp_path):
+    """
+    Given a flat variable,
+    When its page is rendered,
+    Then the trace panel still carries one line per chain (a flat chain is
+      exactly what the reader needs to see) and the density panel carries the
+      reason and value instead of a density.
+    """
+    # ARRANGE
+    idata = _idata_with(np.full((3, 40), 3.5), other=None, n_chain=3)
+    rng = np.random.default_rng(4)
+    idata.posterior["b"] = (("chain", "draw"), rng.normal(size=(3, 40)))
+    rows = run_mod._split_degenerate_vars(idata, ["a"])[1]
+
+    # ACT
+    fig = run_mod._render_degenerate_page(idata, rows, title="t")
+
+    try:
+        # ASSERT
+        assert len(fig.axes) == 2
+        ax_dist, ax_trace = fig.axes
+        assert len(ax_trace.lines) == 3
+        texts = " ".join(t.get_text() for t in ax_dist.texts)
+        assert "no density" in texts
+        assert "constant at 3.5" in texts
+    finally:
+        plt.close(fig)
+
+
+def test_partially_pinned_vector_keeps_its_sampled_densities(tmp_path):
+    """
+    Given a vector variable with some elements pinned constant and some
+      sampled (GP and robust-likelihood hyperparameters are full-length
+      vectors with the non-opted-in files pinned via sigma: 0, and such a
+      vector IS tracked as a Deterministic),
+    When the pages are split,
+    Then only the pinned elements lose their density; the sampled ones stay
+      on an ArviZ page via a coords selection.
+    """
+    # ARRANGE
+    rng = np.random.default_rng(5)
+    vec = rng.normal(size=(2, 60, 4))
+    vec[:, :, 1] = 0.5
+    vec[:, :, 3] = -2.0
+    idata = az.from_dict(
+        {"posterior": {"gp_sigma": vec, "b": rng.normal(size=(2, 60))}}
+    )
+
+    # ACT
+    specs, degenerate = run_mod._split_degenerate_vars(
+        idata, ["gp_sigma", "b"]
+    )
+
+    # ASSERT
+    gp_spec = [s for s in specs if s[0] == "gp_sigma"]
+    assert len(gp_spec) == 1
+    _name, coords, n_rows = gp_spec[0]
+    assert n_rows == 2
+    assert list(coords.values())[0] == [0, 2]
+    assert sorted(r.label for r in degenerate) == [
+        "gp_sigma[1]",
+        "gp_sigma[3]",
+    ]
+    # b is healthy and must not be touched
+    assert ("b", None, 1) in specs
+
+
+def test_degenerate_lp_does_not_kill_the_pdf(tmp_path):
+    """
+    Given a stopped fit whose log-posterior never moved (its own page comes
+      from sample_stats, not posterior),
+    When save_multipage_trace runs,
+    Then the PDF is still written.
+    """
+    # ARRANGE
+    rng = np.random.default_rng(6)
+    idata = az.from_dict(
+        {
+            "posterior": {"a": rng.normal(size=(2, 60))},
+            "sample_stats": {"lp": np.full((2, 60), -123.5)},
+        }
+    )
+    out = tmp_path / "t.pdf"
+
+    # ACT
+    save_multipage_trace(idata, ["a"], str(out))
+
+    # ASSERT
+    assert out.exists()
+    assert out.stat().st_size > 5000
+
+
+def test_healthy_posterior_takes_the_unchanged_path(small_idata):
+    """
+    Given a posterior with no degenerate element,
+    When the split runs,
+    Then it is the identity: every variable keeps coords=None, so the ArviZ
+      call is exactly the one made before degeneracy handling existed.
+    """
+    # ACT
+    specs, degenerate = run_mod._split_degenerate_vars(small_idata, ["a", "b"])
+
+    # ASSERT
+    assert specs == [("a", None, 1), ("b", None, 1)]
+    assert degenerate == []
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        (np.array([[1.0, 2.0], [3.0, 4.0]]), None),
+        (np.full((2, 2), 7.0), "constant at 7"),
+        (np.full((2, 2), np.nan), "no finite draws"),
+        (np.array([[np.nan, np.inf], [-np.inf, np.nan]]), "no finite draws"),
+        (_constant_but_one_ulp(), "float64 steps"),
+        # non-finite values are filtered before the test, exactly as
+        # arviz_stats filters them, so a lone NaN must not change the verdict
+        (np.array([[1.0, 2.0], [3.0, np.nan]]), None),
+    ],
+)
+def test_dist_degeneracy_verdicts(values, expected):
+    """
+    Given each degenerate shape,
+    When _dist_degeneracy inspects it,
+    Then it returns None only when a 512-interval KDE grid can actually be
+      built, and otherwise a reason naming what is wrong.
+    """
+    # ACT
+    reason = run_mod._dist_degeneracy(values)
+
+    # ASSERT
+    if expected is None:
+        assert reason is None
+    else:
+        assert reason is not None and expected in reason


### PR DESCRIPTION
Fixes the crash that ends wrap-up for a short or stopped fit:

```
run.py:_run_fit -> save_multipage_trace -> _render_trace_page
  -> az.plot_trace_dist -> arviz KDE -> np.histogram
ValueError: Too many bins for data range. Cannot create 512 finite-sized bins.
```

Diagnosed from CI (PR #135, ubuntu-3.14). It had been read as a flake in `test_endpoint_run_lifecycle_start_sampling_stop`; PR #46 added error tracebacks to `status.json` specifically so the next occurrence would carry its cause, and this is that occurrence.

## The minimal condition is not what it looks like

`np.histogram` raises when `np.linspace(x_min, x_max, 513)` cannot produce 513 strictly increasing float64 edges. arviz_stats' KDE grid spans **exactly** `[min, max]` of the finite draws (`bound_correction=True`, no bandwidth widening), so the trigger is:

> the finite draws are **not** all identical, but their whole range spans **fewer than ~512 ULPs**.

Measured against the installed stack (arviz\* 1.2.0, numpy 2.4.6):

| shape | pre-fix |
|---|---|
| two ULP-adjacent values | **RAISE** |
| ~100-ULP spread | **RAISE** |
| ~2000-ULP spread | ok |
| exactly constant | no crash -- a **silent blank** panel (arviz's own `np.all(x == x[0])` guard returns a NaN pdf) |
| all NaN / all inf | same silent blank |
| single draw per chain | ok (2 chains give 2 distinct values) |

So it is **not** `min == max`: that case is caught upstream and silently blanked. The crash is the *near*-degenerate case -- exactly what a stopped, unmixed run produces. Both outputs are wrong, so all three shapes are handled.

## Flat variables are routine, not pathological

`Parameter.build_pymc` sets `track_node = any(is_sampled) or force_node or links`, so a **partially** pinned vector is still a Deterministic and its `sigma: 0` elements are exactly constant in the draws. That is the normal state of GP and robust-likelihood hyperparameters, whose non-opted-in files are pinned. Scanning 18 real traces in `examples/*/fitresults/`: `GJ1214b` has 4 (`band.thermal[1..4]`), `OGLE-2016-BLG-1003` 2, `KMT-2019-BLG-1806` 2, `OB140939` 1. Also legitimate: a stuck chain, a variable at a hard bound, a Deterministic whose physics went NaN.

## A second site, already broken

`run.py:_render_trace_page` is the **only** arviz density call in the tree (the GUI uses none, `outputs/modes.py`'s `np.histogram` passes an explicit `range`, `az.summary` handles all three shapes).

But `corner_utils.save_corner_plot` has the same class of bug and is **failing today**: `corner.corner` raises on a constant column *and* on any column containing a single NaN, and a pre-existing `try/except` turned that into one log line and no file. Verified -- `make_corner` on `GJ1214b` produces **no PNG at all** pre-fix.

## The fix

Degenerate rows are routed out of arviz onto their own annotated pages (`_split_degenerate_vars` -> `_render_degenerate_page`), same two-column geometry so pages read continuously and `_shade_trace_axes_by_mode`'s even/odd axis convention still holds. The trace panel is drawn for real; the density panel carries the reason -- `no density / constant at 0.5`, or `range 2.22e-16 around 1 spans fewer than 512 float64 steps`. A per-element `logger.warning` names the variable and the reason.

Annotated rather than skipped or single-binned: a skipped panel reads as a plotting bug, and a single-bin histogram reads as a real (if uninformative) density while conveying neither the value nor why it is the only bin. The value is the one thing a reader of that page needs.

Only degenerate *elements* are diverted -- a partially pinned vector keeps its sampled elements on a normal arviz page via a `coords` selection.

For corner: drop no-finite columns, then non-finite rows, then constant columns, each named in a warning. Dropping rather than passing `range=`, because corner's `range` also sets `force_range`, which would change the axis limits of the panels that were fine.

**No blanket try/except.** That would trade a loud crash for a silently missing plot, which is the pattern review items 3.12 and 3.17 exist to remove.

## Before/after on real traces

Rendered with `SOURCE_DATE_EPOCH` pinned, pre-fix vs post-fix, md5 of the PDF:

| trace | before | after |
|---|---|---|
| `OB08092_pspl` | `4b35928c...` | same |
| `HAT-P-3b` | `1e695be5...` | same |
| `KELT-4A_rv+transit+sed` | `6694a0cf...` | same |
| `DC2018_128` | `090ed6c2...` | same |

Byte-identical. `GJ1214b` (4 pinned elements) differs as intended -- its 4 blank panels became annotated pages.

## Tests

`tests/test_trace_plots.py` (+9) and new `tests/test_corner_degenerate.py` (6) -- **38 passed**. Pre-fix, **12 of the new trace tests fail**, including both behavioural crash cases (one float64 step, hundred float64 steps) and `test_degenerate_variable_is_reported_not_swallowed`, which catches the silent-blank constant case. The corner module does not import pre-fix; that behaviour was confirmed separately -- all three spoiled-column cases wrote **no file** before and write one after.

`tests/test_run_endpoints.py` (13 tests, including the lifecycle stop test): passed, 265 s. That test was deliberately **not** restructured -- the flake's cause is gone rather than made less likely, and the deterministic pin lives in the unit test that constructs the exact ULP condition.

One cleanup: `_n_trace_rows` became dead (the row count now falls out of the enumeration the degeneracy scan already does) and was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)