### PR TITLE
sed: make three stale comments match the code (review 7.8)

### DIFF
--- a/src/exozippy/components/sed/bc_grid.py
+++ b/src/exozippy/components/sed/bc_grid.py
@@ -466,8 +466,19 @@ def build_bc_grid(
             frames[feh] = df[keep].copy()
         per_facility_frames[fac] = frames
 
-    # 3. Cross-check: all facilities must share the same (teff, logg,
-    # feh, Av) grid. Use the first facility as the canonical grid.
+    # 3. Adopt the first facility's (teff, logg, feh, Av) axes as the
+    # canonical grid. Every facility must be on that same grid -- but
+    # that is an ASSUMPTION here, not a checked precondition: no other
+    # facility's axes are ever compared against these. Step 4 places
+    # every facility's rows into the canonical axes by searchsorted, so
+    # a facility on a different grid is silently mis-binned (its row
+    # lands in the next canonical cell up) rather than rejected, or
+    # raises IndexError if its values run past the canonical maximum.
+    # The only guard is step 5's NaN check, which catches an
+    # UNDER-populated grid (a facility with fewer points leaves cells
+    # unwritten) but not a mis-binned one (a facility with the same
+    # number of points at different values fills every cell). Compare
+    # the axes here if that ever stops being good enough.
     canonical_fac = next(iter(per_facility_frames))
     canonical_frames = per_facility_frames[canonical_fac]
     feh_pts = np.array(sorted(canonical_frames.keys()), dtype=float)

--- a/src/exozippy/components/sed/make_bc.py
+++ b/src/exozippy/components/sed/make_bc.py
@@ -20,9 +20,18 @@ Conventions
   calculated one), via the Filter class.
 * Extinction IS applied along the Av axis:
   tau(lam) = ext(lam)/ext(0.55um) * Av / 1.086 (models/extinction_law.ascii),
