### PR TITLE
mulensing: no fabricated trajectory parameters either (sequel to #134)

### DIFF
--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -17,11 +17,15 @@ from ..galacticmodel.physics import expected_proper_motion
 from . import mmexofast_support
 from .op import BinaryLensMagOp, MulensMagOp, VBMDirectMagOp
 from .physics import (
+    _MM_NAN_ADVICE,
     _Q_NAN_ADVICE,
     MU_REL_FLOOR,
     Q_MAX,
     Q_MIN,
+    T_E_FLOOR,
     THETA_E_FLOOR,
+    THETA_E_LENSING_MIN,
+    U_0_FLOOR,
     clip_q,
 )
 
@@ -1106,9 +1110,86 @@ class Lens(Component):
                 "derived from) rather than relying on the clip."
             )
 
+    def _start_values(self, name):
+        """Resolved start value of a lens parameter as a 1-D float array, or
+        None when it has none (unset, or not castable -- a multi-seed entry
+        that survived as a ragged object array)."""
+        par = getattr(self, name, None)
+        if par is None or par.initval is None:
+            return None
+        try:
+            return np.atleast_1d(np.asarray(par.initval, dtype=float)).ravel()
+        except (TypeError, ValueError):
+            return None
+
+    def _validate_pspl_start(self):
+        """Stage 6: check the START values of the SAMPLED trajectory
+        parameters, loudly and once.  The sibling of
+        :meth:`_validate_q_start`, and it makes the same split for the same
+        reason: NaN raises (the fit cannot start), out of range warns (the fit
+        begins at the floored value rather than at the seeded one -- the "the
+        number I typed is not the number being fitted" case that goes
+        unnoticed for months).  This is the half of the old scrub worth
+        keeping, moved to where a raise is free: a check on the inputs at
+        build time, not a mid-graph assert that would kill a run over a
+        proposal the sampler already rejects on its own.
+
+        **Only t_0 and u_0 are checked, and that is deliberate.**  They are
+        the two trajectory parameters that are sampled, so their ``initval``
+        IS the start: raw = 0 maps to it through the logit transform.  The
+        other four quantities `_get_safe_mm_params` handles -- t_E, theta_E,
+        pi_E_N and pi_E_E -- are DERIVED, and for a derived parameter
+        ``initval``
+        is the relaxation engine's own bookkeeping, not the value the model
+        starts at; the graph recomputes it from the sampled coordinates.  The
+        two genuinely differ, so checking them here would be a false positive
+        on working configs.  Measured on `examples/ob161003` (2S2L, two source
+        slots): the engine leaves ``lens.theta_E.initval = [nan, 0.8393]`` and
+        ``lens.pi_rel.initval = [nan, 0.125]`` -- it only ever needed to solve
+        the second slot, both sources sharing one lens -- while the model
+        starts at a perfectly good ``theta_E = [0.8393, 0.8393]`` and a finite
+        logp.  A NaN there says nothing about the fit.  (That the engine
+        writes a NaN into a resolved value at all is a separate, pre-existing
+        oddity; it is not this guard's business to report it.)
+
+        The one range check is on ``|u_0| < U_0_FLOOR``.  Note that at u_0
+        EXACTLY zero the floor does not even engage: ``sign(0) = 0`` makes
+        ``sign(u_0) * maximum(|u_0|, U_0_FLOOR)`` return 0, so the peak
+        magnification stays singular.  ``u_0: 0`` is a plausible seed for a
+        high-magnification event, so the warning says so.  t_0 gets no range
+        check -- it carries two finite hard bounds of its own.
+        """
+        sampled = {
+            "t_0": self._start_values("t_0"),
+            "u_0": self._start_values("u_0"),
+        }
+        nan_named = [
+            f"{self.prefix}.{n} = {v.tolist()}"
+            for n, v in sampled.items()
+            if v is not None and np.any(np.isnan(v))
+        ]
+        if nan_named:
+            raise ValueError(
+                "The lensing trajectory starts at a value that is not a "
+                f"number: {'; '.join(nan_named)}.  {_MM_NAN_ADVICE}"
+            )
+
+        u_0 = sampled["u_0"]
+        if u_0 is not None and np.any(np.abs(u_0) < U_0_FLOOR):
+            small = u_0[np.abs(u_0) < U_0_FLOOR]
+            logger.warning(
+                f"{self.prefix}.u_0 starts at {small.tolist()}, inside the "
+                f"{U_0_FLOOR:g} floor on |u_0| (the magnification diverges "
+                "at u = 0), so the fit will actually START at the floored "
+                "value -- and at exactly 0 not even that, since sign(0) = 0 "
+                "leaves u_0 = 0 and the peak magnification infinite.  Seed a "
+                "small but nonzero impact parameter."
+            )
+
     def build_likelihood(self, model, system):
         """Stage 6: Observational penalties on the lensing geometry."""
         self._validate_q_start()
+        self._validate_pspl_start()
 
         # GEOCENTRIC mu_rel: the event-rate selection is the sky-sweep rate
         # in the frame the event is observed in (rp.py used the geocentric
@@ -1173,31 +1254,80 @@ class Lens(Component):
         return self.alpha.value[j] * _RAD_TO_DEG
 
     def _get_safe_mm_params(self, index=0):
