### PR TITLE
logger: re-point the FileHandler when the prefix changes (review 6.6)

### DIFF
--- a/src/exozippy/logger.py
+++ b/src/exozippy/logger.py
@@ -1,5 +1,16 @@
 import logging
+import os
 import sys
+
+_OWNER_ATTR = "_exozippy_role"
+"""Marks the handlers this module owns, so it never touches anyone else's.
+
+`setup_logging` re-points its own console/file handlers on every call, and
+clearing `log.handlers` wholesale would silently drop handlers something else
+attached -- pytest's caplog, the GUI's, a user's.  Ownership is stamped on the
+handler instance rather than inferred from its type: a foreign `FileHandler`
+on the exozippy logger is somebody else's file, not ours to close.
+"""
 
 
 class _ColorFormatter(logging.Formatter):
@@ -16,21 +27,58 @@ class _ColorFormatter(logging.Formatter):
         return f"{color}{msg}{self._RESET}" if color else msg
 
 
+def _owned_handler(log, role):
+    """The handler this module installed for `role`, or None.
+
+    Any duplicate (which should not happen, but a caller could have copied a
+    handler onto the logger) is removed and closed so the role stays single.
+    """
+    ours = [h for h in log.handlers if getattr(h, _OWNER_ATTR, None) == role]
+    for extra in ours[1:]:
+        log.removeHandler(extra)
+        extra.close()
+    return ours[0] if ours else None
+
+
 def setup_logging(prefix, level="INFO"):
-    """Configure the exozippy logger: console at `level`, file at DEBUG always."""
+    """Configure the exozippy logger: console at `level`, file at DEBUG always.
+
+    Safe to call more than once in one process -- which is what a script
+    driving several fits through `run.run_fit(config, user_params=<dict>)`,
+    the documented in-memory entry point, does.  A call naming a NEW prefix
+    re-points the file handler at `<prefix>.log` (closing the old file) and
+    applies the new console level; a call naming the SAME prefix is a no-op
+    for the file, so a log is never truncated out from under a run in
+    progress and handlers never accumulate.
+    """
     log = logging.getLogger("exozippy")
-    if log.handlers:
-        return  # already configured (e.g. called twice in tests)
     log.setLevel(logging.DEBUG)
 
-    ch = logging.StreamHandler(sys.stdout)
-    ch.setLevel(getattr(logging, level.upper(), logging.INFO))
-    ch.setFormatter(_ColorFormatter("%(message)s"))
-    log.addHandler(ch)
+    console_level = getattr(logging, level.upper(), logging.INFO)
+    ch = _owned_handler(log, "console")
+    if ch is None:
+        ch = logging.StreamHandler(sys.stdout)
+        ch.setFormatter(_ColorFormatter("%(message)s"))
+        setattr(ch, _OWNER_ATTR, "console")
+        log.addHandler(ch)
+    # Applied on every call, including a repeat of the same prefix: the level
+    # is what the caller just asked for, not what the first caller asked for.
+    ch.setLevel(console_level)
 
-    fh = logging.FileHandler(str(prefix) + ".log", mode="w")
+    path = str(prefix) + ".log"
+    fh = _owned_handler(log, "file")
+    if fh is not None:
+        if os.path.abspath(fh.baseFilename) == os.path.abspath(path):
+            return  # same file: keep it open rather than truncating mid-run
+        log.removeHandler(fh)
+        fh.close()  # release the fd; many fits in one process must not leak
+
+    # mode="w" for a new prefix, matching a fresh single-fit run: each fit
+    # owns its own <prefix>.log and starts it empty.
+    fh = logging.FileHandler(path, mode="w")
     fh.setLevel(logging.DEBUG)
     fh.setFormatter(
         logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s")
     )
+    setattr(fh, _OWNER_ATTR, "file")
     log.addHandler(fh)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,169 @@