-  so BC(Av) = M_bol(unextincted) - M_X(extincted). NOTE: the shipped
-  2MASS/GAIA/WISE tables do NOT vary with Av (extinction appears to be
-  missing there); tables generated here do.
+  so BC(Av) = M_bol(unextincted) - M_X(extincted). The shipped tables
+  carry the same 13-point Av axis (0 to 6 mag) and DO vary along it --
+  an earlier version of this note claimed they did not, and that was
+  wrong. Measured at teff = 5600 K, logg = 2.5, [Fe/H] = 0, the
+  least-squares dBC/dAv is -0.303 (2MASS_J), -0.126 (2MASS_Ks), -0.704
+  (Gaia_G), -0.072 (WISE_W1); no shipped column is flat in Av, in any
+  of 2MASS/GAIA/Generic/Keck/TESS/WISE. The three narrow bands there
+  match -A_lam/Av from models/extinction_law.ascii at the band's
+  effective wavelength (-0.305, -0.125, -0.072) to under 1%, i.e. the
+  shipped Av dependence IS this same extinction law; only Gaia_G
+  departs from its single-wavelength value (-0.865), as a passband
+  that wide must.
 
 Accuracy caveat: the shipped R=150 spectra reproduce the original
 2MASS/GAIA BC tables only to ~0.01-0.04 mag (those were evidently

--- a/src/exozippy/components/sed/sed.py
+++ b/src/exozippy/components/sed/sed.py
@@ -123,12 +123,25 @@ class SED(Component):
         # the plot compiler, and the cross-component predict_* API.
         self._m_pred_matrix = None
 
-        # Grid-axis caches, filled by _inject_grid_bounds below. These
-        # are kept on the component so build_likelihood can consult
-        # the (logg_min, logg_max) range when adding a soft potential
-        # on the inline loggsed expression (loggsed isn't a named
-        # star Parameter, so it can't be bounded through the override
-        # channel the way teffsed/feh/av are).
+        # Grid-axis caches, filled by _inject_grid_bounds below.
+        #
+        # NOTHING READS THEM YET. The (logg_min, logg_max) range they
+        # carry was meant to feed a soft potential on the inline loggsed
+        # expression, and that potential was never written:
+        # build_likelihood adds only the teffsed and fbolsed floor
+        # priors. The gap it was meant to close is real. teffsed, feh
+        # and av are held inside the BC grid by _inject_grid_bounds
+        # below, but loggsed is not a named star Parameter -- it is
+        # reconstructed inline from (star.logmass, star.radiussed) in
+        # _predicted_appmag_node -- so there is nothing for the override
+        # channel to bound, and bounding its two inputs separately does
+        # not bound their combination. A draw whose loggsed leaves the
+        # grid (NextGen: 0.0 to 5.0 dex) is therefore linearly
+        # EXTRAPOLATED off the edge cell rather than penalized:
+        # RegularGridInterpolator is built below with fill_value=None,
+        # so it computes out_of_bounds and then discards it. Keep these
+        # caches; add the potential (or a potentials.soft_*_bound on
+        # loggsed) when someone gets to it.
         self.grid_axes = [None]
         self._inject_grid_bounds()
 
@@ -647,8 +660,9 @@ class SED(Component):
         # Bolometric luminosity
         Lbol = calc_luminosity(radiussed, teffsed)
         # Absolute bolometric magnitude from bolometric luminosity.
-        # M_bol = -2.5 log10(L_bol / L_bol_0) with IAU 2015 zero
-        # point (see physics.L_BOL_ZERO_LSUN).
+        # M_bol = -2.5 log10(L_bol / L_0) with the IAU 2015 zero point.
+        # See physics.calc_absbolmag, which adds constants.LOG_L0_CONST
+        # (= 2.5 log10(L_0 / L_sun) = M_bol_sun = 4.7400).
         Mbol_abs = calc_absbolmag(Lbol)  # (nstars,)
 
         # Absolute magnitude per star per filter.


### PR DESCRIPTION
Item 7.8 of `notes/code_review_20260808.txt` is five claims about SED comments. Each was verified against the current code first, because a "this comment is false" finding from 2026-08-08 may since have become true. Two had; three had not.

**Comment/docstring changes only.** `git diff` touches nothing but comments.

## Per-claim verdict

| # | Claim | Verdict |
|---|---|---|
| 1 | `sed.py` promises a `loggsed` soft potential that does not exist | STILL TRUE -> prose fixed |
| 2 | `sed.py`'s guarantee table does not match the `setdefault` code | ALREADY FIXED (1e62b8b) -> untouched |
| 3 | `sed.py` cites a nonexistent `physics.L_BOL_ZERO_LSUN` | STILL TRUE -> prose fixed |
| 4 | `bc_grid.py` describes a cross-check that is not performed | STILL TRUE -> prose fixed |
| 5 | `make_bc.py` says the shipped tables do not vary with Av; they do | STILL TRUE -> prose fixed |

### 1. The `loggsed` soft potential

Nothing reads `self.grid_axes` -- not `build_likelihood`, not anything else. `git log -S grid_axes` returns only the commit that added the SED component, so the attribute has been unread since the day it appeared. This is an **intended feature that was never built**, not a description of one that moved, so the comment says exactly that and keeps the intent rather than deleting it.

It also now states the consequence, which is the part worth knowing. `RegularGridInterpolator` is constructed with `fill_value=None`, so it computes `out_of_bounds` and then discards it: a draw whose `loggsed` leaves the grid (NextGen: 0.0 to 5.0 dex) is **linearly extrapolated** off the edge cell, not penalized and not NaN. `teffsed`/`feh`/`av` are held inside the grid through the override channel; `loggsed` is not a named Parameter (it is rebuilt inline from `star.logmass` + `star.radiussed`), and bounding those two separately does not bound their combination.

### 3. `physics.L_BOL_ZERO_LSUN`

No such name exists anywhere. The real constant is `constants.LOG_L0_CONST` (= 2.5 log10(L_0/L_sun) = M_bol_sun = 4.7400), consumed by `physics.calc_absbolmag`. Reference corrected.

### 4. The bc_grid cross-check

Step 3 said "cross-check: all facilities must share the same (teff, logg, feh, Av) grid" and performed no comparison: it adopts the first facility's axes, and step 4 places every other facility's rows into them by `searchsorted`. A facility on a different grid is silently mis-binned (row lands in the next canonical cell up) or raises `IndexError` past the canonical maximum. Step 5's NaN check catches an *under-populated* grid but not a mis-binned one. The comment now states the assumption as an assumption.

### 5. Av dependence of the shipped tables -- measured

The docstring claimed the shipped 2MASS/GAIA/WISE tables "do NOT vary with Av (extinction appears to be missing there)". They do. Measured directly from the shipped files at teff = 5600 K, logg = 2.5, [Fe/H] = 0 (least-squares slope over the 13-point Av axis, 0 to 6 mag):

| Band | measured dBC/dAv | -A_lam/Av from `extinction_law.ascii` |
|---|---|---|
| 2MASS_J | **-0.303** | -0.305 |
| 2MASS_Ks | -0.126 | -0.125 |
| Gaia_G | -0.704 | -0.865 (passband far too wide for a single-wavelength value) |
| WISE_W1 | -0.072 | -0.072 |

The 2MASS_J figure reproduces the audit's -0.30. No column of any shipped facility (2MASS, GAIA, Generic, Keck, TESS, WISE) is flat in Av; the smallest spread across the Av axis anywhere is 0.12 mag (WISE_W4). The three narrow bands match the shipped extinction law to under 1%, so the shipped Av dependence **is** that same law.

Note on provenance: `git log --follow` on the table files shows two commits, both structural moves. **The tables were never regenerated, so this note was wrong when it was written** rather than made stale by a later fix.

### 2. The setdefault guarantee table (no change)

Already fixed by 1e62b8b ("prov: stop the SED and astrometry writing into user_params"), which replaced the `user_params` injection with `ConfigManager.add_override`. The table's three lines were re-verified against `resolve`/`apply_value`: `max(lower)`/`min(upper)` combination, and a warning naming the parameter when an override bound clips a user's. It matches. Left alone.

## Testing

`tests/test_sed.py`, `tests/test_sed_flux_constraints.py`, `tests/test_make_bc.py`, `tests/test_filter_aliases.py`: **71 passed, 3 skipped**. The 3 skips are `test_make_bc.py`, whose `skipif` fires when the NextGen spectra are absent; the Zenodo fetch (248 MB) ran fine on this box during the first run, and re-running that file afterwards gives 3 passed. Ruff check + format clean on all three changed files. Full suite left to CI.

## Noted, not fixed

- `tests/test_make_bc.py::test_regenerated_2mass_j_matches_shipped_at_av0` compares regenerated against shipped BCs **at Av = 0 only**, so nothing in the suite exercises agreement along the Av axis. That is the coverage gap that let the stale note stand. Not fixed here (this PR is doc-only).
- Nothing was found that belongs to the deferred SED items 4.10 / 5.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)