### PR TITLE
mulensing: name the last two parameter floors; sort a debug symbol walk

### DIFF
--- a/src/exozippy/components/mulensing/mulensinstrument.py
+++ b/src/exozippy/components/mulensing/mulensinstrument.py
@@ -17,7 +17,13 @@ from exozippy.config import RANK_DERIVED_DATA
 from exozippy.ephemeris import get_observer_position
 
 from . import mmexofast_support
-from .physics import clip_q_value, floor_u_0_value
+from .physics import (
+    RHO_FLOOR,
+    S_FLOOR,
+    T_E_FLOOR,
+    clip_q_value,
+    floor_u_0_value,
+)
 
 
 def _raw_initval(data, default=None):
@@ -710,14 +716,14 @@ class MulensInstrument(Instrument):
                     # backends use.  This was a third hard-coded copy of the
                     # clip (and, like them, engaged at every u_0 except 0).
                     "u_0": floor_u_0_value(u0),
-                    "t_E": max(float(tE), 1e-4),
-                    "s": max(float(s_val), 1e-6),
+                    "t_E": max(float(tE), T_E_FLOOR),
+                    "s": max(float(s_val), S_FLOOR),
                     "q": clip_q_value(q_val, "lens.0.q (flux bootstrap)"),
                     "alpha": float(alpha),
                 }
                 rho = _get(f"lens.{j}.rho")
                 if rho is not None:
-                    params["rho"] = max(float(rho), 1e-9)
+                    params["rho"] = max(float(rho), RHO_FLOOR)
                 model = mm.Model(params)
                 if rho is not None:
                     window = 3.0 * params["t_E"]