-        """Sanitized single-source params.  ``index`` is the SOURCE slot: the
-        per-source vector parameters (t_0, u_0, t_E, pi_E_*) hold one element
-        per source body of the single event."""
+        """Range-limited single-source trajectory params.  ``index`` is the
+        SOURCE slot: the per-source vector parameters (t_0, u_0, t_E, pi_E_*)
+        hold one element per source body of the single event.
+
+        Three RANGE decisions survive here -- the t_E floor, the |u_0| floor
+        and the no-lensing parallax gate, all defined and justified next to
+        their constants in physics.py.  What is deliberately GONE is the NaN
+        substitution that used to precede them:
+
+            t_E -> 100 d,  u_0 -> 1,  theta_E -> 0,  pi_E_N -> 0,  pi_E_E -> 0
+
+        i.e. a complete, fabricated PSPL model in place of a failed
+        computation.  It is the same defect ``clip_q``'s ``pt.nan_to_num``
+        was (review item 4.5), five more times and with a much larger blast
+        radius: a fully-NaN parameter vector produced a healthy-looking light
+        curve and a finite likelihood.
+
+        Removing it is safe *and* strictly better, for the same two reasons:
+
+        * It is unreachable.  Every one of the five is finite for every finite
+          raw vector.  t_0 and u_0 are sampled with two finite hard bounds, so
+          the logit transform can only produce a finite number.  theta_E is
+          ``sqrt(max(KAPPA*max(M,1e-12)*max(pi_rel,0), THETA_E_FLOOR**2))``,
+          strictly positive and finite for any finite mass and pi_rel, and
+          pi_rel is a difference of two 1000/distance terms whose distances
+          are logit-bounded away from zero.  t_E = theta_E/(mu_rel_geo/365.25)
+          and pi_E = (pi_rel/theta_E)*(mu_i/mu_rel_geo) are then ratios whose
+          denominators are floored at THETA_E_FLOOR and MU_REL_FLOOR -- those
+          two floors, added in c178305, are exactly what closed the 0/0 that
+          made this scrub live when it was written (May 2026), back when
+          calc_mu_rel_mag was a bare sqrt that could return exactly 0.
+          Measured on examples/ob08092 (PSPL), examples/ob140939 (parallax +
+          Spitzer) and examples/DC2018_128 (binary lens): all five stay finite
+          over the entire raw support out to raw = +/-1e12, one variable at a
+          time and all at once, plus 2000 random raw points per event.  Three
+          real 300-tune/300-draw ptde_async fits (28 worker processes each,
+          172k / 215k / 223k evaluations) instrumented at the scrub itself
+          never once entered the branch.
+        * Where it could fire it could only do harm.  These five are NaN only
+          when an input is already NaN, i.e. the raw vector itself carries a
+          NaN -- and that raw variable's own N(0, 1) prior term already makes
+          the total logp NaN, so the proposal is rejected whatever this
+          function returns (verified on all three events, for every sampled
+          coordinate).  Substituting a "safe" value could never rescue a
+          sample; it invented an entire event geometry -- with a zero
+          gradient, since nan_to_num is a switch -- in place of the one
+          quantity that would have named the failure.
+
+        The theta_E substitution was not even that: ``theta_E_scrubbed`` fed
+        nothing but the ``pt.gt(..., 1e-6)`` comparison, and a comparison
+        against NaN is already False, so dropping it is a no-op in every case,
+        NaN included.
+
+        A NaN now propagates to logp, which is the sampler's own reject
+        signal, so nothing here needs a mid-graph assert (which would kill a
+        whole run over a proposal that is already being rejected) or a -inf
+        potential (no gradient, and the JAX where-trap).  The two SAMPLED
+        start values are checked once, loudly, in _validate_pspl_start; the
+        numeric Op path names the parameter through physics.require_mm_number.
+        """
         tE_raw = self.t_E.value[index]
         u0_raw = self.u_0.value[index]
         theta_E_raw = self.theta_E.value[index]
-        pi_N_raw = self.pi_E_N.value[index]
-        pi_E_raw = self.pi_E_E.value[index]
 
-        tE_scrubbed = pt.nan_to_num(tE_raw, nan=100.0)
-        u0_scrubbed = pt.nan_to_num(u0_raw, nan=1.0)
-        theta_E_scrubbed = pt.nan_to_num(theta_E_raw, nan=0.0)
-        pi_N_scrubbed = pt.nan_to_num(pi_N_raw, nan=0.0)
-        pi_E_scrubbed = pt.nan_to_num(pi_E_raw, nan=0.0)
-
-        tE_safe = pt.maximum(tE_scrubbed, 1e-4)
-        u0_safe = pt.sign(u0_scrubbed) * pt.maximum(pt.abs(u0_scrubbed), 1e-6)
-        is_physical = pt.gt(theta_E_scrubbed, 1e-6)
+        tE_safe = pt.maximum(tE_raw, T_E_FLOOR)
+        u0_safe = pt.sign(u0_raw) * pt.maximum(pt.abs(u0_raw), U_0_FLOOR)
+        is_physical = pt.gt(theta_E_raw, THETA_E_LENSING_MIN)
 
         return {
             "t0": self.t_0.value[index],
             "u0": u0_safe,
             "tE": tE_safe,
-            "pi_N": pt.switch(is_physical, pi_N_scrubbed, 0.0),
-            "pi_E": pt.switch(is_physical, pi_E_scrubbed, 0.0),
+            "pi_N": pt.switch(is_physical, self.pi_E_N.value[index], 0.0),
+            "pi_E": pt.switch(is_physical, self.pi_E_E.value[index], 0.0),
         }
 
     def _get_binary_mm_params(self, index=0):

--- a/src/exozippy/components/mulensing/op.py
+++ b/src/exozippy/components/mulensing/op.py
@@ -11,7 +11,12 @@ from pytensor.graph import Apply, Op
 
 from exozippy.compat import patch_mulensmodel_method_order
 
-from .physics import clip_q_value
+from .physics import (
+    _MM_NAN_ADVICE,
+    T_E_FLOOR,
+    clip_q_value,
+    require_mm_number,
+)
 
 # MulensModel dispatches magnification methods in PYTHONHASHSEED order, and
 # the VBMicrolensing backends are not order-independent, so identical inputs
@@ -59,14 +64,38 @@ def _dev_skycoord(obs_pos_np, cache):
     return cache[key]
 
 
+_BASE_LABELS = (
+    "lens.t_0",
+    "lens.u_0",
+    "lens.t_E",
+    "lens.pi_E_N",
+    "lens.pi_E_E",
+)
+
+
 def _base_mm_params(p):
-    """Sanitized parameters shared by all models: [t_0, u_0, t_E, pi_E_N, pi_E_E]."""
+    """Range-limited parameters shared by all models:
+    [t_0, u_0, t_E, pi_E_N, pi_E_E].
+
+    ``require_mm_number`` raises on a NaN instead of handing it to
+    MulensModel, which used to report whatever generic failure the NaN
+    happened to cause several frames away.  The caller's
+    ``except (ValueError, RuntimeError)`` turns it into the same all-NaN
+    answer as before, now under a message that names the parameter.  Finite
+    values, in range or out, are untouched.
+    """
+    t_0, u_0, t_E, pi_E_N, pi_E_E = (
+        require_mm_number(p[i], _BASE_LABELS[i]) for i in range(5)
+    )
     return {
-        "t_0": float(p[0]),
-        "u_0": float(np.sign(float(p[1])) * max(abs(float(p[1])), 1e-9)),
-        "t_E": float(max(float(p[2]), 1e-4)),
-        "pi_E_N": float(p[3]),
-        "pi_E_E": float(p[4]),
+        "t_0": t_0,
+        # NOTE the 1e-9 floor on |u_0| here vs physics.U_0_FLOOR = 1e-6 on the
+        # symbolic path: a pre-existing disagreement, deliberately left alone
+        # (unifying them would move any fit visiting 1e-9 <= |u_0| < 1e-6).
+        "u_0": float(np.sign(u_0) * max(abs(u_0), 1e-9)),
+        "t_E": float(max(t_E, T_E_FLOOR)),
+        "pi_E_N": pi_E_N,
+        "pi_E_E": pi_E_E,
     }
 
 
