### PR TITLE
config: inject the engine's solution under the index key, not the instance name

### DIFF
--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -1452,7 +1452,33 @@ class ConfigManager:
                     break
 
             if existing_key is None:
-                self.user_params[final_path] = {
+                # A NEW entry is written in the INDEX form (`path`), never the
+                # config-instance-name form (`final_path`).  resolve() looks a
+                # per-element entry up under three keys -- `comp.param`,
+                # `comp.<i>.param` and `comp.<names[i]>.param` -- and only the
+                # index one is guaranteed to address element i: `names` is a
+                # manifest option, so a component may label its elements with
+                # something other than its own config instances' names.
+                #
+                # `lens` does exactly that (examples/ob161003): its per-source
+                # vectors are named for the SOURCE STARS ("SourceA",
+                # "SourceB"), while the lens block has a single entry named
+                # "Lens" at index 0.  So the engine's answer for source slot 0
+                # -- `lens.0.theta_E` -- used to be filed as
+                # `lens.Lens.theta_E`, which matches none of element 0's three
+                # keys, and the solved value was silently dropped.  With no
+                # `initval` in mulensing/defaults.yaml (theta_E is derived) and
+                # element 1 filed readably as `lens.1.theta_E`, apply_value
+                # allocated a NaN-filled vector and wrote only element 1:
+                # `lens.theta_E.initval == [nan, 0.839]`.  Element 0 was the
+                # only one affected because index 0 is the only index a lens
+                # instance name collides with.
+                #
+                # The index form is also the documented internal spelling (see
+                # standardize_param_names) and is what get_conversion_factor,
+                # propagated_scales, scale_hints and the engine's own symbol
+                # paths already use.
+                self.user_params[path] = {
                     "initval": user_val,
                     "derived": True,
                 }

--- a/tests/test_config_healing.py
+++ b/tests/test_config_healing.py
@@ -32,9 +32,12 @@ def test_config_derives_te_from_physical_input():
     cm = ConfigManager(user_params, system_config=system_config)
     cm.finalize_user_params()
 
-    # Check if t_E was derived and injected
-    assert "lens.Lens.t_E" in cm.user_params
-    derived_te = cm.user_params["lens.Lens.t_E"]["initval"]
+    # Check if t_E was derived and injected.  The engine's solution is filed
+    # under the canonical INDEX form (lens.0.t_E) -- the only spelling
+    # ConfigManager.resolve reads for every element of every component.  See
+    # the inject-back comment in finalize_user_params and tests/test_nsnl.py.
+    assert "lens.0.t_E" in cm.user_params
+    derived_te = cm.user_params["lens.0.t_E"]["initval"]
 
     # Manual check:
     # pi_rel = 1000/4000 - 1000/8000 = 0.125

--- a/tests/test_microlensing_physics.py
+++ b/tests/test_microlensing_physics.py
@@ -145,12 +145,15 @@ def test_microlensing_sympy_pytensor_equivalence():
     cm = ConfigManager(user_params, system_config=system_config)
     cm.finalize_user_params()
 
-    # Verify the solver completed the chain
-    assert "lens.Lens.t_E" in cm.user_params
+    # Verify the solver completed the chain.  Derived values are injected
+    # under the canonical INDEX form (lens.0.t_E) -- the only spelling
+    # ConfigManager.resolve reads for every element.  See the inject-back
+    # comment in finalize_user_params and tests/test_nsnl.py.
+    assert "lens.0.t_E" in cm.user_params
 
-    te_sympy = cm.user_params["lens.Lens.t_E"]["initval"]
-    thetaE_sympy = cm.user_params["lens.Lens.theta_E"]["initval"]
-    pirel_sympy = cm.user_params["lens.Lens.pi_rel"]["initval"]
+    te_sympy = cm.user_params["lens.0.t_E"]["initval"]
+    thetaE_sympy = cm.user_params["lens.0.theta_E"]["initval"]
+    pirel_sympy = cm.user_params["lens.0.pi_rel"]["initval"]
 
     # 3. Feed the SAME raw inputs into the PyTensor graph
     # (Using .eval() to pull the numeric result out of the graph)

--- a/tests/test_nsnl.py
+++ b/tests/test_nsnl.py
@@ -201,3 +201,74 @@ def test_single_source_backward_compat():
     np.testing.assert_array_equal(system.lens.source_map, [1])
     lp = model.compile_logp()(system.get_raw_start(model))
     assert np.isfinite(lp)
+
+
+# ---------------------------------------------------------------------------
+# The relaxation engine's answer must reach source slot 0.
+#
+# The engine solves the per-source chain at index-form paths (lens.0.theta_E,
+# lens.1.theta_E).  finalize_user_params used to file a NEW entry under the
+# CONFIG INSTANCE name instead -- and index 0 is the one index a lens instance
+# name collides with, so lens.0.theta_E became lens.Lens.theta_E.  resolve()
+# addresses element j of a per-source vector as lens.j.<param> or
+# lens.<SOURCE STAR NAME>.<param> ("SourceA"), never lens.Lens.<param>, so the
+# solved value for slot 0 was dropped: with no initval in
+# mulensing/defaults.yaml (theta_E is derived) apply_value allocated a
+# NaN-filled vector and wrote only element 1.
+# ---------------------------------------------------------------------------
+
+
+def test_derived_solutions_are_injected_under_the_index_key(system_2s2l):
+    """Given a lens event named 'Lens' whose per-source vectors are named for
+    the SOURCE stars, when the relaxation engine's solution is injected back,
+    then slot 0's entry uses the index form that resolve() can read, not the
+    lens instance's own name."""
+    system, _ = system_2s2l
+    up = system.config_manager.user_params
+
+    for param in ("theta_E", "pi_rel", "mu_rel_mag"):
+        assert f"lens.0.{param}" in up, f"lens.0.{param} was not injected"
+        assert f"lens.Lens.{param}" not in up, (
+            f"lens.Lens.{param} is unreadable: resolve() addresses source "
+            f"slot 0 as lens.0.{param} or lens.SourceA.{param}"
+        )
+
+
+def test_per_source_derived_initvals_are_finite(system_2s2l):
+    """Given a 2-source event, when the derived per-source chain is resolved,
+    then EVERY element carries the engine's value -- no NaN hole where a slot
+    got no readable entry."""
+    system, _ = system_2s2l
+    lens = system.lens
+
+    for param in ("theta_E", "pi_rel", "mu_rel_mag", "mu_ra_rel"):
+        initval = np.atleast_1d(getattr(lens, param).initval)
+        assert np.all(np.isfinite(initval)), (
+            f"lens.{param}.initval = {initval} has a non-finite element"
+        )
+
+    # Both sources share one lens, so the shared chain is the same for both.
+    np.testing.assert_allclose(
+        lens.theta_E.initval, [0.8392544170490658] * 2, rtol=1e-9
+    )
+    np.testing.assert_allclose(lens.pi_rel.initval, [0.125] * 2, rtol=1e-9)
+
+
+def test_no_parameter_has_a_non_finite_initval(system_2s2l):
+    """Given the built 2S2L system, when every Parameter is inspected, then
+    none carries a non-finite initval -- an initval is either a value or
+    absent (None), never NaN on some elements and a number on others."""
+    system, _ = system_2s2l
+
+    offenders = []
+    for par in system.get_all_parameters():
+        if par.initval is None:
+            continue
+        try:
+            arr = np.asarray(par.initval, dtype=float)
+        except (TypeError, ValueError):
+            continue  # symbolic (linked) start; not a numeric vector
+        if arr.size and not np.all(np.isfinite(arr)):
+            offenders.append(f"{par.label} = {arr}")
+
+    assert offenders == []


### PR DESCRIPTION
Traces the NaN initvals in `examples/ob161003` to their source. **It was not MMEXOFAST** (the user's hypothesis), not a params file, not the relaxation engine and not `to_vec`. It is a **key-spelling collision** in `ConfigManager.finalize_user_params`' inject-back (`config.py:1420-1468`), and its general form silently drops correctly-solved values.

## The evidence chain

1. The config points at `ob161003.params.yaml` (tracked, no NaN). The `ob161003.params.2.yaml` sitting in the working tree is gitignored, unused by the config, and contains no `theta_E`/`pi_rel` at all. There is no `mmexofast:` key in this example.
2. **The engine solved every affected value correctly**, at its index-form symbol paths (`lens.0.theta_E`, `lens.1.theta_E`). `cm._last_resolved` contains **zero** non-finite entries.
3. The inject-back translates a resolved index path back to the **config instance name**: `name_to_index[("lens", "Lens")] == 0`, so `lens.0.theta_E` is filed as `lens.Lens.theta_E`.
4. `ConfigManager.resolve` addresses element *i* under three keys: `comp.param`, `comp.<i>.param`, `comp.<names[i]>.param`. `names` is a manifest option, and the lens's per-source vectors are named for the **source stars** (`Lens._source_instance_names()` -> `["SourceA", "SourceB"]`). So element 0's keys are `lens.theta_E` / `lens.0.theta_E` / `lens.SourceA.theta_E`. **`lens.Lens.theta_E` is none of them**, and the solved value is dropped.
5. `theta_E` has no defaults.yaml `initval` (it is derived), so `resolved["initval"]` started as `None`; element 1's readable `lens.1.theta_E` made `apply_value` allocate `np.full(2, nan)` and write only index 1. Element 0 stayed NaN.

**Five parameters, not two**: `theta_E`, `pi_rel`, `mu_rel_mag`, `mu_ra_rel`, `mu_dec_rel`.

**Why element 0**: index 0 is the only index a `lens` instance name can collide with, since the block has one entry named "Lens". Index 1 has no lens instance, so `lens.1.theta_E` stayed readable.

**And the NaN is the lucky case.** A *single*-source lens loses the same value **silently and without any NaN** -- `resolved["initval"]` is never allocated, so it simply stays `None`. The visible NaN in ob161003 only exists because a second element happened to be readable.

## Why it is harmless today

All five are derived (`expression is not None`), so `Parameter.build_pymc` sets `is_derived` and the model's start comes from the expression rather than the initval. Confirmed empirically: start logp unchanged.

## The fix

One semantic line: a **new** inject-back entry is written under the index form (`path`), never the instance-name form. Entries that already exist are still matched under either spelling and updated in place, so `mann.B.ks_offset` and friends are untouched. Index form is the documented internal spelling and is already what `get_conversion_factor`, `propagated_scales`, `scale_hints` and the engine's own symbol paths use.

## Other examples: none

All 24 shipped configs scanned (19 build; 5 have no `parameter_file`). **`initval` NaNs occur in ob161003 and nowhere else.** The other non-finite fields that turn up (`star.logmass.sigma`, `band.thermal.sigma`, `orbit.period.init_scale`, `star.parallax.mu`) are the codebase's documented **"unset" sentinel** -- `to_vec(..., fill=np.nan)`, and `Parameter._initval_present`'s docstring says so for `initval` too. Not systemic.

## A stage-3 refusal: argued against, not added

- **It cannot live at stage 3.** The per-element vectors that carry the hole are built by `ConfigManager.resolve`, called from `Component.add_parameter` -- stage **5**. Stage 3 produces only a flat symbol->value map, which had no holes even before this fix.
- **It cannot be blanket.** NaN in `initval` *is* the "never set" sentinel, and derived elements legitimately have none (`lens.mu_rel_geo_mag` ships that way). Refusing would reject every example.
- The narrow correct version -- a **sampled** element with no start value, mirroring #141's stage-5 pin check -- was implemented and then **backed out**: all 24 examples pass it, but **8 existing tests** deliberately build valueless sampled parameters, including `test_inspect_start.py::test_unset_element_falls_back_to_user_params_either_spelling`, whose name encodes the opposite invariant. Enforcing it needs an audit those tests deserve on their own. No assertion was weakened to make anything pass; the reasoning is in the commit message.

## Bit-identity

Start logp measured for every shipped example before and after (`System.get_raw_start` + `model.compile_logp()`). **All 19 identical to the last digit**; the only difference in the entire scan is ob161003's non-finite list shrinking. ob161003 reads `79356.587620672726` on both sides, and `lens.theta_E.initval` is now `[0.8392544170490658, 0.8392544170490658]`, `pi_rel` `[0.125, 0.125]`.

## Tests

3 new in `tests/test_nsnl.py` (index-form injection; per-source initvals finite; no Parameter carries a non-finite initval). **All three fail pre-fix.** Two files pinned the old `lens.Lens.t_E` spelling for an engine-derived value and now pin `lens.0.t_E` -- same assertion, same number: `test_config_healing.py`, `test_microlensing_physics.py`.

577 tests across 30 files pass (config, parameter, mulensing, galactic, mkparam, multiseed, sed, orbit, mann/torres, `test_examples_prepare`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)