--- a/src/exozippy/components/mulensing/op.py
+++ b/src/exozippy/components/mulensing/op.py
@@ -13,6 +13,8 @@ from exozippy.compat import patch_mulensmodel_method_order
 
 from .physics import (
     _MM_NAN_ADVICE,
+    RHO_FLOOR,
+    S_FLOOR,
     T_E_FLOOR,
     clip_q_value,
     floor_u_0_value,
@@ -104,8 +106,12 @@ def _base_mm_params(p):
 
 
 def _safe_rho(value):
-    """rho <= 0 is unphysical and breaks finite-source methods; floor it."""
-    return float(max(float(value), 1e-9))
+    """Floor the source radius at physics.RHO_FLOOR.
+
+    One number, shared with the flux bootstrap's own copy of this clip, for
+    the same reason U_0_FLOOR is: two literals drift.
+    """
+    return float(max(float(value), RHO_FLOOR))
 
 
 def _build_pspl_model(p, coords, mag_method, use_rho=False):
@@ -156,7 +162,7 @@ def _build_binary_model(p, coords, mag_method, use_rho=False):
     if use_rho:
         mm_params["rho"] = _safe_rho(p[idx])
         idx += 1
-    mm_params["s"] = float(max(float(p[idx]), 1e-6))
+    mm_params["s"] = float(max(float(p[idx]), S_FLOOR))
     mm_params["q"] = clip_q_value(p[idx + 1], "lens.q")
     mm_params["alpha"] = float(p[idx + 2])
 
@@ -565,7 +571,7 @@ class VBMDirectMagOp(Op):
         for j in range(self.n_companions):
             companions.append(
                 (
-                    float(max(float(p[idx]), 1e-6)),
+                    float(max(float(p[idx]), S_FLOOR)),
                     clip_q_value(p[idx + 1], f"lens.q[{j}]"),
                     float(np.radians(float(p[idx + 2]))),
                 )

--- a/src/exozippy/components/mulensing/physics.py
+++ b/src/exozippy/components/mulensing/physics.py
@@ -258,6 +258,31 @@ T_E_FLOOR = 1e-4  # days
 U_0_FLOOR = 1e-9  # Einstein radii
 THETA_E_LENSING_MIN = 1e-6  # mas
 
+# --- Binary/finite-source floors --------------------------------------------
+# The same rule as the three above -- a statement about where the model is
+# DEFINED -- for the two parameters that only exist once the lens is binary or
+# the source is resolved.  They lived as five hard-coded literals (s three
+# times, rho twice) rather than here, which is how U_0_FLOOR came to disagree
+# with itself across backends; naming them is what stops that recurring.
+#
+# S_FLOOR    the binary-lens equation places the components at +/- s/2, so
+#            s <= 0 puts the secondary on the wrong side of the primary (or on
+#            top of it) and the caustic topology is undefined.  s -> 0 is also
+#            the close-binary limit where the central caustic shrinks as s^2
+#            and VBM's contour integration needs ever finer sampling, so a
+#            floor is a numerical necessity as well as a physical one.
+# RHO_FLOOR  the source radius in Einstein radii.  rho <= 0 is unphysical and
+#            the finite-source methods integrate over the source disc, so a
+#            non-positive radius is not merely small but meaningless.  It is
+#            floored rather than clipped away because rho -> 0 IS the correct
+#            point-source limit -- the floor only has to keep the integration
+#            well-posed, and 1e-9 is far below any resolvable source.
+#
+# Both are the values that were already in force everywhere they appeared, so
+# naming them changed no result; see the PR that introduced them.
+S_FLOOR = 1e-6  # Einstein radii (binary separation)
+RHO_FLOOR = 1e-9  # Einstein radii (source radius)
+
 
 def apply_u_0_floor(u_0):
     """Move u_0 out of the open interval (-U_0_FLOOR, U_0_FLOOR) -- symbolic.

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -2582,8 +2582,15 @@ class ConfigManager:
             # Format as "lhs = rhs" instead of "Eq(lhs, rhs)"
             eq_str = f"{eq.lhs} = {eq.rhs}"
 
-            # Replace only the known symbols so the math structure is preserved
-            for s in eq.free_symbols:
+            # Replace only the known symbols so the math structure is
+            # preserved.  Sorted for the same reason as _execute_solve's walk
+            # (free_symbols is a set of Symbols whose hashes include the
+            # string hash): successive re.sub calls are not commutative when
+            # one symbol's name is a substring of another's, so an unsorted
+            # walk could render this line differently in two processes.  It
+            # is only a debug string today -- but a diagnostic that varies
+            # run to run is the one thing a diagnostic must not do.
+            for s in sorted(eq.free_symbols, key=str):
                 s_str = str(s)
                 if s_str in resolved:
                     # Format to 5 sig figs (handles scientific notation automatically)


### PR DESCRIPTION
The two deferred items, both tails of larger fixes.

## Five literals, not the one #148 recorded

`S_FLOOR` and `RHO_FLOOR` join `T_E_FLOOR` / `U_0_FLOOR` / `Q_MIN` / `Q_MAX` in `physics.py`. They existed as **five** hard-coded literals:

| parameter | sites |
|---|---|
| `s` | `op.py:159`, `op.py:568`, `mulensinstrument.py:714` |
| `rho` | `op.py:108` (`_safe_rho`), `mulensinstrument.py:720` |
| `t_E` | `mulensinstrument.py:713` had a literal `1e-4` while `op.py` used `T_E_FLOOR` |

Five copies of a number is exactly how `U_0_FLOOR` came to disagree with itself across two backends -- 1e-6 symbolic against 1e-9 numeric, so any fit visiting that band got a different answer depending on which path it was on (#148). Naming these is what stops that recurring, not tidiness.

Each constant carries the reasoning: `s <= 0` puts the secondary on the wrong side of the primary and the caustic topology is undefined (and `s -> 0` is the close-binary limit where the central caustic shrinks as `s^2` and VBM's contour integration needs ever finer sampling, so the floor is numerical as well as physical); `rho <= 0` is meaningless for a method that integrates over the source disc, but is floored rather than clipped away because `rho -> 0` **is** the correct point-source limit.

**Every value is the one already in force at every site**, so nothing changes. Verified:

| example | start logp |
|---|---|
| ob08092 | `6187.7111017152465138` |
| DC2018_128 | `3364.6825381919006759` |
| ob161003 | `79356.587620672740741` |
| KMT-2019-BLG-1806 | `44276.516070689976914` |

all matching the values recorded in #141 / #145 / #147.

## The last unsorted `free_symbols` walk

`config.py`'s debug walk is now sorted -- the last instance of the class #147 fixed. It builds a log string by successive `re.sub` calls, which are **not commutative** when one symbol's name is a substring of another's, so an unsorted walk could render the line differently in two processes.

Debug-only today, which is why #147 reported it rather than fixing it. But a diagnostic that varies run to run is the one thing a diagnostic must not do -- and `scripts/diag_mulens.py` (#139) was a live example of a diagnostic quietly printing the wrong thing.

## Left alone

`op.py:636`'s `eps=1e-6` is a VBM accuracy tolerance, not a parameter floor.

## Tests

**165 passed** across `test_trajectory_sanitization`, `test_q_sanitization`, `test_microlensing_physics`, `test_mulens_review_fixes`, `test_pspl_symbolic_vs_op`, `test_nsnl`, `test_hashseed_determinism`, `test_config_healing`. `ruff check` and `ruff format --check` clean.

No new test: every value is unchanged by construction, and `test_trajectory_sanitization.py`'s existing source scan (from #148) already asserts no stray floor expression survives in these modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)