### PR TITLE
docs: audit review 7.1-7.4/7.15 -- four had gone stale, one real fix

### DIFF
--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -1392,8 +1392,16 @@ class Lens(Component):
         obs_pos : (N, 3) Skowron+2011 geocentric deviations in AU --
         the observer's offset from the linear Earth trajectory anchored at
         t0_par (MulensInstrument._abs_to_delta).  The MulensModel Op path
-        consumes the exact same array (fed as satellite_skycoord), so the
-        two paths are interchangeable.  Zero rows mean no parallax.
+        consumes the exact same array (fed as satellite_skycoord), so both
+        paths carry the same parallax, annual and satellite alike, and are
+        interchangeable on this input.  Zero rows mean no parallax.
+
+        The one input they do NOT share is the line of sight: this formula
+        reads the live star.ra/star.dec nodes, while the Op takes a coordinate
+        STRING frozen at the start value (_frozen_op_coords_deg, which warns
+        when they are sampled).  That only separates the two paths in a
+        topology that actually samples ra/dec, and by ~1e-5 per arcsec of
+        coordinate error -- see that method for why the freeze is free.
         """
         source_ndx = self.source_map[index]
         ra = system.star.ra.value[source_ndx]

--- a/src/exozippy/components/star/physics.py
+++ b/src/exozippy/components/star/physics.py
@@ -30,11 +30,12 @@ def calc_logg_from_logmass(logmass, radius):
 @register_physics
 def calc_mass(logmass):
     """
-    Calculates surface gravity (logg) from mass and radius.
-    mass: solar masses
-    radius: solar radii
-    returns: cgs (log10)
-    Note: this odd form of logg is designed to simplify the symbolic math and chain rule derivatives
+    Calculates stellar mass from its base-10 logarithm.
+    logmass: log_10 of stellar mass, in solar masses
+    returns: solar masses
+    Note: logmass is the SAMPLED coordinate and mass is derived from it, so
+    logmass's bounds are the real hard support (see star/defaults.yaml);
+    star.mass carries no lower/upper of its own.
     """
     return 10**logmass
 


### PR DESCRIPTION
Review items 7.1, 7.2, 7.3, 7.4 and 7.15 from section 7 ("COMMENT / DOCSTRING ACCURACY") of `notes/code_review_20260808.txt`, verified individually against the current tree before touching anything.

Section 7 was written against the tree of 2026-08-08. **Four of the five complained about a comment that was false because of a bug -- and the commit that fixed the bug rewrote the comment with it.** The text is now correct, and "fixing" it would have made the documentation wrong.

## Per-item verdict

| Item | Verdict | Fixed by |
|---|---|---|
| 7.1 `op.py` "annual parallax is embedded" | ALREADY-TRUE | `ae751f7` (bug 1.1) |
| 7.2 `lens.py` "interchangeable callers" | ALREADY-TRUE, one caveat added | `ae751f7` (bug 1.1) |
| 7.3 `rm.py` "same LD basis as transit.py" | ALREADY-TRUE (and understated) | `22a3137` (bug 1.7) |
| 7.4 `transit.py` `dur_b` primary vs secondary | ALREADY-TRUE | `568f036b` (bugs 1.2/1.12) |
| 7.15 `star/physics.py` `calc_mass` docstring | STILL-WRONG -> FIXED | -- (no bug behind it) |

**7.1** -- `_dev_skycoord`'s docstring and both `_build_*_model` parallax comments were rewritten by the fix itself (blame: every line is `ae751f7`, 2026-08-08). Verified independently against the installed MulensModel: `Trajectory._get_delta_satellite` is `-dot(satellite.cartesian, north_projected/east_projected)`, and `_get_delta_satellite_results` is keyed on `(ra, dec, times)` alone -- exactly what `_clear_mm_satellite_cache` says it clears and why. No change.

**7.2** -- Genuinely interchangeable *on `obs_pos`*: both paths take the same `_abs_to_delta` array, share the `u_0`/`t_E` floors through `physics`, and the two opposite sign conventions (`+dot` symbolic, `-dot` in MulensModel) compose to the same tau/beta shifts through `_project_delta`. `tests/test_pspl_symbolic_vs_op.py` pins no-parallax, annual-parallax and satellite-offset parity. One caveat is real and was not stated at this docstring: the Op takes the line of sight as a coordinate **string** frozen at the start value, while the symbolic formula reads the live `star.ra`/`star.dec` nodes. Stated precisely, pointing at `_frozen_op_coords_deg`, which already owns the argument for why the freeze is free and warns when ra/dec are sampled.

**7.3** -- Not merely the same basis: `22a3137` routed `rm.py` and both `transit.py` sites through `components/limbdark.py:quad_limb_darkened_flux`, and the comment already says "the same shared helper (and therefore the same Green's-basis conversion) transit.py uses". No change.

**7.4** -- `568f036b` swapped the denominators back, so `dur_b` now takes `1 + esinw` (Winn 2010 eqs 7-8: the primary conjunction is at true anomaly `pi/2 - omega`, where `r = a(1-e^2)/(1 + esinw)`) and `dur_bs` takes `1 - esinw`, matching the comment written above them in the same commit. `tests/test_transit_durations.py` already pins primary and secondary against numpy Winn 2010 on an `e=0.3, omega=60 deg` system, plus a `b < bs` / `t14 < t14s` direction assertion that catches a consistent re-swap, plus `calc_b`'s convention -- so the docstring/code disagreement that produced this item cannot recur silently. No change, no new test needed.

**7.15** -- The one item with no bug behind it. `calc_mass`'s docstring was a verbatim copy of `calc_logg_from_logmass`'s: wrong inputs, wrong return, wrong units, and a note about "this odd form of logg". Rewritten, noting that `logmass` is the sampled coordinate whose bounds are the real hard support (`star/defaults.yaml` deletes `mass`'s own `lower`/`upper` for exactly that reason).

## Verification

Doc-only -- `git diff` touches two docstrings and nothing else; no behaviour change.

`tests/test_pspl_symbolic_vs_op.py`, `tests/test_transit_durations.py`, `tests/test_limbdark.py`, `tests/test_physics_registry.py`: 25 passed. (One `test_pspl_symbolic_vs_op` run hit a `~/.pytensor` compile-lock timeout from concurrent suites on this box; it passes on its own.) `ruff check` + `ruff format --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)