### PR TITLE
determinism: kill the live PYTHONHASHSEED leak in model construction

### DIFF
--- a/src/exozippy/compat/__init__.py
+++ b/src/exozippy/compat/__init__.py
@@ -14,5 +14,9 @@ you need one, wrap it here.
 """
 
 from .blackjax_progressbar import patch_blackjax_progress_bar
+from .mulensmodel_method_order import patch_mulensmodel_method_order
 
-__all__ = ["patch_blackjax_progress_bar"]
+__all__ = [
+    "patch_blackjax_progress_bar",
+    "patch_mulensmodel_method_order",
+]

--- a/src/exozippy/compat/mulensmodel_method_order.py
+++ b/src/exozippy/compat/mulensmodel_method_order.py
@@ -1,0 +1,136 @@
+"""Make MulensModel's magnification-method dispatch order deterministic.
+
+``MagnificationCurve.methods_indices`` (MulensModel <= 3.11,
+``magnificationcurve.py``) groups the epochs by magnification method like
+this::
+
+    self._methods_indices = {}
+    methods = self.methods_for_epochs
+    methods_ = np.array(methods)
+    for method in set(methods):                 # <-- hash-ordered
+        self._methods_indices[method] = (methods_ == method)
+
+``methods`` is a list of method-name *strings* whose hashes are
+PYTHONHASHSEED-randomized, so with more than one method in play the resulting
+dict's order -- and with it the order in which
+``_set_binary_lens_magnification_objects`` constructs the per-method backends
+and ``get_binary_lens_magnification`` evaluates them -- flips from process to
+process.
+
+That would be harmless if the backends were pure functions of their own
+epochs.  They are not: the VBMicrolensing solvers behind both ``VBM`` and the
+binary ``point_source`` method carry state across calls, so evaluating the
+same epochs *after a different first batch* moves the magnifications by up to
+~3 ulp.  Measured on ``examples/ob161003`` (2 sources, 2 lens bodies, a
+``VBM`` window inside a ``point_source`` baseline): reversing the dict order
+alone -- at a fixed PYTHONHASHSEED, with byte-identical inputs -- changes 238
+of 1716 magnifications, in *both* selections.
+
+Downstream that is not cosmetic.  Those magnifications are the NNLS design
+matrix of ``MulensInstrument._estimate_flux_components``, so the bootstrapped
+``q_source``/``q_flux`` start values, and therefore the model's start-point
+logp, took one of exactly two values per run:
+
+    PYTHONHASHSEED=0,2,3 -> set(['point_source', 'VBM']) -> lp ...726189
+    PYTHONHASHSEED=1,7   -> set(['VBM', 'point_source']) -> lp ...740741
+
+Sorting the walk by method name fixes the order for good.  Name order, not
+first-appearance order, so the answer does not depend on how the epochs
+happen to be laid out either.  It changes nothing else: the selections are
+disjoint boolean masks, so which one is filled first is not a modeling choice.
+
+This is the same fix shape as the relaxation engine's ``free_symbols`` sort
+(PR #57) -- iterate a hash-ordered container in a stated order, because a
+float result downstream depends on it.
+
+Retiring this: ``_is_affected`` reads the *source* and looks for the unsorted
+set walk, so the patch disables itself the moment upstream sorts it (or
+switches to ``dict.fromkeys``).  Delete the module once the MulensModel floor
+in pyproject.toml is past that release.
+"""
+
+import inspect
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_PATCH_FLAG = "_exozippy_method_order_patched"
+
+
+def _sort_key(method):
+    """Total order over method names, tolerating the ``None`` default method.
+
+    ``methods_for_epochs`` fills unbracketed epochs with
+    ``MagnificationCurve._default_method``, which is ``None`` unless a caller
+    set one -- so a bare ``sorted()`` would raise on ``None`` vs ``str``.
+    """
+    return (method is None, str(method))
+
+
+def _methods_indices(self):
+    """Deterministic replacement for ``MagnificationCurve.methods_indices``.
+
+    Byte-for-byte the upstream body, except the walk is
+    ``sorted(set(methods), key=_sort_key)`` instead of ``set(methods)``.
+    """
+    if self._methods_indices is None:
+        self._methods_indices = {}
+        methods = self.methods_for_epochs
+        methods_ = np.array(methods)
+
+        # Sorted: see this module's docstring.  The order is load-bearing
+        # because the VBMicrolensing backends are not order-independent --
+        # do not "simplify" this back to `for method in set(methods)`.
+        for method in sorted(set(methods), key=_sort_key):
+            selection = methods_ == method
+            self._methods_indices[method] = selection
+
+    return self._methods_indices
+
+
+def _is_affected(prop):
+    """True when upstream still walks ``set(methods)`` unsorted.
+
+    Reads the source rather than a version, so an upstream fix stops matching
+    without anyone bumping a check here.  Source that cannot be read is
+    treated as unaffected: leaving a working library alone beats patching
+    blind.
+    """
+    fget = getattr(prop, "fget", None)
+    if fget is None or getattr(fget, _PATCH_FLAG, False):
+        return False
+    try:
+        src = inspect.getsource(fget)
+    except (OSError, TypeError):
+        return False
+    return "set(methods)" in src and "sorted(set(methods)" not in src
+
+
+def patch_mulensmodel_method_order():
+    """Fix MulensModel's method-dispatch order.  Returns True if patched.
+
+    Idempotent, and a no-op when MulensModel cannot be imported or when the
+    unsorted walk is already gone.
+    """
+    try:
+        from MulensModel.magnificationcurve import MagnificationCurve
+    except Exception:  # pragma: no cover - optional dep
+        return False
+
+    prop = MagnificationCurve.__dict__.get("methods_indices")
+    if not isinstance(prop, property) or not _is_affected(prop):
+        return False
+
+    setattr(_methods_indices, _PATCH_FLAG, True)
+    MagnificationCurve.methods_indices = property(
+        _methods_indices, doc=prop.__doc__
+    )
+
+    logger.debug(
+        "Applied the MulensModel determinism patch "
+        "(exozippy.compat.mulensmodel_method_order): magnification methods "
+        "now dispatch in sorted name order."
+    )
+    return True

--- a/src/exozippy/components/mulensing/mulensinstrument.py
+++ b/src/exozippy/components/mulensing/mulensinstrument.py
@@ -11,6 +11,7 @@ import pytensor
 import pytensor.tensor as pt
 from scipy.optimize import nnls
 
+from exozippy.compat import patch_mulensmodel_method_order
 from exozippy.components.instrument import Instrument
 from exozippy.config import RANK_DERIVED_DATA
 from exozippy.ephemeris import get_observer_position
@@ -667,6 +668,15 @@ class MulensInstrument(Instrument):
         alpha = _get("lens.0.alpha")
         if s_val is None or q_val is None or alpha is None:
             return None
+
+        # Idempotent, and self-guarding if MulensModel is missing; op.py has
+        # normally applied it already.  Repeated here because this is the
+        # OTHER place exozippy calls MulensModel, and the fluxes bootstrapped
+        # below land in the model's start values -- an unpatched call here
+        # makes the whole build PYTHONHASHSEED-dependent.  Outside the try:
+        # a failure to patch must not be swallowed into the silent
+        # fall-back-to-PSPL path below.
+        patch_mulensmodel_method_order()
 
         try:
             import MulensModel as mm

--- a/src/exozippy/components/mulensing/op.py
+++ b/src/exozippy/components/mulensing/op.py
@@ -9,7 +9,16 @@ from astropy.coordinates import SkyCoord
 from pytensor.gradient import DisconnectedType
 from pytensor.graph import Apply, Op
 
+from exozippy.compat import patch_mulensmodel_method_order
+
 from .physics import clip_q_value
+
+# MulensModel dispatches magnification methods in PYTHONHASHSEED order, and
+# the VBMicrolensing backends are not order-independent, so identical inputs
+# give different answers in different processes.  This is the exozippy module
+# that owns the MulensModel import, so patch it here, before any Op can build
+# an mm.Model.  See exozippy/compat/mulensmodel_method_order.py.
+patch_mulensmodel_method_order()
 
 
 def _clear_mm_satellite_cache():

--- a/src/exozippy/components/orbit/orbit.py
+++ b/src/exozippy/components/orbit/orbit.py
@@ -133,7 +133,17 @@ class Orbit(Component):
             ("companion", self.companion_bodies),
         ):
             types = {t for g in groups for (t, _) in g}
-            for ctype in types:
+            # Sorted: _group_w is a plain dict populated in THIS order, and
+            # add_parameter walks it to lazily materialize each referenced
+            # component's `mass` -- so an unsorted walk decides whether
+            # star.mass or planet.mass becomes a PyMC RV first.
+            # model.free_RVs order is the compiled input signature
+            # (system.py), the gradient-vector layout (polish.py) and the
+            # on-disk mass matrix (outputs/save_mass_matrix.py), none of
+            # which may depend on PYTHONHASHSEED.  Inert while one side
+            # references a single body type; live for a hierarchical group
+            # that mixes stars and planets.
+            for ctype in sorted(types):
                 section = sys_cfg.get(ctype) or []
                 if not isinstance(section, list):
                     section = [section]

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -540,8 +540,13 @@ class ConfigManager:
                         for rel in getattr(module, "RELATIONS", []):
                             module_symbols.update(rel.free_symbols)
 
+                        # Sorted: module_symbols is a set, so its walk order
+                        # is PYTHONHASHSEED-dependent, and `subs` below is
+                        # applied as an unordered mapping.  The renaming is
+                        # order-independent today (disjoint symbols), but the
+                        # cost of stating the order is zero.
                         subs = {}
-                        for sym in module_symbols:
+                        for sym in sorted(module_symbols, key=str):
                             if sym.name in instance_map:
                                 subs[sym] = sp.Symbol(instance_map[sym.name])
 
@@ -2238,7 +2243,12 @@ class ConfigManager:
         one held at RANK_DERIVED_MIXED or below (including the solver's own
         previous answer) still re-fires as its inputs refine.
         """
-        for lookup_key in self.standalone_solvers:
+        # Sorted: standalone_solvers is a set, and each solver both reads and
+        # writes `resolved`, so with two of them registered the walk order
+        # decides whether one sees the other's answer from this iteration or
+        # the last -- feeding _meaningful_change, the provenance ranks and
+        # the cycle history.  Only orbit.m_total is registered today.
+        for lookup_key in sorted(self.standalone_solvers):
             solver_func = self.custom_solvers[lookup_key]
             comp, param = lookup_key.split(".")[0], lookup_key.split(".")[-1]
             for path in list(self.master_symbol_map):
@@ -2884,9 +2894,13 @@ class ConfigManager:
         if not solutions:
             try:
                 guess = float(resolved.get(target_str, 1.0))
+                # Sorted: sympy applies an unordered subs mapping in its own
+                # canonical order, but the dict's own insertion order comes
+                # straight off a hash-randomized set -- do not rely on a
+                # third party to launder that for us.
                 sub_dict = {
                     s: resolved[str(s)]
-                    for s in eq.free_symbols
+                    for s in sorted(eq.free_symbols, key=str)
                     if str(s) != target_str
                 }
                 expr = (eq.lhs - eq.rhs).subs(sub_dict).evalf()
@@ -2914,7 +2928,15 @@ class ConfigManager:
             # Propagate Scale (Calculus-based)
             if hasattr(valid_sol, "free_symbols"):
                 scale_variance = 0.0
-                for parent_sym in valid_sol.free_symbols:
+                # Sorted for the same reason as _execute_solve's walk (whose
+                # `inputs` list is already derived from a sorted
+                # symbols_in_eq): free_symbols is a set of Symbols whose
+                # hashes include the PYTHONHASHSEED-randomized name string.
+                # Here the order is doubly load-bearing -- it is the
+                # SUMMATION order of the float accumulation below, so an
+                # unsorted walk makes init_scale differ in its last bits
+                # between two processes running identical code.
+                for parent_sym in sorted(valid_sol.free_symbols, key=str):
                     parent_str = str(parent_sym)
                     # Fallback to a small epsilon if parent scale is missing
                     parent_scale = resolved_scales.get(parent_str, 1e-9)

--- a/src/exozippy/graph.py
+++ b/src/exozippy/graph.py
@@ -100,7 +100,20 @@ def determine_pymc_build_order(active_components, config_manager):
                 )
 
     # 4. Sort agnostically