+"""Tests for exozippy.logger.setup_logging.
+
+The reason this file exists: `run.run_fit(config, user_params=<dict>)` is the
+documented in-memory API for driving many fits from one process, and each fit
+calls `setup_logging` with its own prefix. Before 2026-08 an early return on
+`if log.handlers` made every fit after the first log into the FIRST fit's file
+-- the second file was never even created -- and froze the console level at the
+first call's setting.
+"""
+
+import logging
+
+import pytest
+
+from exozippy.logger import setup_logging
+
+
+@pytest.fixture
+def clean_exozippy_logger():
+    """Restore the module-level `exozippy` logger after each test.
+
+    setup_logging mutates a process-global logger, so a test that leaves its
+    handlers attached would leak an open file handle into every later test.
+    """
+    log = logging.getLogger("exozippy")
+    saved_handlers = list(log.handlers)
+    saved_level = log.level
+    log.handlers = []
+    yield log
+    for handler in log.handlers:
+        handler.close()
+    log.handlers = saved_handlers
+    log.setLevel(saved_level)
+
+
+def _read(path):
+    with open(path) as fh:
+        return fh.read()
+
+
+def test_second_prefix_repoints_the_file_handler(
+    clean_exozippy_logger, tmp_path
+):
+    """
+    Given two fits run back to back in one process, under different prefixes,
+    When each calls setup_logging with its own prefix and logs one message,
+    Then each prefix's log file exists and holds only its own message.
+    """
+    # Arrange
+    log = clean_exozippy_logger
+    prefix_a = tmp_path / "fit_a"
+    prefix_b = tmp_path / "fit_b"
+
+    # Act
+    setup_logging(prefix_a)
+    log.info("message from fit A")
+    setup_logging(prefix_b)
+    log.info("message from fit B")
+
+    # Assert
+    text_a = _read(str(prefix_a) + ".log")
+    assert "message from fit A" in text_a
+    assert "message from fit B" not in text_a
+
+    text_b = _read(str(prefix_b) + ".log")
+    assert "message from fit B" in text_b
+    assert "message from fit A" not in text_b
+
+
+def test_repointing_closes_the_old_file(clean_exozippy_logger, tmp_path):
+    """
+    Given a logger already writing to the first fit's file,
+    When setup_logging is called with a new prefix,
+    Then the old file handler is detached and closed, so many fits in one
+    process cannot leak file descriptors.
+    """
+    # Arrange
+    log = clean_exozippy_logger
+    setup_logging(tmp_path / "first")
+    old = [h for h in log.handlers if isinstance(h, logging.FileHandler)][0]
+
+    # Act
+    setup_logging(tmp_path / "second")
+
+    # Assert
+    assert old not in log.handlers
+    assert old.stream is None  # logging.FileHandler.close() clears the stream
+
+
+def test_same_prefix_does_not_duplicate_handlers_or_messages(
+    clean_exozippy_logger, tmp_path
+):
+    """
+    Given setup_logging has already configured the logger for a prefix,
+    When it is called a second time with that same prefix,
+    Then no second handler is added, nothing already written is truncated,
+    and a message is recorded exactly once.
+    """
+    # Arrange
+    log = clean_exozippy_logger
+    prefix = tmp_path / "same"
+    setup_logging(prefix)
+    log.info("written before the second call")
+    handlers_after_first = list(log.handlers)
+
+    # Act
+    setup_logging(prefix)
+    log.info("written after the second call")
+
+    # Assert
+    assert log.handlers == handlers_after_first
+    text = _read(str(prefix) + ".log")
+    assert text.count("written before the second call") == 1
+    assert text.count("written after the second call") == 1
+
+
+def test_console_level_follows_the_latest_call(
+    clean_exozippy_logger, tmp_path
+):
+    """
+    Given a logger configured with one console level,
+    When setup_logging is called again with a different level,
+    Then the console handler carries the level from the most recent call.
+    """
+    # Arrange
+    log = clean_exozippy_logger
+    setup_logging(tmp_path / "quiet", level="WARNING")
+
+    # Act
+    setup_logging(tmp_path / "loud", level="DEBUG")
+
+    # Assert
+    console = [
+        h
+        for h in log.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+    ]
+    assert len(console) == 1
+    assert console[0].level == logging.DEBUG
+
+
+def test_foreign_handlers_are_left_alone(clean_exozippy_logger, tmp_path):
+    """
+    Given something else has attached its own handler to the exozippy logger
+    (pytest's caplog, the GUI, a user's script),
+    When setup_logging is called repeatedly with different prefixes,
+    Then that handler is neither removed nor closed and keeps receiving records.
+    """
+    # Arrange
+    log = clean_exozippy_logger
+    foreign_path = tmp_path / "foreign.log"
+    foreign = logging.FileHandler(str(foreign_path), mode="w")
+    foreign.setLevel(logging.DEBUG)
+    log.addHandler(foreign)
+
+    # Act
+    setup_logging(tmp_path / "one")
+    log.info("first fit")
+    setup_logging(tmp_path / "two")
+    log.info("second fit")
+
+    # Assert
+    assert foreign in log.handlers
+    assert foreign.stream is not None
+    foreign.flush()
+    text = _read(str(foreign_path))
+    assert "first fit" in text
+    assert "second fit" in text