@@ -350,6 +379,9 @@ class VBMDirectMagOp(Op):
         # copy-on-write copy, so per-instance scratch state is never shared.
         self._vbm = self._build_vbm()
         self._delta_cache = {}
+        # Warn-once flag for the non-finite guard in _compute, mirroring
+        # _MagOpBase._warned.
+        self._warned = False
 
     def _build_vbm(self):
         vbm = VBMicrolensing.VBMicrolensing()
@@ -473,6 +505,19 @@ class VBMDirectMagOp(Op):
             A = np.full(len(times_np), np.nan)
         outputs[0][0] = np.asarray(A, dtype=np.float64)
 
+    def _param_labels(self):
+        """Names of the entries of this Op's param vector, in order -- so the
+        non-finite guard below can say WHICH parameter failed rather than
+        just that something did."""
+        labels = list(_BASE_LABELS)
+        if self.use_rho:
+            labels.append("lens.rho")
+        for j in range(self.n_companions):
+            labels += [f"lens.s[{j}]", f"lens.q[{j}]", f"lens.alpha[{j}]"]
+        if self.bandpass is not None:
+            labels.append("band.u1")
+        return labels
+
     def _compute(self, p, times_np, obs_pos_np):
         # Non-finite check FIRST: it is the explicit handler for a NaN
         # parameter vector (return NaN magnifications -> logp = -inf ->
@@ -480,7 +525,30 @@ class VBMDirectMagOp(Op):
         # clip_q_value never has to be the one to notice.  It used to sit
         # after the unpacking, which only worked because np.clip passed NaN
         # through silently.