-    sorter = graphlib.TopologicalSorter(forward_graph)
+    #
+    # Hand graphlib SORTED predecessor lists, not the raw sets.  The order
+    # returned here is the order the PyMC nodes -- and so the terms of the
+    # summed logp -- get created in, so a hash-ordered tie-break would move
+    # the last bits of every fit's logp from process to process.  Step 1
+    # above happens to make today's output independent of these sets (every
+    # node is already a key of forward_graph before the sorter sees it, so
+    # graphlib registers nodes in the dict's order, not the sets'), which is
+    # why sorting changes nothing right now -- but that is a property of
+    # step 1, not of graphlib, and it should not be the only thing standing
+    # between us and a PYTHONHASHSEED-dependent model.
+    sorter = graphlib.TopologicalSorter(
+        {node: sorted(deps) for node, deps in forward_graph.items()}
+    )
     try:
         return list(sorter.static_order())
     except graphlib.CycleError as e:

--- a/src/exozippy/mkparam.py
+++ b/src/exozippy/mkparam.py
@@ -710,7 +710,10 @@ def write_param_file(
             for k in list(output)
             if k.endswith(f".{y_name}")
         }
-        for prefix in set(_x_keys) & set(_y_keys):
+        # Sorted: the body deletes the x/y entries and inserts the angle in
+        # their place, so a hash-ordered set intersection would shuffle the
+        # written params file's key order from run to run.
+        for prefix in sorted(set(_x_keys) & set(_y_keys)):
             x_key, y_key = _x_keys[prefix], _y_keys[prefix]
             xv, yv = output[x_key]["initval"], output[y_key]["initval"]
             # initval may be a scalar (single-seed) or a length-K list

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -266,10 +266,15 @@ def _run_fit(config, gui, user_params=None):
         if "reason" in reqs:
             _reasons.append(reqs["reason"])
 