### PR DESCRIPTION
## The bug

`setup_logging` returned early on `if log.handlers`, so a **second call in one process did nothing at all**. Reproduced: `setup_logging('A')` then `setup_logging('B')` puts both messages in `A.log` and **never creates `B.log`**. The same early return froze the console level at the first call's setting, and -- because it triggers on *any* handler -- made `setup_logging` a complete no-op whenever something else had already attached one (`solve_api._WarningCollector`, pytest's caplog, the GUI).

Latent today only because every shipped caller runs one fit per process (the CLI, the GUI's subprocess, `examples/DC2018/run_event.py`). But `run_fit(config, user_params=<dict>)` is documented at `mkparam.py:469` as exactly the in-memory API for driving many fits, so the next person to use it as documented gets a silent, total logging failure.

## The fix

`setup_logging` re-points its own handlers instead of bailing out. Contained to that function plus a small ownership helper.

- **Idempotence** is preserved by comparing the resolved path, not by refusing to act. A repeat call with the SAME prefix keeps the open handler, so a log is never truncated mid-run and handlers never accumulate. The console level is applied on every call either way -- it is what the caller just asked for, not what the first caller asked for.
- **The old file**: a NEW prefix detaches and `close()`s the previous `FileHandler` (many fits in one process must not leak file descriptors) and opens the new one with `mode="w"` -- matching a fresh single-fit run today, where each fit owns its own `<prefix>.log` and starts it empty.
- **Foreign handlers**: only handlers this module installed are touched, marked with an ownership attribute on the instance rather than matched by type. Clearing `log.handlers` wholesale is the obvious fix and it is wrong: a foreign `FileHandler` on the exozippy logger is somebody else's file, not ours to close.
- **Nothing caches the log path or the logger's configured state.** `run.py`, `cli_modes.py` and `gui/app.py:_log_path` each derive `<prefix>.log` from the prefix at the point of use; `outputs/modeling.py`'s `.log` is pdflatex's.

## Verification

- `tests/test_logger.py` is new. Against `origin/master` **4 of its 5 tests fail** (repointing, old-file close, console level, foreign handlers); the idempotence test passes there, which is what the early return was protecting and what this PR preserves. All 5 pass with the fix.
- `tests/test_logger.py test_run_endpoints.py test_runner.py test_runner_lifecycle.py test_runner_interrupt.py test_gui_app.py test_gui_run_crash.py test_mode_report_cli.py`: all pass.
- No test in the suite referenced `setup_logging` before this PR, so nothing depended on the early return.
- One short end-to-end fit (`examples/ob08092`, copied out of the tree, tune/draws cut to 50) run twice -- once on this branch, once on master's logger -- writes the same `<prefix>.log` in the same place with the same format and same content structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)