-        if not np.all(np.isfinite(p)):
+        #
+        # Warn once, naming the entries, for the same reason _MagOpBase warns
+        # once: a *misconfigured* model is non-finite on every proposal, which
+        # is indistinguishable from ordinary rejection unless the first one is
+        # reported.  This branch used to return NaN in complete silence.
+        bad = ~np.isfinite(np.asarray(p, dtype=float))
+        if np.any(bad):
+            if not self._warned:
+                self._warned = True
+                labels = self._param_labels()
+                named = ", ".join(
+                    f"{labels[i] if i < len(labels) else f'p[{i}]'}"
+                    f" = {float(p[i])!r}"
+                    for i in np.flatnonzero(bad)
+                )
+                warnings.warn(
+                    f"{type(self).__name__}: non-finite magnification "
+                    f"parameter(s) {named} -- returning NaN magnifications "
+                    "(logp = -inf) for this proposal.  If this repeats for "
+                    "every proposal the model is misconfigured, not merely "
+                    f"exploring bad parameters.  {_MM_NAN_ADVICE}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
             return np.full(len(times_np), np.nan)
 
         base = _base_mm_params(p)

--- a/src/exozippy/components/mulensing/physics.py
+++ b/src/exozippy/components/mulensing/physics.py
@@ -209,6 +209,77 @@ def clip_q_value(q, label="lens.q"):
     return float(np.clip(q, Q_MIN, Q_MAX))
 
 
+# --- Trajectory (PSPL) parameter floors -------------------------------------
+# The three RANGE decisions Lens._get_safe_mm_params makes on the single-source
+# trajectory parameters before handing them to a magnification backend.  Like
+# Q_MIN/Q_MAX above, each is a statement about where the model is DEFINED, and
+# each must stand alone: none of them may be paired with a NaN substitution.
+#
+# T_E_FLOOR  every backend divides by t_E, and t_E <= 0 is not a timescale.
+#            The same 1e-4 d is applied on the numeric Op path
+#            (op._base_mm_params), so the two paths agree exactly.
+# U_0_FLOOR  A = (u^2+2)/(u*sqrt(u^2+4)) diverges as u -> 0, so the peak
+#            magnification of an exactly-central trajectory is infinite.  The
+#            floor is applied to |u_0| and the sign restored, which keeps the
+#            u_0 -> -u_0 reflection exact.  NOTE it is 1e-6 here and 1e-9 in
+#            op._base_mm_params: a pre-existing disagreement, deliberately left
+#            alone, because unifying them would move any fit that visits
+#            1e-9 <= |u_0| < 1e-6 -- a modelling change, not a sanitization one.
+# THETA_E_LENSING_MIN
+#            pi_E = pi_rel/theta_E, so as theta_E -> 0 the parallax vector
+#            diverges while the event itself stops being a lensing event at
+#            all.  Below this the trajectory is evaluated WITHOUT parallax
+#            (pi_E_N = pi_E_E = 0) rather than with a diverging one; the
+#            source_behind_lens / theta_E_singularity soft bounds in
+#            Lens.build_likelihood are what actually push the sampler out.
+#            It is a comparison, and a comparison against NaN is False, so
+#            this branch never needed a NaN substitution to begin with.
+T_E_FLOOR = 1e-4  # days
+U_0_FLOOR = 1e-6  # Einstein radii
+THETA_E_LENSING_MIN = 1e-6  # mas
+
+_MM_NAN_ADVICE = (
+    "The trajectory parameters are derived from the sampled coordinates: "
+    "t_E and pi_E_N/pi_E_E from theta_E and the relative proper motion, "
+    "theta_E from the lens mass and pi_rel, pi_rel from the two "
+    "star.<...>.distance values.  Check the initval (and any 'sigma: 0' "
+    "link expression) on star.<lens>.logmass, star.<lens>.distance, "
+    "star.<source>.distance and the star.<...>.pm_ra/pm_dec pair, plus "
+    "lens.<...>.t_0 and lens.<...>.u_0, which are sampled directly."
+)
+
+
+def require_mm_number(value, label):
+    """Numeric guard for a trajectory parameter on its way to a backend.
+
+    The counterpart of :func:`clip_q_value` for the five quantities
+    ``Lens._get_safe_mm_params`` handles, and it exists for the same reason:
+    ``pt.nan_to_num`` used to replace a NaN t_E with 100 d, a NaN u_0 with 1,
+    and a NaN theta_E/pi_E_N/pi_E_E with 0 -- a complete, fabricated PSPL model
+    in place of the one quantity that would have named the failure.  That scrub
+    is gone (see ``Lens._get_safe_mm_params``); on the symbolic path a NaN now
+    reaches logp, which is the sampler's own reject signal, and on this numeric
+    path it raises with a message that says which parameter it was.
+
+    Every caller already has the error path that turns the raise into the right
+    thing: ``_MagOpBase.perform`` catches ValueError, warns once, and returns
+    NaN magnifications -- logp = -inf, proposal rejected, exactly what a NaN
+    handed to MulensModel produced anyway, only three frames further away and
+    under a generic message.
+
+    The infinities are NOT an error, the same split :func:`clip_q_value` makes:
+    an infinity carries a sign and is an ordinary out-of-range value, which the
+    caller's own floor then handles.  NaN is the case with no value at all.
+    """
+    v = float(value)
+    if np.isnan(v):
+        raise ValueError(
+            f"{label} is nan: a trajectory parameter must be a number.  "
+            f"{_MM_NAN_ADVICE}"
+        )
+    return v
+
+
 @register_physics
 def calc_mlens_total(*masses):
     # Total lens mass: sum over all lens bodies.  theta_E, t_E, rho, and pi_E

--- a/tests/test_trajectory_sanitization.py
+++ b/tests/test_trajectory_sanitization.py
@@ -1,0 +1,696 @@
+"""Trajectory-parameter (t_0, u_0, t_E, theta_E, pi_E_N, pi_E_E) sanitization.
+
+The sequel to tests/test_q_sanitization.py.  ``Lens._get_safe_mm_params`` used
+to scrub all five of its inputs with ``pt.nan_to_num``::
+
+    t_E -> 100 d,  u_0 -> 1,  theta_E -> 0,  pi_E_N -> 0,  pi_E_E -> 0
+
+so a fully-NaN parameter vector produced a complete, fabricated PSPL model and
+a healthy-looking likelihood.  The scrub is gone; the three RANGE decisions it
+was tangled up with (the t_E floor, the |u_0| floor, the no-lensing parallax
+gate) survive, and the failure now names the parameter -- in the graph by
+propagating to logp, on the numeric Op path by raising, and at build time by
+``Lens._validate_pspl_start``.
+"""
+
+import inspect
+import warnings
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+
+from exozippy.components.mulensing.lens import Lens
+from exozippy.components.mulensing.op import (
+    MulensMagOp,
+    VBMDirectMagOp,
+    _base_mm_params,
+    _build_pspl_model,
+)
+from exozippy.components.mulensing.physics import (
+    T_E_FLOOR,
+    THETA_E_LENSING_MIN,
+    U_0_FLOOR,
+    require_mm_number,
+)
+from exozippy.system import System
+
+_COORDS = "268.0d -29.0d"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _pspl_config():
+    """A minimal PSPL topology: star.0 lens, star.1 source."""
+    config = {
+        "star": [{"name": "Lens"}, {"name": "Source"}],
+        "lens": [
+            {
+                "name": "Lens",
+                "lenses": ["star.0"],
+                "sources": ["star.1"],
+                "finite_source": False,
+            }
+        ],
+    }
+    user_params = {
+        "lens.Lens.t_0": {"initval": 2455379.571},
+        "lens.Lens.u_0": {"initval": 0.523},
+        "lens.Lens.t_E": {"initval": 17.94},
+        "star.Lens.ra": {"initval": 268.0, "sigma": 0},
+        "star.Lens.dec": {"initval": -29.0, "sigma": 0},
+        "star.Source.ra": {"initval": 268.0, "sigma": 0},
+        "star.Source.dec": {"initval": -29.0, "sigma": 0},
+    }
+    return config, user_params
+
+
+@pytest.fixture(scope="module")
+def pspl_system():
+    config, user_params = _pspl_config()
+    system = System(config, user_params=user_params)
+    system.prepare()
+    model = system.build_model()
+    return system, model
+
+
+class _FakeParam:
+    """The only thing _get_safe_mm_params asks of a Parameter: ``.value``."""
+
+    def __init__(self, node):
+        self.value = node
+
+
+class _FakeLens:
+    """Enough of a Lens to call _get_safe_mm_params on symbolic inputs."""
+
+    def __init__(self):
+        self.t_0 = _FakeParam(pt.dvector("t_0"))
+        self.u_0 = _FakeParam(pt.dvector("u_0"))
+        self.t_E = _FakeParam(pt.dvector("t_E"))
+        self.theta_E = _FakeParam(pt.dvector("theta_E"))
+        self.pi_E_N = _FakeParam(pt.dvector("pi_E_N"))
+        self.pi_E_E = _FakeParam(pt.dvector("pi_E_E"))
+
+    def inputs(self):
+        return [
+            self.t_0.value,
+            self.u_0.value,
+            self.t_E.value,
+            self.theta_E.value,
+            self.pi_E_N.value,
+            self.pi_E_E.value,
+        ]
+
+
+_KEYS = ("t0", "u0", "tE", "pi_N", "pi_E")
+
+
+def _legacy_safe_mm_params(lens, index=0):
+    """The pre-fix body of Lens._get_safe_mm_params, verbatim."""
+    tE_raw = lens.t_E.value[index]
+    u0_raw = lens.u_0.value[index]
+    theta_E_raw = lens.theta_E.value[index]
+    pi_N_raw = lens.pi_E_N.value[index]
+    pi_E_raw = lens.pi_E_E.value[index]
+
+    tE_scrubbed = pt.nan_to_num(tE_raw, nan=100.0)
+    u0_scrubbed = pt.nan_to_num(u0_raw, nan=1.0)
+    theta_E_scrubbed = pt.nan_to_num(theta_E_raw, nan=0.0)
+    pi_N_scrubbed = pt.nan_to_num(pi_N_raw, nan=0.0)
+    pi_E_scrubbed = pt.nan_to_num(pi_E_raw, nan=0.0)
+
+    tE_safe = pt.maximum(tE_scrubbed, 1e-4)
+    u0_safe = pt.sign(u0_scrubbed) * pt.maximum(pt.abs(u0_scrubbed), 1e-6)
+    is_physical = pt.gt(theta_E_scrubbed, 1e-6)
+
+    return {
+        "t0": lens.t_0.value[index],
+        "u0": u0_safe,
+        "tE": tE_safe,
+        "pi_N": pt.switch(is_physical, pi_N_scrubbed, 0.0),
+        "pi_E": pt.switch(is_physical, pi_E_scrubbed, 0.0),
+    }
+
+
+def _compiled_pair():
+    """(new, legacy) evaluators of the five outputs on the same inputs."""
+    fake = _FakeLens()
+    new = Lens._get_safe_mm_params(fake, 0)
+    old = _legacy_safe_mm_params(fake, 0)
+    ins = fake.inputs()
+    f_new = pytensor.function(ins, [new[k] for k in _KEYS])
+    f_old = pytensor.function(ins, [old[k] for k in _KEYS])
+    return f_new, f_old
+
+
+# ---------------------------------------------------------------------------
+# The surviving range decisions are unchanged, bit for bit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "vals",
+    [
+        (2455379.571, 0.523, 17.94, 0.2337, 0.0767, 0.0485),
+        (2456836.22, -0.922, 25.03, 0.878, -0.2706, 0.2074),
+        (2458554.89, 1e-5, 1e-3, 1e-5, 0.0, 0.0),
+        (2458554.89, -1e-7, 1e-6, 1e-9, 1.0, -1.0),
+        (2458554.89, 18.0, 1e19, 5e4, 1e18, -1e18),
+        (2458554.89, 0.0, 0.0, 0.0, 0.0, 0.0),
+        (2458554.89, 0.5, -30.0, -1.0, 3.0, 4.0),
+    ],
+)
+def test_finite_inputs_are_byte_identical_to_the_old_expression(vals):
+    """
+    Given any FINITE trajectory parameters -- in range, out of range, at the
+      floors, and at the extremes of the sampled support,
+    When the five sanitized outputs are computed,
+    Then they are bit-identical to the pre-fix expression that scrubbed with
+      nan_to_num first.  Removing the scrub is a change to the NaN case only;
+      no working fit may move.
+    """
+    f_new, f_old = _compiled_pair()
+    args = [np.array([v], dtype=float) for v in vals]
+    for k, a, b in zip(_KEYS, f_new(*args), f_old(*args)):
+        a, b = np.asarray(a, dtype=float), np.asarray(b, dtype=float)
+        assert a.tobytes() == b.tobytes(), f"{k}: {a} != {b}"
+
+
+def test_the_floors_are_the_historical_literals():
+    """
+    Given the three range decisions, now named constants in physics.py,
+    When their values are read,
+    Then they are exactly the literals that were open-coded in the old
+      expression -- naming a constant must not move a number.
+    """
+    assert T_E_FLOOR == 1e-4
+    assert U_0_FLOOR == 1e-6
+    assert THETA_E_LENSING_MIN == 1e-6
+
+
+def test_t_E_is_floored_and_u_0_keeps_its_sign():
+    """
+    Given a non-positive t_E and a tiny negative u_0,
+    When the range decisions are applied,
+    Then t_E is floored at T_E_FLOOR and |u_0| at U_0_FLOOR with the sign
+      preserved -- these are statements about where the backends are defined
+      and they survive the removal of the NaN scrub.
+    """
+    f_new, _ = _compiled_pair()
+    out = dict(
+        zip(
+            _KEYS,
+            f_new(
+                np.array([2458554.89]),
+                np.array([-1e-12]),
+                np.array([-5.0]),
+                np.array([1.0]),
+                np.array([0.1]),
+                np.array([0.2]),
+            ),
+        )
+    )
+    assert float(out["tE"]) == T_E_FLOOR
+    assert float(out["u0"]) == -U_0_FLOOR
+
+
+def test_the_parallax_gate_still_zeroes_pi_E_below_the_lensing_threshold():
+    """
+    Given a theta_E at or below THETA_E_LENSING_MIN (no lensing) with a
+      nonzero parallax vector,
+    When the params are built,
+    Then pi_E_N and pi_E_E are zero -- pi_E = pi_rel/theta_E diverges there,
+      and the soft bounds in build_likelihood, not a fabricated value, are
+      what push the sampler out.
+    """
+    f_new, _ = _compiled_pair()
+    out = dict(
+        zip(
+            _KEYS,
+            f_new(
+                np.array([2458554.89]),
+                np.array([0.5]),
+                np.array([20.0]),
+                np.array([THETA_E_LENSING_MIN]),
+                np.array([0.3]),
+                np.array([-0.4]),
+            ),
+        )
+    )
+    assert float(out["pi_N"]) == 0.0
+    assert float(out["pi_E"]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# The NaN path: propagate, never fabricate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "which, fabricated, affected",
+    [
+        ("t_E", 100.0, ["tE"]),
+        ("u_0", 1.0, ["u0"]),
+        ("pi_E_N", 0.0, ["pi_N"]),
+        ("pi_E_E", 0.0, ["pi_E"]),
+    ],
+)
+def test_a_nan_input_propagates_instead_of_becoming_its_old_default(
+    which, fabricated, affected
+):
+    """
+    Given a NaN in one trajectory parameter,
+    When the params are built,
+    Then the corresponding output is NaN, NOT the value the old nan_to_num
+      substituted (t_E -> 100 d, u_0 -> 1, pi_E -> 0).
+
+    This is the substance of the change.  A NaN here means an input is already
+    NaN, i.e. the raw vector carries a NaN, which already makes the total logp
+    NaN through that variable's own N(0, 1) prior (test below) -- so the
+    proposal is rejected either way and the substitution could never rescue a
+    sample.  What it did instead was invent an entire event geometry, with a
+    zero gradient (nan_to_num is a switch), in place of the one quantity that
+    would have named the failure.
+    """
+    f_new, f_old = _compiled_pair()
+    base = dict(
+        t_0=2458554.89,
+        u_0=0.523,
+        t_E=17.94,
+        theta_E=0.234,
+        pi_E_N=0.077,
+        pi_E_E=0.049,
+    )
+    base[which] = np.nan
+    args = [
+        np.array([base[k]])
+        for k in ("t_0", "u_0", "t_E", "theta_E", "pi_E_N", "pi_E_E")
+    ]
+
+    new = dict(zip(_KEYS, f_new(*args)))
+    old = dict(zip(_KEYS, f_old(*args)))
+    for key in affected:
+        assert np.isnan(float(new[key])), f"{key} did not propagate the NaN"
+        assert float(old[key]) == fabricated, "legacy expression changed"
+
+
+def test_a_nan_theta_E_still_gates_the_parallax_off_and_nans_t_E():
+    """
+    Given a NaN theta_E,
+    When the params are built,
+    Then the parallax gate is False (a comparison against NaN is False, with
+      or without the old nan_to_num -- which is why THAT substitution was a
+      no-op in every case, NaN included) and the NaN still reaches the model
+      through t_E, which is theta_E / mu_rel.
+    """
+    f_new, f_old = _compiled_pair()
+    args = [
+        np.array([2458554.89]),
+        np.array([0.523]),
+        np.array([np.nan]),  # t_E, which derives from theta_E
+        np.array([np.nan]),  # theta_E
+        np.array([0.077]),
+        np.array([0.049]),
+    ]
+    new = dict(zip(_KEYS, f_new(*args)))
+    old = dict(zip(_KEYS, f_old(*args)))
+    assert float(new["pi_N"]) == 0.0 and float(new["pi_E"]) == 0.0
+    assert float(old["pi_N"]) == 0.0 and float(old["pi_E"]) == 0.0
+    assert np.isnan(float(new["tE"]))
+    assert float(old["tE"]) == 100.0
+
+
+def test_no_scrub_survives_in_the_source():
+    """
+    Given _get_safe_mm_params,
+    When its source is inspected,
+    Then it neither calls nan_to_num nor open-codes the three floors, so the
+      fabrication cannot creep back by copy-paste without failing here.
+    """
+    src = inspect.getsource(Lens._get_safe_mm_params)
+    body = src.split('"""')[-1]
+    assert "nan_to_num" not in body
+    assert "1e-4" not in body and "1e-6" not in body
+
+
+# ---------------------------------------------------------------------------
+# Why the NaN branch is unreachable, pinned on a real model
+# ---------------------------------------------------------------------------
+
+
+def test_the_five_stay_finite_over_the_whole_sampled_support(pspl_system):
+    """
+    Given a PSPL model,
+    When the five quantities are evaluated at raw coordinates far beyond
+      anything a sampler reaches (+/-1e12 on every raw variable at once, then
+      one at a time, then randomly),
+    Then they are always finite.  t_0/u_0 are logit-bounded; theta_E's
+      radicand is floored, so it is strictly positive; and t_E and pi_E are
+      ratios whose denominators are floored at THETA_E_FLOOR / MU_REL_FLOOR.
+      This is the premise the removal rests on.
+    """
+    system, model = pspl_system
+    lens = system.lens
+    names = ["t_0", "u_0", "t_E", "theta_E", "pi_E_N", "pi_E_E"]
+    rvs = list(model.value_vars)
+    outs = model.replace_rvs_by_values([getattr(lens, n).value for n in names])
+    fn = pytensor.function(rvs, outs, on_unused_input="ignore")
+
+    ip = model.initial_point()
+    base = [np.asarray(ip[v.name], dtype=float) for v in rvs]
+
+    with np.errstate(all="ignore"):
+        for extreme in (-1e12, -1e4, -50.0, 0.0, 50.0, 1e4, 1e12):
+            vals = fn(*[np.full(np.shape(b), extreme) for b in base])
+            for n, v in zip(names, vals):
+                assert np.all(np.isfinite(v)), f"{n} not finite at {extreme}"
+
+        for i in range(len(rvs)):
+            for extreme in (-1e12, 1e12):
+                args = [b.copy() for b in base]
+                args[i] = np.full(np.shape(base[i]), extreme)
+                for n, v in zip(names, fn(*args)):
+                    assert np.all(np.isfinite(v)), (
+                        f"{n} not finite at {rvs[i].name}={extreme}"
+                    )
+
+        rng = np.random.default_rng(0)
+        for scale in (1.0, 1e3, 1e6):
+            for _ in range(40):
+                vals = fn(
+                    *[
+                        b + rng.normal(scale=scale, size=np.shape(b))
+                        for b in base
+                    ]
+                )
+                for n, v in zip(names, vals):
+                    assert np.all(np.isfinite(v)), f"{n} not finite (random)"
+
+
+def test_a_nan_raw_coordinate_already_makes_logp_nan(pspl_system):
+    """
+    Given a NaN in any sampled coordinate -- the only way these five can go
+      NaN,
+    When the model logp is evaluated,
+    Then it is NaN regardless of what the trajectory params do, because that
+      raw variable's own N(0, 1) prior term is NaN.  The proposal is rejected
+      either way, so the scrub could never have rescued a sample; it could
+      only hide which quantity failed.
+    """
+    _, model = pspl_system
+    ip = model.initial_point()
+    logp = model.compile_logp()
+    assert np.isfinite(logp(ip))
+
+    for v in model.value_vars:
+        point = dict(ip)
+        point[v.name] = np.full(np.shape(np.asarray(ip[v.name])), np.nan)
+        assert np.isnan(logp(point)), f"{v.name}=NaN did not poison logp"
+
+
+# ---------------------------------------------------------------------------
+# The numeric (Op) path names the parameter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "index, label",
+    [
+        (0, "lens.t_0"),
+        (1, "lens.u_0"),
+        (2, "lens.t_E"),
+        (3, "lens.pi_E_N"),
+        (4, "lens.pi_E_E"),
+    ],
+)
+def test_base_mm_params_raises_naming_the_nan_parameter(index, label):
+    """
+    Given a param vector with a NaN in one trajectory slot,
+    When the MulensModel param builder runs,
+    Then it raises ValueError naming that parameter, instead of handing NaN
+      to MulensModel and letting it report whatever generic failure the NaN
+      happened to cause several frames away.
+    """
+    p = np.array([2458554.89, 0.1, 18.2, 0.02, -0.01])
+    p[index] = np.nan
+    with pytest.raises(ValueError) as exc:
+        _base_mm_params(p)
+    msg = str(exc.value)
+    assert label in msg
+    assert "must be a number" in msg
+    assert "logmass" in msg and "distance" in msg
+
+
+def test_base_mm_params_is_unchanged_for_finite_input():
+    """
+    Given finite trajectory parameters,
+    When _base_mm_params runs,
+    Then every field is what the old body produced: t_0 and the two pi_E
+      untouched, |u_0| floored at 1e-9 with its sign, t_E floored at
+      T_E_FLOOR.
+    """
+    p = np.array([2458554.89, -1e-12, -3.0, 0.02, -0.01])
+    got = _base_mm_params(p)
+    assert got["t_0"] == 2458554.89
+    assert got["u_0"] == -1e-9
+    assert got["t_E"] == T_E_FLOOR
+    assert got["pi_E_N"] == 0.02
+    assert got["pi_E_E"] == -0.01
+
+
+def test_require_mm_number_passes_infinities_through():
+    """
+    Given an infinite trajectory parameter,
+    When require_mm_number is applied,
+    Then it is returned, not raised on -- the same NaN/infinity split
+      clip_q_value makes.  An infinity carries a sign and is an ordinary
+      out-of-range value the caller's own floor handles; NaN has no value at
+      all.
+    """
+    assert require_mm_number(np.inf, "lens.t_E") == np.inf
+    assert require_mm_number(-np.inf, "lens.u_0") == -np.inf
+    assert (
+        _base_mm_params(np.array([2458554.89, 0.1, np.inf, 0.0, 0.0]))["t_E"]
+        == np.inf
+    )
+
+
+def test_pspl_op_reports_a_nan_by_name_and_still_rejects_the_proposal():
+    """
+    Given a param vector whose t_E is NaN,
+    When MulensMagOp.perform runs,
+    Then it still returns all-NaN magnifications (logp = -inf, proposal
+      rejected -- unchanged), but the warn-once message now names lens.t_E.
+    """
+    p = np.array([2458554.89, 0.1, np.nan, 0.0, 0.0])
+    t = np.linspace(2458554.89 - 5, 2458554.89 + 5, 21)
+    obs = np.zeros((len(t), 3))
+    out = [[None]]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        MulensMagOp(coords=_COORDS, mag_method="point_source").perform(
+            None, [p, t, obs], out
+        )
+
+    assert np.all(np.isnan(out[0][0]))
+    assert any("lens.t_E" in str(w.message) for w in caught)
+
+
+def test_build_pspl_model_is_unchanged_for_a_healthy_vector():
+    """
+    Given an ordinary PSPL param vector,
+    When the MulensModel model is built,
+    Then its parameters are exactly the input -- the guard is inert on
+      everything a fit actually visits.
+    """
+    p = np.array([2458554.89, 0.1, 18.2, 0.02, -0.01])
+    model = _build_pspl_model(p, _COORDS, "point_source", use_rho=False)
+    assert float(model.parameters.t_0) == 2458554.89
+    assert float(model.parameters.u_0) == 0.1
+    assert float(model.parameters.t_E) == 18.2
+    assert float(model.parameters.pi_E_N) == 0.02
+    assert float(model.parameters.pi_E_E) == -0.01
+
+
+def test_vbm_direct_names_the_non_finite_entry_it_short_circuits_on():
+    """
+    Given a param vector with a NaN t_E,
+    When VBMDirectMagOp.perform runs,
+    Then it returns all-NaN through its own non-finite guard -- unchanged --
+      but warns once naming lens.t_E.  That branch used to return NaN in
+      complete silence, which is indistinguishable from an ordinary rejected
+      proposal even when the model is misconfigured on every one.
+    """
+    p = np.array([2458554.89, 0.1, np.nan, 0.02, -0.01, 0.98, 1.1e-3, -52.0])
+    t = np.linspace(2458554.89 - 5, 2458554.89 + 5, 21)
+    obs = np.zeros((len(t), 3))
+    out = [[None]]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        VBMDirectMagOp(coords=_COORDS, n_companions=1, use_rho=False).perform(
+            None, [p, t, obs], out
+        )
+
+    assert np.all(np.isnan(out[0][0]))
+    assert any("lens.t_E" in str(w.message) for w in caught)
+
+
+def test_vbm_direct_labels_cover_the_whole_param_vector():
+    """
+    Given the VBM param layouts,
+    When the label list is built,
+    Then it lines up with the vector the Op actually unpacks, so the warning
+      cannot name the wrong parameter.
+    """
+    op = VBMDirectMagOp(coords=_COORDS, n_companions=2, use_rho=True)
+    labels = op._param_labels()
+    assert labels[:5] == [
+        "lens.t_0",
+        "lens.u_0",
+        "lens.t_E",
+        "lens.pi_E_N",
+        "lens.pi_E_E",
+    ]
+    assert labels[5] == "lens.rho"
+    assert labels[6:9] == ["lens.s[0]", "lens.q[0]", "lens.alpha[0]"]
+    assert labels[9:12] == ["lens.s[1]", "lens.q[1]", "lens.alpha[1]"]
+    assert len(labels) == 12
+
+
+# ---------------------------------------------------------------------------
+# The build-time guard on the start values
+# ---------------------------------------------------------------------------
+
+
+def test_a_healthy_pspl_start_neither_warns_nor_raises(pspl_system, caplog):
+    """
+    Given an ordinary PSPL start,
+    When the guard runs,
+    Then it is silent -- it must not fire on working configs.
+    """
+    system, _ = pspl_system
+    with caplog.at_level("WARNING"):
+        system.lens._validate_pspl_start()
+    assert "starts at" not in caplog.text
+
+
+@pytest.mark.parametrize("name", ["t_0", "u_0"])
+def test_a_nan_sampled_start_raises_naming_the_parameter(pspl_system, name):
+    """
+    Given a NaN start for a SAMPLED trajectory parameter (a broken seed, or a
+      hard link whose expression went NaN),
+    When the lens builds its likelihood,
+    Then it raises, naming that parameter and what to check.  This is the one
+      place a raise is free: a check on the inputs at build time, not a
+      mid-graph assert that would kill a run over a proposal the sampler
+      already rejects on its own.
+    """
+    system, _ = pspl_system
+    par = getattr(system.lens, name)
+    saved = par.initval
+    try:
+        par.initval = np.array([np.nan])
+        with pytest.raises(ValueError) as exc:
+            system.lens._validate_pspl_start()
+    finally:
+        par.initval = saved
+
+    msg = str(exc.value)
+    assert f".{name}" in msg
+    assert "not a number" in msg
+    assert "logmass" in msg
+
+
+@pytest.mark.parametrize("name", ["t_E", "theta_E", "pi_E_N", "pi_E_E"])
+def test_a_derived_parameters_initval_is_not_treated_as_the_start(
+    pspl_system, name, caplog
+):
+    """
+    Given a NaN in the resolved ``initval`` of a DERIVED trajectory parameter,
+    When the guard runs,
+    Then it neither raises nor warns, because for a derived parameter
+      ``initval`` is the relaxation engine's bookkeeping and NOT the value the
+      model starts at -- the graph recomputes it from the sampled coordinates.
+
+    This is not hypothetical.  examples/ob161003 ships with
+    ``lens.theta_E.initval = [nan, 0.8393]`` (the engine only ever solved the
+    second source slot) while the model starts at ``theta_E = [0.8393,
+    0.8393]`` with a finite logp, so a guard that read derived initvals would
+    refuse to build a working, shipped example.
+    """
+    system, _ = pspl_system
+    par = getattr(system.lens, name)
+    saved = par.initval
+    try:
+        par.initval = np.array([np.nan])
+        with caplog.at_level("WARNING"):
+            system.lens._validate_pspl_start()  # must not raise
+    finally:
+        par.initval = saved
+    assert "starts at" not in caplog.text
+
+
+@pytest.mark.parametrize("u0", [0.0, 1e-12, -1e-9])
+def test_a_tiny_u_0_start_warns(pspl_system, caplog, u0):
+    """
+    Given an impact parameter seeded inside the |u_0| floor -- including
+      exactly zero, a plausible seed for a high-magnification event,
+    When the guard runs,
+    Then it warns.  At exactly zero the floor does not even engage
+      (sign(0) = 0 leaves u_0 = 0 and the peak magnification infinite), which
+      is why the message says so.
+    """
+    system, _ = pspl_system
+    par = system.lens.u_0
+    saved = par.initval
+    try:
+        par.initval = np.array([u0])
+        with caplog.at_level("WARNING"):
+            system.lens._validate_pspl_start()
+    finally:
+        par.initval = saved
+    assert ".u_0 starts at" in caplog.text
+
+
+def test_an_infinite_start_does_not_raise(pspl_system, caplog):
+    """
+    Given an infinite u_0 start,
+    When the guard runs,
+    Then it does not raise -- the same NaN/infinity split require_mm_number
+      and clip_q_value make, so the build-time guard and the runtime helpers
+      cannot disagree about what is fatal.  An infinity carries a sign; NaN
+      has no value at all.
+    """
+    system, _ = pspl_system
+    par = system.lens.u_0
+    saved = par.initval
+    try:
+        par.initval = np.array([-np.inf])
+        with caplog.at_level("WARNING"):
+            system.lens._validate_pspl_start()  # must not raise
+    finally:
+        par.initval = saved
+    assert ".u_0 starts at" not in caplog.text
+
+
+def test_the_examples_that_ship_build_without_the_guard_firing(pspl_system):
+    """
+    Given the guard,
+    When it is asked which parameters it reads,
+    Then it reads only the two SAMPLED trajectory parameters.  A guard that
+      read the derived ones would refuse examples/ob161003, whose engine-
+      resolved theta_E initval carries a NaN in the slot it never needed to
+      solve while the model itself starts fine.
+    """
+    src = inspect.getsource(Lens._validate_pspl_start)
+    body = src.split('"""')[-1]
+    assert '"t_0"' in body and '"u_0"' in body
+    for derived in ("t_E", "theta_E", "pi_E_N", "pi_E_E"):
+        assert f'"{derived}"' not in body


