### PR TITLE
docs: correct five stale comments (review 7.13/7.20/7.21/7.22/7.23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ The stamp also records the code that produced the draws -- `exozippy_version` pl
 
 ### User-defined parameter links (`linking.py`)
 
-Any of the six numeric fields in a `params.yaml` entry may be a string expression referencing other parameters (`star.A.age: {initval: star.B.age, sigma: 0}`, `orbit.b.omega: {initval: "orbit.c.omega + 180", sigma: 0}`, `star.A.av: {lower: star.B.av}`). Semantics:
+Any of the five linkable numeric fields in a `params.yaml` entry (`initval`, `mu`, `sigma`, `lower`, `upper` -- `linking.LINKABLE_FIELDS`) may be a string expression referencing other parameters (`star.A.age: {initval: star.B.age, sigma: 0}`, `orbit.b.omega: {initval: "orbit.c.omega + 180", sigma: 0}`, `star.A.av: {lower: star.B.av}`). Semantics:
 - `initval` link + `sigma: 0` → hard link: the element is never sampled and deterministically tracks the expression.
 - `initval` link + `sigma > 0` (or a `mu` link) → soft link: sampled normally plus a Gaussian `pm.Potential` on the difference.
 - `initval` link, no sigma → initialization seeding only (relaxation-engine snapshot, no runtime tie).

--- a/src/exozippy/components/instrument.py
+++ b/src/exozippy/components/instrument.py
@@ -536,10 +536,13 @@ class Instrument(Component):
 
         Accepted ``mask:`` forms on an instrument's config entry:
 
-        - a path to a whitespace/newline-delimited file with ONE value per
-          data row (0/1, true/false): nonzero/true means EXCLUDE that row.
-          This is the shape a bad-data flag vector (e.g. from MMEXOFAST)
-          saves to naturally.
+        - a path to a whitespace/newline-delimited file with ONE NUMERIC flag
+          per data row: nonzero means EXCLUDE that row.  This is the shape a
+          bad-data flag vector (e.g. from MMEXOFAST) saves to naturally.  The
+          file is read with ``np.loadtxt(dtype=float)``, so ``true``/``false``
+          word literals are NOT accepted there -- write 1/0, or use the
+          boolean-list form below, which is the YAML spelling of the same
+          thing.
         - a list of booleans, one per data row: True means EXCLUDE.
         - a list of integers: 0-based row indices to EXCLUDE.
 
@@ -553,7 +556,22 @@ class Instrument(Component):
         n = len(df)
 
         if isinstance(spec, str):
-            flags = np.loadtxt(spec, dtype=float, comments="#").ravel()
+            try:
+                flags = np.loadtxt(spec, dtype=float, comments="#").ravel()
+            except ValueError as exc:
+                # numpy's own message ("could not convert string 'true' to
+                # float64 at row 0, column 1") names neither the file nor the
+                # instrument nor what the reader wants.  A flag file written
+                # with true/false word literals is the likely case and has a
+                # one-line fix, so say so.
+                raise ValueError(
+                    f"[{label}] mask file '{spec}' is not a numeric flag "
+                    f"file: it must hold one number per data row (nonzero = "
+                    f"exclude).  Word literals such as 'true'/'false' are not "
+                    f"accepted -- write 1/0, or give the mask inline as a "
+                    f"YAML list of booleans or of 0-based row indices.  "
+                    f"({exc})"
+                ) from exc
             if flags.size != n:
                 raise ValueError(
                     f"[{label}] mask file '{spec}' has {flags.size} entries "

--- a/src/exozippy/evaluator.py
+++ b/src/exozippy/evaluator.py
@@ -38,8 +38,11 @@ This module supplies the millisecond half of that loop:
     and data file list -- insensitive to dict key order and to pure
     initval changes.  The GUI compares hashes to decide stale vs live.
 
-Only model-role traces are evaluated; data traces never change with a
-slider.  See exozippy.plotspec for the PlotSpec/Trace contract and
+Model-role traces are always evaluated.  Data traces normally are not --
+raw observations do not move with a slider -- EXCEPT on specs whose meta
+declares ``dynamic_data``, where the plotted data ARE point-dependent
+(phase folds, RV gamma subtraction, mulens flux alignment) and are
+re-shipped too.  See exozippy.plotspec for the PlotSpec/Trace contract and
 Component.plot_data for how a component draws itself at an arbitrary point.
 """
 
@@ -282,9 +285,12 @@ class Evaluator:
     ) -> Dict[str, Dict[str, Dict[str, np.ndarray]]]:
         """Re-render every plot's model traces at ``raw_point``.
 
-        Returns ``{plot_id: {trace_name: {"x": array, "y": array}}}`` (data
-        traces are omitted -- they never change with a slider). Each
-        component's own ``plot_data(system, point)`` is called fresh, so the
+        Returns ``{plot_id: {trace_name: {"x": array, "y": array}}}``.  Data
+        traces are omitted -- raw observations do not move with a slider --
+        unless the spec's meta declares ``dynamic_data``, in which case its
+        data traces (plus ``yerr`` where present) are re-shipped because the
+        plotted data themselves depend on the point (see the loop below).
+        Each component's own ``plot_data(system, point)`` is called fresh, so the
         result is always an exact recompute -- not an approximation -- even
         for phase-folded curves (re-sorted/re-selected from a multi-column
         node) and SED spectra (NumPy spectral-library interpolation), both of

--- a/src/exozippy/linking.py
+++ b/src/exozippy/linking.py
@@ -215,9 +215,11 @@ def parse_link_expression(expr_str, system_config, context=""):
 
 def extract_links(user_params, system_config):
     """
-    Scan standardized user_params for link expressions in the six linkable
-    fields, REMOVE them from the entries (so downstream numeric code never
-    sees strings), and return {target_path: {field: ParamLink}}.
+    Scan standardized user_params for link expressions in the five
+    ``LINKABLE_FIELDS`` (initval, mu, sigma, lower, upper), REMOVE them from
+    the entries (so downstream numeric code never sees strings), and return
+    {target_path: {field: ParamLink}}.  ``init_scale`` is deliberately not
+    among them -- see the module docstring.
 
     Must be called after standardize_param_names, so all list-component keys
     are in index form (comp.idx.param).

--- a/src/exozippy/polish.py
+++ b/src/exozippy/polish.py
@@ -94,8 +94,13 @@ DEFAULT_POLISH_STEPS = 150
 _LBFGS_FTOL = 1e-12  # effectively off; gtol + maxiter terminate
 _LBFGS_GTOL = 1e-2
 # Non-finite logp guard: L-BFGS line searches handle inf poorly, so a
-# non-finite evaluation returns this plateau plus a quadratic pull back
-# toward the last finite iterate's neighborhood (gradient points home).
+# non-finite evaluation returns this plateau plus |x - x0|^2, whose gradient
+# 2*(x - x0) points back at THE POLISH START x0 -- not at the last finite
+# iterate, which the objective never records.  x0 is the fixed seed the
+# polish was handed (and logp/grad there are checked finite before the
+# L-BFGS path is taken at all), so the pull is always toward a point the
+# logp is known to be defined at; the quadratic is what makes the plateau
+# navigable, since a flat 1e15 gives the line search no direction.
 _NONFINITE_PENALTY = 1e15
 
 # Sentinel: "caller said nothing", so the DE engine's own defaults apply.

--- a/src/exozippy/utilities/mkticsed.py
+++ b/src/exozippy/utilities/mkticsed.py
@@ -934,7 +934,7 @@ def mkticsed(
                     and np.isfinite(c1)
                     and m1 > 0
                 ):
-                    # Cassegrande+2011, eq. 2 (FGK solar neighbourhood)
+                    # Casagrande+2011, eq. 2 (FGK solar neighbourhood)
                     if (
                         0.23 < by < 0.63
                         and 0.05 < m1 <= 0.68
@@ -959,9 +959,9 @@ def mkticsed(
                             "sigma": 0.10,
                         }
                         notes.append(
-                            "[Fe/H] from Paunzen+2015 Stromgren via Cassegrande+2011 eq. 2"
+                            "[Fe/H] from Paunzen+2015 Stromgren via Casagrande+2011 eq. 2"
                         )
-                    # Cassegrande+2011, eq. 3 (cooler range)
+                    # Casagrande+2011, eq. 3 (cooler range)
                     elif (
                         0.43 < by < 0.63
                         and 0.07 < m1 <= 0.68
@@ -986,7 +986,7 @@ def mkticsed(
                             "sigma": 0.12,
                         }
                         notes.append(
-                            "[Fe/H] from Paunzen+2015 Stromgren via Cassegrande+2011 eq. 3"
+                            "[Fe/H] from Paunzen+2015 Stromgren via Casagrande+2011 eq. 3"
                         )
 
     # Last-resort: wide Gaussian [Fe/H] prior

--- a/tests/test_instrument_mask.py
+++ b/tests/test_instrument_mask.py
@@ -97,6 +97,30 @@ def test_mask_indices_refer_to_raw_file_row_order(tmp_path):
     np.testing.assert_allclose(inst.time, [1.0, 3.0, 5.0, 7.0])
 
 
+def test_mask_file_word_literals_raise_a_clear_error(tmp_path):
+    """
+    Given a mask FILE written with true/false word literals rather than 1/0,
+    When the data file is loaded,
+    Then a ValueError naming the instrument, the mask file and the two
+    working spellings is raised -- not numpy's bare "could not convert
+    string 'true' to float64", which names none of them.
+
+    The flag file is deliberately numeric-only (``np.loadtxt(dtype=float)``);
+    the boolean spelling lives on the inline YAML list form, exercised by
+    test_boolean_list_mask_excludes_flagged_rows.
+    """
+    mask_file = tmp_path / "inst.mask"
+    mask_file.write_text("false\ntrue\nfalse\ntrue\nfalse\n")
+    with pytest.raises(ValueError) as excinfo:
+        _load(tmp_path, mask=str(mask_file))
+    msg = str(excinfo.value)
+    assert "Inst" in msg
+    assert str(mask_file) in msg
+    assert "numeric flag" in msg
+    assert "1/0" in msg
+    assert "booleans" in msg
+
+
 def test_mask_file_length_mismatch_raises(tmp_path):
     """
     Given a mask file whose flag count differs from the data row count,

--- a/tests/test_mkticsed.py
+++ b/tests/test_mkticsed.py
@@ -412,6 +412,47 @@ def test_negative_parallax_is_still_written_as_a_prior(
     assert "NEGATIVE" in notes
 
 
+def test_stromgren_feh_header_note_spells_casagrande_correctly(
+    tmp_path, patched_catalogs
+):
+    """
+    Given a TIC row with no [M/H] and a Paunzen+2015 Stromgren row inside
+      the calibration range of Casagrande+2011 eq. 2,
+    When mkticsed writes the params file,
+    Then a [Fe/H] prior is written AND the emitted header note names
+      "Casagrande" -- the author's actual name.  The header is user-facing
+      output, so a misspelling there ("Cassegrande", until 2026-08) ships to
+      every user of the tool and into every paper written from it.
+    """
+    # Arrange: TIC with a missing [M/H] so the Stromgren pathway is reached.
+    tic = _tic_table()
+    tic["[M/H]"] = [np.nan]
+    patched_catalogs["IV/39/tic82"] = tic
+    patched_catalogs["J/A+A/580/A23/catalog"] = Table(
+        {
+            "RAJ2000": [TARGET_RA],
+            "DEJ2000": [TARGET_DEC],
+            "b-y": [0.40],
+            "e_b-y": [0.005],
+            "m1": [0.20],
+            "e_m1": [0.005],
+            "c1": [0.35],
+            "e_c1": [0.005],
+        }
+    )
+    priorfile = tmp_path / "p.yaml"
+
+    # Act
+    _run(tmp_path, priorfile=str(priorfile))
+    priors = _read_priors(priorfile)
+    notes = " ".join(_prior_notes(priorfile))
+
+    # Assert
+    assert "star.Host.feh" in priors
+    assert "Casagrande+2011" in notes
+    assert "Cassegrande" not in notes
+
+
 def test_dr2_fallback_also_writes_a_parallax_prior(tmp_path, patched_catalogs):
     """
     Given no Gaia DR3 row but a matched Gaia DR2 one,


### PR DESCRIPTION
Section 7 (COMMENT / DOCSTRING ACCURACY) of `notes/code_review_20260808.txt`, items 7.12, 7.13, 7.20, 7.21, 7.22, 7.23 -- each verified against current master before touching anything, since several section-7 complaints have been overtaken by fixes.

## Per-item verdict

| Item | Verdict | Evidence |
|---|---|---|
| 7.12 rvinstrument "sampler steps in 'logjitter'" | **ALREADY TRUE -- no change** | `git grep logjitter` over `src/` and `tests/` returns nothing. PR #124 (`44090d4`) moved the bridge to `Instrument` (`JITTER_SYMBOLS`/`JITTER_SYMBOL_MAP`/`JITTER_RELATIONS`) and rewrote all three children's comments to say `jitter_variance`. The surviving "Reparameterization Bridges (Base-10)" headers in `star`/`orbit` are genuine (`mass = 10**logmass`, `period = 10**logP`). |
| 7.13 mask docstring promises `true/false` in a flag FILE | **STILL FALSE -- docstring fixed, error message improved** | `instrument.py:_apply_mask` reads the file with `np.loadtxt(spec, dtype=float)`, which raises `ValueError: could not convert string 'true' to float64 at row 0, column 1` (reproduced). |
| 7.20 "Cassegrande" | **STILL FALSE -- fixed, 4 occurrences** | `mkticsed.py` 937/962/964/989. Two are `notes.append()` strings that reach emitted output. |
| 7.21 "six linkable fields" | **STILL FALSE -- fixed** | `linking.py:50` `LINKABLE_FIELDS = ("initval", "mu", "sigma", "lower", "upper")` -- five. The module docstring at the top of the same file already said five. |
| 7.22 "(data traces are omitted)" | **STILL FALSE -- fixed** | `evaluator.py` `eval_plots` re-ships data traces for specs with `meta["dynamic_data"]`. The branch is the newer truth (`75bf1ba`, the GUI overhaul); the docstrings predate it. |
| 7.23 non-finite penalty "pulls toward the last finite iterate" | **STILL FALSE -- fixed** | `polish.py` returns `_NONFINITE_PENALTY + sum((x - x0)**2)` with gradient `2*(x - x0)`. `x0 = flatten(center)` is the fixed polish start; no last-finite-iterate is ever recorded. |

## 7.13: which side was fixed, and why

The **docstring**, not the reader. Three reasons: `_mask_config_schema`'s user-facing doc already says "a path to a file with one 0/1 flag per data row"; CLAUDE.md's `_apply_mask` paragraph says the same; and the boolean spelling already exists as the inline YAML list form, which is the natural place for it (YAML parses `true` to a bool; a text flag file does not). Making the file reader accept word literals would have added a second spelling of an existing feature.

But the failure was a bad user experience either way, so the numpy `ValueError` is now caught and re-raised naming the instrument, the mask file, what the reader wants, and both working alternatives. That message is **the only behaviour change in this PR**; the set of accepted inputs is unchanged.

## 7.20: proof the fix reaches emitted output

The two corrected strings are `notes.append(...)` calls; `notes` is written as `# {note}` header lines into the generated params file (`mkticsed.py`, section 13). Note the review said `.sed` headers -- it is actually the params/priors file header (`sed_notes` is the separate list that reaches `.sed`). `test_stromgren_feh_header_note_spells_casagrande_correctly` drives a TIC row with a missing `[M/H]` plus a synthetic Paunzen+2015 Stromgren row inside eq. 2's calibration range, then asserts on the text actually written to disk.

## Tests

New: `tests/test_instrument_mask.py::test_mask_file_word_literals_raise_a_clear_error`, `tests/test_mkticsed.py::test_stromgren_feh_header_note_spells_casagrande_correctly`.

Run locally (`-n0`): `test_mkticsed.py`, `test_instrument_mask.py`, `test_evaluator.py`, `test_instrument_base.py`, `test_instrument_time_columns.py`, `test_linked_params.py`, `test_polish.py` -- 166 passed. Full suite left to CI (parallel agents on this box). `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)