+    # sorted(), not next(iter(...)): _recommended is a set, so with two
+    # components recommending different samplers the choice would be a
+    # PYTHONHASHSEED coin flip -- i.e. a different sampler per run.  Only one
+    # component recommends anything today (mulensing's Lens), so this is
+    # inert; it stops being inert silently.
     if method is None:
-        method = next(iter(_recommended)) if _recommended else "nuts"
+        method = sorted(_recommended)[0] if _recommended else "nuts"
     elif method.lower() in _incompatible:
-        rec_str = next(iter(_recommended)) if _recommended else "ptde_async"
+        rec_str = sorted(_recommended)[0] if _recommended else "ptde_async"
         reason_str = (
             "; ".join(_reasons) if _reasons else "incompatible with this model"
         )

--- a/tests/test_hashseed_determinism.py
+++ b/tests/test_hashseed_determinism.py
@@ -1,0 +1,181 @@
+"""Two runs of identical code must build the identical model, bit for bit.
+
+Python randomizes string hashes per process unless ``PYTHONHASHSEED`` is set,
+so any ``set``/``frozenset`` of strings iterates in a different order in every
+run.  That is fine right up until the order reaches a float, at which point a
+fit's start values -- and its logp -- take a different value in every process.
+It has bitten this codebase twice:
+
+* PR #57: ``eq.free_symbols`` walks in the relaxation engine's (since-deleted)
+  sympy scale passes scattered ``init_scale`` by orders of magnitude.
+* This file: MulensModel's ``MagnificationCurve.methods_indices`` walks
+  ``set(methods)``, so the per-method magnification backends are constructed
+  and evaluated in hash order -- and VBMicrolensing is not order-independent,
+  so the magnifications move by ~3 ulp.  Those magnifications are the NNLS
+  design matrix behind ``MulensInstrument``'s bootstrapped ``q_source`` /
+  ``q_flux`` start values, so ``examples/ob161003``'s start-point logp took
+  one of exactly two values per run:
+
+      PYTHONHASHSEED=0,2,3 -> 79356.587620672726189
+      PYTHONHASHSEED=1,7   -> 79356.587620672740741
+
+  Fixed by ``exozippy.compat.mulensmodel_method_order``.
+
+Seeds 0 and 1 are not arbitrary: they are the pair that puts
+``set(['point_source', 'VBM'])`` in opposite orders, i.e. the exact pair that
+used to produce the two values above.
+
+These run in subprocesses because ``PYTHONHASHSEED`` is read once at
+interpreter startup -- ``monkeypatch.setenv`` cannot reproduce this in-process.
+They deliberately exercise the magnification kernel rather than a whole
+``System``: it is the same defect in ~2 seconds instead of ~2 minutes, and it
+fails at the actual leak rather than 300 lines downstream of it.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+mm = pytest.importorskip("MulensModel")
+
+# The two hash seeds that order set(['point_source', 'VBM']) oppositely.
+SEED_A = "0"
+SEED_B = "1"
+
+
+def _run_under_seed(script, seed):
+    """Run ``script`` in a fresh interpreter with PYTHONHASHSEED=seed.
+
+    Returns its last stdout line.  Inherits the environment (so an
+    editable/PYTHONPATH install of exozippy is importable) and overrides only
+    the hash seed.
+    """
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = seed
+    # Thread-count noise would be a second, unrelated source of last-bit
+    # differences; pin it so a failure can only mean hash ordering.
+    for var in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS"):
+        env[var] = "1"
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"subprocess with PYTHONHASHSEED={seed} failed:\n{proc.stderr[-3000:]}"
+    )
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    assert lines, f"subprocess with PYTHONHASHSEED={seed} printed nothing"
+    return lines[-1].strip()
+
+
+# A binary lens with a finite-source (VBM) window inside a point-source
+# baseline, i.e. TWO magnification methods -- the configuration
+# MulensInstrument._binary_magnification_columns builds for every binary-lens
+# flux bootstrap.  Geometry is ob161003's (Jung+2017 Table 1), on a synthetic
+# time grid so the test needs no data files.
+_BINARY_LENS_SETUP = """
+import numpy as np
+# Importing exozippy's MulensModel wrapper is what applies the determinism
+# patch -- the test is as much about that wiring as about the patch itself.
+import exozippy.components.mulensing.op  # noqa: F401
+import MulensModel as mm
+
+t_0, t_E, window = 2457551.038, 28.931, 3.0 * 28.931
+t = np.linspace(t_0 - 5 * t_E, t_0 + 5 * t_E, 400)
+inside = np.abs(t - t_0) < window
+assert inside.any() and (~inside).any(), "need BOTH methods in play"
+
+model = mm.Model({
+    "t_0": t_0, "u_0": 0.059, "t_E": t_E,
+    "s": 1.033, "q": 1.188, "alpha": 131.757, "rho": 4.51e-4,
+})
+model.set_magnification_methods([t_0 - window, "VBM", t_0 + window])
+"""
+
+_MAGNIFICATION_SCRIPT = (
+    _BINARY_LENS_SETUP
+    + """
+a = np.asarray(model.get_magnification(t), dtype=float)
+print(a.tobytes().hex())
+"""
+)
+
+_DISPATCH_ORDER_SCRIPT = (
+    _BINARY_LENS_SETUP
+    + """
+curve = model.get_magnification_curve(t, None, None)
+curve.set_magnification_methods(
+    [t_0 - window, "VBM", t_0 + window], "point_source"
+)
+methods = list(curve.methods_indices)
+assert len(methods) == 2, methods
+print(",".join(methods))
+"""
+)
+
+
+def test_magnification_method_dispatch_order_is_hashseed_independent():
+    """
+    Given a binary-lens model with two magnification methods,
+    When the per-method epoch selection is built in two processes whose
+      PYTHONHASHSEED orders set(['point_source', 'VBM']) oppositely,
+    Then the methods dispatch in the same order in both.
+
+    This is the leak itself.  It is separated from the numerical test below
+    because it says *why* the numbers moved, and it stays meaningful even if
+    a future VBMicrolensing happens to be order-independent.
+    """
+    order_a = _run_under_seed(_DISPATCH_ORDER_SCRIPT, SEED_A)
+    order_b = _run_under_seed(_DISPATCH_ORDER_SCRIPT, SEED_B)
+
+    assert order_a == order_b, (
+        "magnification methods dispatch in PYTHONHASHSEED order: "
+        f"{order_a!r} vs {order_b!r}.  See "
+        "exozippy/compat/mulensmodel_method_order.py."
+    )
+
+
+def test_binary_lens_magnification_is_hashseed_independent():
+    """
+    Given the binary-lens + finite-source geometry the microlensing flux
+      bootstrap evaluates for every such event,
+    When the magnifications are computed in two processes with different
+      PYTHONHASHSEED values,
+    Then every one of them is bit-for-bit identical.
+
+    Compared as raw float64 bytes, not with a tolerance: the whole point is
+    that a ~3 ulp drift here reaches the model's start values, and any
+    tolerance loose enough to pass a broken build is loose enough to hide the
+    next instance of this bug.
+    """
+    mags_a = _run_under_seed(_MAGNIFICATION_SCRIPT, SEED_A)
+    mags_b = _run_under_seed(_MAGNIFICATION_SCRIPT, SEED_B)
+
+    assert mags_a == mags_b, (
+        "binary-lens magnifications differ between PYTHONHASHSEED=0 and =1 "
+        "for byte-identical inputs; the model built from them (and its logp) "
+        "is therefore not reproducible.  See "
+        "exozippy/compat/mulensmodel_method_order.py."
+    )
+
+
+def test_compat_patch_is_idempotent_and_self_retiring():
+    """
+    Given the MulensModel determinism patch,
+    When it is applied a second time,
+    Then it reports that it did nothing -- and it would have reported the same
+      had upstream already sorted the walk.
+
+    ``compat``'s contract: detect the defect, not the version, and be safe to
+    call from every site that touches the library.
+    """
+    from exozippy.compat import patch_mulensmodel_method_order
+
+    # op.py applies it at import; either way, one more call settles it.
+    patch_mulensmodel_method_order()
+
+    assert patch_mulensmodel_method_order() is False


### PR DESCRIPTION
`examples/ob161003`'s start logp took two values across runs of identical code. Three separate agents hit it this week and each concluded "pre-existing float reassociation in the VBM binary-lens path". **That was wrong.** With OMP/OpenBLAS/MKL pinned to one thread it still alternated; with `PYTHONHASHSEED` fixed it was perfectly deterministic and the value was a function of the seed:

    seeds 0, 2, 3 -> 79356.587620672726189
    seeds 1, 7    -> 79356.587620672740741

## The offending iteration is third-party

**`MulensModel/magnificationcurve.py:605`** (MulensModel <= 3.11, `MagnificationCurve.methods_indices`):

```python
for method in set(methods):          # method names are STRINGS -> hash-ordered
    self._methods_indices[method] = (methods_ == method)
```

That dict's order is the order `_set_binary_lens_magnification_objects` constructs the per-method backends and `get_binary_lens_magnification` evaluates them. Harmless if the backends were pure. They are not: **reversing the dict order alone, at a fixed `PYTHONHASHSEED`, with byte-identical inputs, changes 238 of ob161003's 1716 magnifications** (up to 6.6e-16 relative, ~3 ulp) -- in *both* the `VBM` and `point_source` selections.

The smoking gun: `set(['point_source', 'VBM'])` iterates as `['point_source', 'VBM']` for seeds 0/2/3 and `['VBM', 'point_source']` for 1/7 -- a perfect match to the two logp values.

**How it was localized.** Dump-and-diff at each stage boundary under two seeds. `prepare()`'s resolved config and the PyMC build order are byte-identical; the only differing `model.logp(sum=False)` terms were `logit_uniform_prior.mulensinstrument.q_source` and `.q_flux` -- the bootstrapped flux starts. Those come from `_estimate_flux_components`' NNLS, whose design matrix is `_binary_magnification_columns`. Instrumenting that showed identical inputs (params dict and time-array md5 both equal) and bit-different magnification columns out. A 12-line standalone repro then reproduced it with no exozippy at all.

## The fix

`src/exozippy/compat/mulensmodel_method_order.py`, on the same self-retiring contract as the existing blackjax patch: it reads the *upstream source* for the unsorted `set(methods)` walk and disables itself the moment upstream sorts it. Applied at both sites exozippy calls MulensModel -- `components/mulensing/op.py` (module level) and `_binary_magnification_columns` (outside its `try:`, so a failure to patch cannot be swallowed into the silent fall-back-to-PSPL path).

## Determinism

- **10/10 runs with `PYTHONHASHSEED` unset**: `79356.587620672740741`, bit-identical (plus 12 earlier runs, same value). Independently reproduced here: 8/8.
- **Fixed seeds 0, 1, 2, 3, 7**: all the same value.

The fixed value equals the former seed-1 value (`sorted()` gives `['VBM', 'point_source']`), so it is one of the two originally measured, not a third.

| example | before | after |
|---|---|---|
| ob161003 | **2 values** | one, 15 runs |
| DC2018_128 | stable | unchanged (3 curves dispatch 2 methods, logp did not move) |
| ob140939 | stable | unchanged (no MulensModel curves) |
| kelt4 / kelt4_rv+transit+sed | stable | unchanged |
| KMT-2019-BLG-1806 | stable | unchanged (every curve dispatches 1 method) |
| ob08092 | stable | unchanged |

**No pinned baseline moved** -- `test_runaway_logp_regression.py` passes untouched.

## Siblings, hardened with PR #57's fix shape (sort, and say why)

**Real:**
- `config.py:_solve_and_update` accumulated a float **sum** over `valid_sol.free_symbols`, an unordered set. Its `_execute_solve` twin was safe only accidentally, via a sorted `inputs`.
- `orbit.py:136`, `for ctype in {star, planet}`, decides whether `star.mass` or `planet.mass` becomes a PyMC RV first -- and `model.free_RVs` order is the compiled input signature, the gradient-vector layout and the **on-disk mass matrix**. Live for a hierarchical group mixing stars and planets.

**Latent, fixed anyway:** `run.py`'s `next(iter(_recommended))` would coin-flip the **sampler** once a second component recommends one; `config.py`'s `standalone_solvers` walk, nsolve `sub_dict` and RELATIONS renaming map; `mkparam.py`'s x/y->angle pass (params-file key order); `graph.py` now hands graphlib sorted predecessor lists -- verified a no-op on today's build order across 8 seeds, but today's safety is a property of step 1's node pre-registration, not of graphlib.

**Reported, not fixed:** `config.py:2505`'s `free_symbols` walk builds a **debug-only** log string via successive regex substitutions -- non-commutative in principle, `logger.debug` in practice.

## Test

`tests/test_hashseed_determinism.py`, three tests, ~27 s. Two spawn subprocesses under opposite hash seeds -- necessary, since `PYTHONHASHSEED` is read once at interpreter startup and `monkeypatch.setenv` cannot reproduce it -- and compare the dispatch order and the magnifications as **raw float64 bytes**. It exercises the magnification kernel rather than a whole `System`: the same defect in ~25 s instead of ~2 min, and it fails at the leak rather than 300 lines downstream. **All three fail pre-fix.**

`PYTHONHASHSEED` is deliberately **not** pinned anywhere in the suite. The test asserts across two specific opposite seeds, which is strictly stronger than pinning one and does not blind the rest of the suite to the next instance.

120 tests green across `test_graph`, `test_config_discovery_order`, `test_mkparam`, `test_runaway_logp_regression`, `test_nsnl`, `test_multiseed_mmexofast`, `test_examples_prepare`, `test_mmexofast_support`, `test_hierarchical_orbit`, `test_orbit_tc_window`, `test_integration_kelt4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)