### PR DESCRIPTION
`Lens._get_safe_mm_params` scrubbed non-finite values out of five quantities before handing them to the magnification backend -- `t_E -> 100`, `u_0 -> 1`, `theta_E -> 0`, `pi_E_N -> 0`, `pi_E_E -> 0` -- so a fully-NaN parameter vector produced a **complete, fabricated PSPL model** rather than a NaN. The same defect #134 removed for `q`, five more times and with a larger blast radius.

Same method as #134: establish per quantity whether it can actually go non-finite, whether the branch ever fires, and whether the scrub could ever rescue a sample.

## Per quantity

| quantity | provenance | can go non-finite? | fires in a real fit? |
|---|---|---|---|
| `t_E` | derived, `theta_E/(mu_rel_geo_mag/365.25)` | **No** -- both operands floored (`THETA_E_FLOOR`, `MU_REL_FLOOR` = 1e-12), so no 0/0 | **No** |
| `u_0` | **sampled**, hard bounds [-18, 18] | **No** -- the logit transform of a finite raw is always finite | **No** |
| `theta_E` | derived, `sqrt(max(KAPPA*max(M,1e-12)*max(pi_rel,0), 1e-24))` | **No** -- radicand floored; `pi_rel` is a difference of two `1000/distance` terms, and distances are logit-bounded off zero | **No** |
| `pi_E_N`, `pi_E_E` | derived, `(pi_rel/theta_E)*(mu_i/mu_rel_geo)` | **No** -- the same two floors are the denominators | **No** |

Evidence: the whole raw support swept on `ob08092` (PSPL), `ob140939` (parallax + Spitzer) and `DC2018_128` (binary) -- raw = +/-1e12 all at once, then one variable at a time, plus 2000 random points per event: zero non-finite. Then three real 300-tune/300-draw `ptde_async` fits with a pass-through `Print` Op on the scrub inputs writing from every worker: **28 processes, 172k / 215k / 223k evaluations per event, zero hits.**

Could the scrub rescue a sample? No -- verified on all three events, for *every* sampled coordinate: a NaN raw already makes total logp NaN through its own `N(0,1)` prior term, so the proposal is rejected whatever the model does.

## None of the five is a live bug -- and the history says why it once was

The floors that close the `0/0` landed in `c178305` (Aug 2026); the scrub dates from May 2026, when `calc_mu_rel_mag` was a bare `sqrt` that could return exactly 0, making `t_E = theta_E/0` genuinely reachable. So this is dead paper left behind by a real fix, exactly as suspected.

One extra: the `theta_E` scrub was **never live even in principle** -- it fed only the `pt.gt(..., 1e-6)` gate, and a comparison against NaN is already False.

## What changed

- The five `nan_to_num` calls are deleted. The three genuine **range** decisions are kept, now named constants in `physics.py` with the reasoning attached: `T_E_FLOOR`, `U_0_FLOOR`, `THETA_E_LENSING_MIN`.
- `physics.require_mm_number` (the numeric sibling of #134's `clip_q_value`) raises on NaN naming the parameter, called from `op._base_mm_params`; the existing `except ValueError` handlers turn it into the same all-NaN answer with a message that names the cause. Infinities pass through -- they carry a sign and are ordinary out-of-range values.
- `VBMDirectMagOp`'s non-finite guard now warns once, naming the entries (`_param_labels`). It used to return NaN in silence.
- `Lens._validate_pspl_start` at stage 6: a NaN start raises; a `|u_0|` inside the floor warns -- and notes that at exactly 0, `sign(0) = 0` defeats the floor entirely, a latent hole in the existing clip.

## The surprise: a shipped example ships NaN initvals

A first version that checked all six start values **refused to build `examples/ob161003`**, which carries `lens.theta_E.initval = [nan, 0.8393]` and `lens.pi_rel.initval = [nan, 0.125]` -- while the model starts at a healthy `theta_E = [0.8393, 0.8393]` with finite logp.

For a **derived** parameter, `initval` is the relaxation engine's bookkeeping, not the start. So the guard now reads only the sampled pair (`t_0`, `u_0`). That the engine writes a NaN into a resolved value at all is a separate pre-existing oddity -- left alone, documented.

## Byte identity

Start-point logp, the five sanitized outputs, and a sha256 of the magnification curve: `ob08092`, `ob140939`, `DC2018_128` **identical**. `ob161003` identical except logp in the last ulp -- and three runs of *identical* code also produce both values, the same pre-existing float reassociation #134 recorded and #141 hit independently. Plus a 7-point finite grid comparing the new and old expressions bit for bit. `numpyro` sampled `ob08092` end to end, since the changed code is on the symbolic path.

## Tests

`tests/test_trajectory_sanitization.py` -- **41 passed**. Pre-fix the module does not even import; a direct replay shows all 14 core assertions failing (`t_E` returns the fabricated 100.0, `u_0` 1.0, `pi_E` 0.0, ...).

Neighbours green: `test_q_sanitization`, `test_pspl_symbolic_vs_op`, `test_microlensing_physics`, `test_mulens_flux_likelihood`, `test_mulens_review_fixes`, `test_nsnl`, `test_log_s`, `test_mu_rel_geo`, `test_vbm_direct_vs_mulensmodel`, `test_silent_bandaids` (138), and `test_examples_prepare`, `test_mmexofast_support`, `test_multiseed_mmexofast`, `test_seed_quality`, `test_runaway_logp_regression`, `test_plot_data` (81). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)