### PR TITLE
gui: request-id addressed tune worker protocol + silence deadline (review 6.5 / 1.4 / 1.5)

### DIFF
--- a/src/exozippy/gui/gui.md
+++ b/src/exozippy/gui/gui.md
@@ -97,6 +97,8 @@ push it into one of these contracts instead.
   dedicated **worker process** (spawn context, request/response over
   multiprocessing queues) that holds the System/model/`Evaluator` so pytensor
   compile + eval stay off the API event loop. One session per open project.
+  Its wire protocol is **addressed by request id**, and waiting is **bounded**
+  -- see "The tune worker protocol" below.
 - `runner.py` + `status.py` (G6) -- `start_run(config, cwd) -> RunHandle`
   (launches `python -m exozippy.cli <config>` as a fresh subprocess with
   `EXOZIPPY_GUI_SNAPSHOT=1`), `RunHandle.status()/stop(force=)`,
@@ -277,6 +279,59 @@ freezes the live plots until the next Solve. Slider/bound/prior edits are still
 real G8 `set_param_field` commands (undoable, RANK_USER, saved to params.yaml);
 the Tune toolbar has its own Save button (the shared document's dirty flag)
 so tuned values can be written to disk without leaving the tab.
+
+## The tune worker protocol (`tune.py`)
+
+Two multiprocessing queues carry request dicts one way and response dicts the
+other. Two rules make that safe; both exist because the naive version was
+racy in ways that were invisible until they were not (review 1.4 and 1.5).
+
+**1. Every request carries a uuid, and the worker echoes it on every message it
+sends back** -- the final answer, the error, and the mid-solve
+`{"progress": "compiling", "data_plots": [...]}` alike. The parent runs ONE
+reader thread that drains the response queue and files each message under the
+id it echoes; each caller waits only on its own id, and a message addressed to
+an id nobody is waiting on is dropped at the reader (the only place that
+decision is made).
+
+This is what lets a slider eval and a Solve be in flight at once, which the
+server really does produce: a Solve runs on the single-slot `tune_pool` while
+`POST /api/tune/eval` runs on FastAPI's threadpool. Before ids, whichever
+thread called `get()` first took whatever message arrived -- an eval could
+return the Solve's payload, and the eval's wait silently ATE the Solve's
+progress message, losing the data-only plots. `TuneSession.eval`'s phase gate
+narrowed that window but could not close it: the gate is read **unlocked** and
+`solve()`'s put+await is deliberately **outside** the session lock (taking the
+lock across either would serialize the slider behind a seconds-long Solve).
+The request id, not the lock, is what makes those unlocked reads safe -- do not
+"fix" the lock discipline by widening the lock.
+
+**2. Silence has a deadline, and expiry means terminate + respawn.** A worker
+that dies raises immediately (the response queue is polled, not blocked on). A
+worker that hangs while still ALIVE -- a pytensor compile deadlock, a wedge in
+native code, an OOM-frozen child -- used to wedge every later Solve until the
+server was restarted. Now each request has a silence budget
+(`SOLVE_TIMEOUT_S = 900`, `EVAL_TIMEOUT_S = 120`; every message restarts the
+clock, so a job is only ever killed for going quiet, never for being long).
+On expiry the parent terminates the process, replaces BOTH queues (a process
+killed mid-write can leave a partial pickle in the pipe), spawns a clean
+worker and raises `WorkerTimeout` -- a `RuntimeError`, so `TuneSession.solve`
+surfaces it as the error phase and `/api/tune/eval` as a 409. A restart also
+bumps a generation counter that releases any OTHER in-flight request at once,
+instead of leaving it to burn its own deadline and terminate the fresh worker
+in turn. A timed-out eval sets the session to the error phase, because the
+respawned worker holds no compiled evaluator: the UI has to Solve again.
+
+The deadlines are deliberately generous and are read at call time (never
+captured), so a slow machine can monkeypatch them. A false positive is worse
+than a late detection -- terminating a healthy worker throws away a compile
+that was about to finish and looks, from the UI, exactly like the bug the
+deadline is there to fix.
+
+There is **no cancel endpoint**: nothing lets a user abandon an in-flight Solve
+early. The deadline covers the wedged case; a deliberate cancel is a separate
+feature (it needs a UI affordance and a request-scoped abort, not just
+`worker.close()`).
 
 ## Invariants (do not break these)
 

--- a/src/exozippy/gui/tune.py
+++ b/src/exozippy/gui/tune.py
@@ -15,7 +15,11 @@ The Tune tab implements a hybrid interaction model:
 Because the pytensor compile + eval is CPU-heavy and must not stall the
 FastAPI event loop, the evaluator lives in a DEDICATED WORKER PROCESS -- one
 per open project.  :class:`EvaluatorWorker` owns that subprocess and speaks a
-tiny request/response protocol over two multiprocessing queues.
+tiny request/response protocol over two multiprocessing queues: every request
+carries a uuid the worker echoes on every message it sends back, and each
+caller waits only on its own id, so a slider eval and a Solve can be in flight
+together without stealing each other's replies.  A worker that goes silent past
+a generous deadline is terminated and respawned rather than wedging the tab.
 :class:`TuneSession` drives it from the server side, tracking the
 solving -> compiling -> live phase for the status endpoint.
 
@@ -34,13 +38,48 @@ import queue
 import signal
 import sys
 import threading
+import time
+import uuid
 from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
 # How long the parent waits on the response queue before re-checking that the
-# worker process is still alive (see EvaluatorWorker._next_message).
+# worker process is still alive (see EvaluatorWorker._reader_loop / _take).
 _AWAIT_POLL_S = 0.25
+
+# SILENCE deadlines: how long the parent will wait with NO message at all from
+# the worker before declaring it wedged, terminating it and respawning (see
+# EvaluatorWorker._await).  Each progress message restarts the clock, so these
+# bound one silent stretch, not the whole job.
+#
+# They are deliberately generous, because a false positive is far worse than a
+# late detection: terminating a healthy worker throws away a compile that was
+# about to finish and looks, from the UI, exactly like the bug it is meant to
+# fix.  A legitimate first Solve is silent for as long as pytensor takes to
+# build and compile the model on a cold cache -- tens of seconds routinely, and
+# minutes for a big SED/transit topology -- so SOLVE gets 15 minutes, about an
+# order of magnitude above the worst legitimate silence.  An eval is
+# milliseconds by design, but the first one after a Solve can lazily compile
+# plotters (the GP conditional means, the outlier probabilities), so it gets 2
+# minutes rather than something that looks tight next to a slider drag.
+#
+# Read at call time (never captured at import) so a slow machine -- or a test
+# -- can monkeypatch them.
+SOLVE_TIMEOUT_S = 900.0
+EVAL_TIMEOUT_S = 120.0
+
+
+class WorkerTimeout(RuntimeError):
+    """The worker went silent past its deadline and was terminated.
+
+    A subclass of ``RuntimeError`` so every existing handler (``TuneSession``'s
+    solve wrapper, ``app.py``'s ``/api/tune/eval``) already surfaces it.
+    """
+
+
+class _DeadlineExpired(Exception):
+    """Internal: no message for this request within its silence deadline."""
 
 
 # ---------------------------------------------------------------------------
@@ -83,7 +122,9 @@ def _do_solve(state, msg, resp_q):
     Emits a ``{"progress": "compiling", "data_plots": [...]}`` message once
     the relaxation engine (the "solving" half) has finished and the model
     build begins, so the parent can advance its phase indicator and render
-    the data-only plots while the compile runs.
+    the data-only plots while the compile runs.  Like every response, it
+    echoes the request's ``id`` so the parent can route it back to the caller
+    that is waiting for it (see EvaluatorWorker).
     """
     from exozippy.evaluator import compile_evaluator, structural_hash
     from exozippy.system import System
@@ -115,7 +156,11 @@ def _do_solve(state, msg, resp_q):
         # Relaxation done; the seconds-scale compile begins now. Ship the
         # data-only plots along so the GUI has something to draw meanwhile.
         resp_q.put(
-            {"progress": "compiling", "data_plots": _data_only_plots(system)}
+            {
+                "id": msg.get("id"),
+                "progress": "compiling",
+                "data_plots": _data_only_plots(system),
+            }
         )
         model = system.build_model()
         base_raw = system.get_raw_start(model)
@@ -202,26 +247,40 @@ def _install_parent_death_signal():
 
 
 def _worker_main(req_q, resp_q):
-    """Entry point of the evaluator subprocess: a serve loop over the queues."""
+    """Entry point of the evaluator subprocess: a serve loop over the queues.
+
+    EVERY message this loop puts on the response queue echoes the request's
+    ``id``; the parent routes on it, so a response with no id (or a wrong one)
+    is dropped and its caller waits out its deadline.
+    """
     _install_parent_death_signal()
     state: dict = {}
     while True:
         msg = req_q.get()
         op = msg.get("op")
+        rid = msg.get("id")
         if op == "shutdown":
             break
         try:
             if op == "solve":
                 result = _do_solve(state, msg, resp_q)
-                resp_q.put({"ok": True, **result})
+                resp_q.put({"ok": True, "id": rid, **result})
             elif op == "eval":
                 result = _do_eval(state, msg)
-                resp_q.put({"ok": True, **result})
+                resp_q.put({"ok": True, "id": rid, **result})
             else:  # pragma: no cover - defensive
-                resp_q.put({"ok": False, "error": f"unknown op '{op}'"})
+                resp_q.put(
+                    {"ok": False, "id": rid, "error": f"unknown op '{op}'"}
+                )
         except Exception as exc:  # noqa: BLE001 - report, keep the loop alive
             logger.exception("tune worker error")
-            resp_q.put({"ok": False, "error": f"{type(exc).__name__}: {exc}"})
+            resp_q.put(
+                {
+                    "ok": False,
+                    "id": rid,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -236,6 +295,30 @@ class EvaluatorWorker:
     BLAS have initialised in the server process is unsafe, and spawn re-imports
     cleanly at the cost of a slower (seconds) startup that is dwarfed by the
     solve itself.
+
+    **The protocol is request-id addressed.**  Every request carries a fresh
+    uuid; the child echoes it on every message it sends back (progress
+    included); the parent runs ONE reader thread that drains the shared
+    response queue and files each message under the id it echoes, and each
+    caller waits only on its own id.  The queues are shared but the mailboxes
+    are not, which is what makes it safe for a slider eval and a Solve to be in
+    flight at the same time -- the case the server really produces, since a
+    Solve runs on the tune pool while ``/api/tune/eval`` runs on FastAPI's
+    threadpool.  Before ids, whichever thread called ``get()`` first took
+    whatever message arrived: an eval could return the Solve's payload, and the
+    ``_await(None)`` in the eval path silently ATE the Solve's
+    ``{"progress": "compiling", "data_plots": ...}`` message (review 1.5).
+    Both are structurally impossible now -- an eval never sees a message
+    addressed to the Solve, so there is nothing for it to steal or drop.
+
+    A message whose id nobody is waiting on (a superseded request, or an answer
+    that arrived after its caller gave up) is DROPPED at the reader, which is
+    the only place that decision is made.
+
+    Waiting is bounded twice over: a worker that DIES raises immediately, and a
+    worker that hangs while still alive -- a pytensor compile deadlock, native
+    code, an OOM-frozen child -- is terminated and respawned when its silence
+    deadline expires (review 1.4).
     """
 
     def __init__(self):
@@ -243,6 +326,14 @@ class EvaluatorWorker:
         self._req_q = self._ctx.Queue()
         self._resp_q = self._ctx.Queue()
         self._proc = None
+        # Response demultiplexer.  _cv guards all four fields below; its lock
+        # is an RLock so a waiter can stop the reader without releasing it.
+        self._cv = threading.Condition(threading.RLock())
+        self._inbox: dict = {}  # request id -> [messages], oldest first
+        self._pending: dict = {}  # request id -> generation it was sent in
+        self._generation = 0  # bumped by every restart / close
+        self._reader = None
+        self._reader_stop = None
 
     def start(self):
         if self._proc is not None and self._proc.is_alive():
@@ -257,58 +348,207 @@ class EvaluatorWorker:
 
     def solve(self, config, params, workdir, on_progress=None):
         """Run a full solve; block for the result, forwarding progress states."""
+        rid = self._begin_request()
         self._req_q.put(
             {
                 "op": "solve",
+                "id": rid,
                 "config": config,
                 "params": params,
                 "workdir": workdir,
             }
         )
-        return self._await(on_progress)
+        return self._await(rid, on_progress, SOLVE_TIMEOUT_S)
 
     def set_and_eval(self, path, value):
         """Move one parameter and return the updated model traces."""
-        self._req_q.put({"op": "eval", "path": path, "value": value})
-        return self._await(None)
+        rid = self._begin_request()
+        self._req_q.put(
+            {"op": "eval", "id": rid, "path": path, "value": value}
+        )
+        return self._await(rid, None, EVAL_TIMEOUT_S)
 
-    def _next_message(self):
-        """Next queue message, raising if the worker died without answering.
+    # -- request bookkeeping ------------------------------------------------
 
-        Polls rather than blocking forever on ``get()``: a worker that dies --
-        or is closed out from under an in-flight solve, which is what opening a
-        different project does -- never answers, and an unbounded get() would
-        wedge the caller. The server's tune pool has a single slot, so one such
-        stuck thread would block every later solve.
+    def _begin_request(self):
+        """Mint a request id and register it BEFORE the request is sent.
+
+        Registering first is what makes the reader's drop rule safe: an id it
+        does not know is one nobody will ever wait for, never one whose caller
+        has not got around to registering yet.
         """
-        while True:
-            try:
-                return self._resp_q.get(timeout=_AWAIT_POLL_S)
-            except queue.Empty:
-                if self.is_alive():
-                    continue
-                try:
-                    # Last drain: the child may have answered as it exited,
-                    # with the payload still in flight through the pipe.
-                    return self._resp_q.get(timeout=_AWAIT_POLL_S)
-                except queue.Empty:
-                    raise RuntimeError("evaluator worker exited") from None
+        rid = uuid.uuid4().hex
+        with self._cv:
+            self._pending[rid] = self._generation
+        return rid
 
-    def _await(self, on_progress):
-        while True:
-            msg = self._next_message()
-            if "progress" in msg:
-                if on_progress:
-                    # The full message: phase string plus any payload riding
-                    # along (data_plots). TuneSession._progress also accepts a
-                    # bare phase string for simpler worker stubs.
-                    on_progress(msg)
+    def _end_request(self, rid):
+        with self._cv:
+            self._pending.pop(rid, None)
+            self._inbox.pop(rid, None)
+
+    # -- response demultiplexer --------------------------------------------
+
+    def _ensure_reader(self):
+        """Start the reader thread for the CURRENT response queue, if needed."""
+        with self._cv:
+            if self._reader is not None and self._reader.is_alive():
+                return
+            stop = threading.Event()
+            self._reader_stop = stop
+            self._reader = threading.Thread(
+                target=self._reader_loop,
+                args=(self._resp_q, stop),
+                daemon=True,
+                name="exozippy-tune-reader",
+            )
+            self._reader.start()
+
+    def _stop_reader(self):
+        with self._cv:
+            stop, self._reader_stop, self._reader = (
+                self._reader_stop,
+                None,
+                None,
+            )
+        if stop is not None:
+            stop.set()
+
+    def _reader_loop(self, resp_q, stop):
+        """Drain ``resp_q`` and file every message under the id it echoes.
+
+        Bound to the queue it was started with, so a restart's fresh queue gets
+        a fresh reader and this one retires with the process it was reading.
+        """
+        while not stop.is_set():
+            try:
+                msg = resp_q.get(timeout=_AWAIT_POLL_S)
+            except queue.Empty:
                 continue
-            if not msg.get("ok"):
-                raise RuntimeError(msg.get("error", "worker error"))
-            return msg
+            except (OSError, ValueError, EOFError):  # queue closed under us
+                break
+            rid = msg.get("id") if isinstance(msg, dict) else None
+            with self._cv:
+                if rid in self._pending:
+                    self._inbox.setdefault(rid, []).append(msg)
+                    self._cv.notify_all()
+                else:
+                    logger.debug(
+                        "tune: dropping worker message for unclaimed "
+                        "request id %r",
+                        rid,
+                    )
+
+    def _take(self, rid, deadline):
+        """Next message addressed to ``rid``, or raise.
+
+        Raises ``_DeadlineExpired`` on silence, ``RuntimeError`` if the worker
+        died or was restarted out from under this request.
+        """
+        self._ensure_reader()
+        with self._cv:
+            while True:
+                msgs = self._inbox.get(rid)
+                if msgs:
+                    return msgs.pop(0)
+                if (
+                    self._pending.get(rid, self._generation)
+                    != self._generation
+                ):
+                    raise RuntimeError(
+                        "evaluator worker was restarted; this request is void"
+                    )
+                if not self.is_alive():
+                    # Grace: the child may have answered as it exited, with the
+                    # payload still in flight through the pipe and the reader
+                    # yet to file it.
+                    self._cv.wait(_AWAIT_POLL_S)
+                    msgs = self._inbox.get(rid)
+                    if msgs:
+                        return msgs.pop(0)
+                    self._stop_reader()
+                    raise RuntimeError("evaluator worker exited")
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise _DeadlineExpired
+                self._cv.wait(min(_AWAIT_POLL_S, remaining))
+
+    def _await(self, rid, on_progress, timeout):
+        """Block for ``rid``'s answer, forwarding its progress messages.
+
+        ``timeout`` is a SILENCE budget, not a total: every message addressed
+        to this request restarts it, so a job that keeps reporting is never
+        killed for being long, only for going quiet.
+        """
+        deadline = time.monotonic() + timeout
+        try:
+            while True:
+                try:
+                    msg = self._take(rid, deadline)
+                except _DeadlineExpired:
+                    self._hard_restart()
+                    raise WorkerTimeout(
+                        f"evaluator worker stopped responding "
+                        f"(no message for {timeout:.0f}s); it was terminated "
+                        f"and respawned -- press Solve again"
+                    ) from None
+                deadline = time.monotonic() + timeout
+                if "progress" in msg:
+                    if on_progress:
+                        # The full message: phase string plus any payload
+                        # riding along (data_plots). TuneSession._progress also
+                        # accepts a bare phase string for simpler worker stubs.
+                        on_progress(msg)
+                    continue
+                if not msg.get("ok"):
+                    raise RuntimeError(msg.get("error", "worker error"))
+                return msg
+        finally:
+            self._end_request(rid)
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def _hard_restart(self):
+        """Kill a wedged worker and spawn a clean one on fresh queues.
+
+        The queues are replaced rather than reused: a process killed mid-write
+        can leave a partial pickle in the pipe, and every later ``get()`` would
+        inherit that. Bumping the generation releases any OTHER request waiting
+        on the dead process immediately, instead of leaving it to burn its own
+        deadline and terminate the fresh worker in turn.
+        """
+        proc, self._proc = self._proc, None
+        self._stop_reader()
+        if proc is not None:
+            try:
+                proc.terminate()
+                proc.join(timeout=2.0)
+                if proc.is_alive():  # pragma: no cover - SIGTERM ignored
+                    proc.kill()
+                    proc.join(timeout=2.0)
+            except Exception:  # noqa: BLE001 - best effort; we respawn anyway
+                logger.debug("tune: terminate failed", exc_info=True)
+        for q in (self._req_q, self._resp_q):
+            try:
+                q.cancel_join_thread()
+                q.close()
+            except Exception:  # noqa: BLE001 - best effort
+                logger.debug("tune: queue close failed", exc_info=True)
+        self._req_q = self._ctx.Queue()
+        self._resp_q = self._ctx.Queue()
+        with self._cv:
+            self._generation += 1
+            self._inbox.clear()
+            self._cv.notify_all()
+        logger.warning("tune: evaluator worker was wedged; respawning")
+        self.start()
 
     def close(self):
+        with self._cv:
+            self._generation += 1  # release anyone still waiting
+            self._inbox.clear()
+            self._cv.notify_all()
+        self._stop_reader()
         if self._proc is None:
             return
         try:
@@ -406,11 +646,30 @@ class TuneSession:
         return self.phase
 
     def eval(self, path, value):
-        """Move one parameter (LIVE mode only) and return updated traces."""
-        if self._worker is None or self.phase != "live":
+        """Move one parameter (LIVE mode only) and return updated traces.
+
+        The phase gate is read WITHOUT the lock and the call is made outside
+        it, deliberately.  Taking the lock across either would serialize the
+        slider against a seconds-long Solve (and, with a deadline in play, let
+        one wedged eval hold the lock long enough to block the next Solve's
+        respawn).  Neither needs the lock any more: the worker addresses every
+        response by request id, so an eval that slips through the gate
+        microseconds before a re-Solve starts can only ever receive its OWN
+        answer -- or a clean "worker was restarted" error.  That is the half of
+        review 1.5 the gate could not close.
+        """
+        worker = self._worker
+        if worker is None or self.phase != "live":
             raise RuntimeError("no live evaluator; press Solve first")
-        with self._lock:
-            return self._worker.set_and_eval(path, value)
+        try:
+            return worker.set_and_eval(path, value)
+        except WorkerTimeout as exc:
+            # The worker was terminated and respawned, so it no longer holds
+            # the compiled evaluator: nothing is live until the next Solve, and
+            # the UI has to be told that rather than left on stale sliders.
+            self.error = str(exc)
+            self.phase = "error"
+            raise
 
     def status(self):
         return {

--- a/tests/test_gui_tune.py
+++ b/tests/test_gui_tune.py
@@ -17,6 +17,7 @@ skipped when the optional 'gui' extra is absent.
 import os
 import queue
 import shutil
+import threading
 import time
 from pathlib import Path
 
@@ -377,3 +378,243 @@ def test_worker_await_raises_when_the_process_dies(monkeypatch):
 
     with pytest.raises(RuntimeError, match="worker exited"):
         worker.solve({}, {}, None)
+
+
+# ---------------------------------------------------------------------------
+# Worker protocol: request ids and the silence deadline (review 1.4 / 1.5)
+# ---------------------------------------------------------------------------
+
+
+class _FakeChild:
+    """A stand-in for the worker subprocess, driven from a thread.
+
+    Speaks the real queue protocol (reads request dicts, echoes their ``id``)
+    with none of the pytensor cost, and lets a test decide exactly when each
+    reply is sent -- which is what makes the cross-wiring race deterministic
+    instead of a sleep-and-hope.
+    """
+
+    def __init__(self, worker):
+        self.worker = worker
+        self.requests = {}  # op -> request dict
+        self.arrived = threading.Event()
+
+    def collect(self, n, timeout=5.0):
+        """Block until ``n`` requests have been received; return them by op."""
+        deadline = time.time() + timeout
+        while len(self.requests) < n and time.time() < deadline:
+            try:
+                req = self.worker._req_q.get(timeout=0.05)
+            except queue.Empty:
+                continue
+            self.requests[req["op"]] = req
+        assert len(self.requests) == n, self.requests
+        return self.requests
+
+    def reply(self, op, payload):
+        self.worker._resp_q.put(
+            {"ok": True, "id": self.requests[op]["id"], **payload}
+        )
+
+    def progress(self, op, payload):
+        self.worker._resp_q.put({"id": self.requests[op]["id"], **payload})
+
+
+def _plain_queue_worker(monkeypatch, alive=True):
+    """An EvaluatorWorker wired to plain queues, with no real subprocess."""
+    from exozippy.gui import tune
+
+    monkeypatch.setattr(tune, "_AWAIT_POLL_S", 0.01)
+    worker = tune.EvaluatorWorker()
+    worker._req_q = queue.Queue()
+    worker._resp_q = queue.Queue()
+    monkeypatch.setattr(type(worker), "is_alive", lambda self: alive)
+    return worker
+
+
+def test_a_response_for_a_superseded_request_is_ignored(monkeypatch):
+    """
+    Given a worker that emits a reply addressed to some OTHER (superseded)
+        request before the reply to the live one,
+    When the caller waits for its own answer,
+    Then it returns its own payload and never the stale one (review 1.5: the
+        shared response queue used to hand back whatever arrived first).
+    """
+    worker = _plain_queue_worker(monkeypatch)
+    child = _FakeChild(worker)
+    got = {}
+
+    def run():
+        got["res"] = worker.set_and_eval("orbit.b.logP", 0.6)
+
+    caller = threading.Thread(target=run, daemon=True)
+    caller.start()
+    child.collect(1)
+
+    # A reply for a request nobody is waiting on any more, then the real one.
+    worker._resp_q.put({"ok": True, "id": "superseded", "plots": "STALE"})
+    child.reply("eval", {"plots": "MINE"})
+
+    caller.join(timeout=5.0)
+    assert not caller.is_alive()
+    assert got["res"]["plots"] == "MINE"
+
+
+def test_a_concurrent_eval_and_solve_do_not_cross_wire(monkeypatch):
+    """
+    Given a solve and a slider eval in flight against one worker at once,
+    When the worker answers the eval first and the solve second,
+    Then each caller gets its own payload and the solve's progress message
+        (with its data_plots) reaches the solve's handler instead of being
+        eaten by the eval's wait -- the whole of review 1.5, race and bonus
+        defect alike.
+    """
+    worker = _plain_queue_worker(monkeypatch)
+    child = _FakeChild(worker)
+    got = {}
+    progress = []
+
+    def run_solve():
+        got["solve"] = worker.solve(
+            {"star": []}, {}, None, on_progress=progress.append
+        )
+
+    def run_eval():
+        got["eval"] = worker.set_and_eval("orbit.b.logP", 0.6)
+
+    threads = [
+        threading.Thread(target=run_solve, daemon=True),
+        threading.Thread(target=run_eval, daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    child.collect(2)  # both requests are queued before either is answered
+
+    child.progress("solve", {"progress": "compiling", "data_plots": ["DATA"]})
+    child.reply("eval", {"plots": "EVAL"})
+    child.reply("solve", {"parameters": {}, "plots": ["SOLVE"]})
+
+    for t in threads:
+        t.join(timeout=5.0)
+        assert not t.is_alive()
+    assert got["eval"]["plots"] == "EVAL"
+    assert got["solve"]["plots"] == ["SOLVE"]
+    assert progress == [
+        {
+            "id": child.requests["solve"]["id"],
+            "progress": "compiling",
+            "data_plots": ["DATA"],
+        }
+    ]
+
+
+class _FakeProc:
+    """Records terminate/join instead of owning a real subprocess."""
+
+    def __init__(self):
+        self.terminated = False
+
+    def is_alive(self):
+        return not self.terminated
+
+    def terminate(self):
+        self.terminated = True
+
+    def join(self, timeout=None):
+        pass
+
+
+def test_a_hung_but_alive_worker_is_terminated_and_respawned(monkeypatch):
+    """
+    Given a worker process that is alive but has stopped answering,
+    When a request's silence deadline expires,
+    Then the parent terminates it, respawns, and raises WorkerTimeout -- it
+        does not block forever (review 1.4: a compile deadlock or an
+        OOM-frozen child used to wedge every later Solve until a restart).
+    """
+    from exozippy.gui import tune
+
+    worker = _plain_queue_worker(monkeypatch)
+    monkeypatch.setattr(tune, "EVAL_TIMEOUT_S", 0.2)
+    proc = _FakeProc()
+    worker._proc = proc
+    respawns = []
+    monkeypatch.setattr(
+        type(worker), "start", lambda self: respawns.append(True)
+    )
+
+    started = time.time()
+    with pytest.raises(tune.WorkerTimeout, match="stopped responding"):
+        worker.set_and_eval("orbit.b.logP", 0.6)
+    elapsed = time.time() - started
+
+    assert proc.terminated is True
+    assert respawns == [True]
+    assert elapsed < 3.0, elapsed  # bounded by the deadline, not unbounded
+
+
+def test_a_restart_releases_a_second_in_flight_request(monkeypatch):
+    """
+    Given two requests in flight when one of them times out,
+    When the wedged worker is terminated and respawned,
+    Then the OTHER caller is released with a clear error at once rather than
+        burning its own deadline and terminating the fresh worker in turn.
+    """
+    from exozippy.gui import tune
+
+    worker = _plain_queue_worker(monkeypatch)
+    monkeypatch.setattr(tune, "EVAL_TIMEOUT_S", 0.2)
+    monkeypatch.setattr(tune, "SOLVE_TIMEOUT_S", 60.0)
+    worker._proc = _FakeProc()
+    monkeypatch.setattr(type(worker), "start", lambda self: None)
+    err = {}
+
+    def run_solve():
+        try:
+            worker.solve({"star": []}, {}, None)
+        except RuntimeError as exc:
+            err["solve"] = str(exc)
+
+    solver = threading.Thread(target=run_solve, daemon=True)
+    solver.start()
+    _FakeChild(worker).collect(1)
+
+    with pytest.raises(tune.WorkerTimeout):
+        worker.set_and_eval("orbit.b.logP", 0.6)  # trips the short deadline
+
+    solver.join(timeout=5.0)
+    assert not solver.is_alive()
+    assert "restarted" in err["solve"]
+
+
+def test_a_timed_out_eval_leaves_the_session_needing_a_resolve(monkeypatch):
+    """
+    Given a live session whose worker hangs during a slider eval,
+    When the eval times out,
+    Then the session reports the error phase -- the respawned worker holds no
+        compiled evaluator, so the UI must ask for a Solve, not keep sliding.
+    """
+    from exozippy.gui import tune
+
+    class _HangingWorker:
+        def start(self):
+            pass
+
+        def is_alive(self):
+            return True
+
+        def set_and_eval(self, path, value):
+            raise tune.WorkerTimeout("worker stopped responding")
+
+        def close(self):
+            pass
+
+    session = tune.TuneSession(worker_factory=_HangingWorker)
+    session._worker = _HangingWorker()
+    session.phase = "live"
+
+    with pytest.raises(tune.WorkerTimeout):
+        session.eval("orbit.b.logP", 0.6)
+
+    assert session.phase == "error"
+    assert "stopped responding" in session.error


### PR DESCRIPTION
Fixes item **6.5** of `notes/code_review_20260808.txt`, which closes GUI review **1.4** and the **1.5** residual from `notes/code_review_20260717.txt`. All changes are local to `gui/tune.py` (plus its tests and `gui.md`).

## What was wrong

The Tune tab's worker protocol was two multiprocessing queues with no addressing and no bound on waiting.

**No request ids (1.5).** Whichever parent thread called `get()` first took whatever message arrived. A Solve runs on the single-slot `tune_pool` while `POST /api/tune/eval` runs on FastAPI's threadpool, so the two really do overlap. Consequences, both reproduced: an eval could return the *Solve's* payload (and leave the Solve waiting forever), and the eval's `_await(None)` silently **ate** the Solve's `{"progress": "compiling", "data_plots": ...}` message. `TuneSession.eval`'s phase gate narrowed the window but could not close it -- the gate is read **unlocked** and `solve()`'s put+await is deliberately **outside** the session lock.

**No deadline for a hung-but-alive worker (1.4).** `_next_message` raises on a *dead* worker (added in #111 for 2.11.1), but a worker that hangs while still `is_alive()` -- a pytensor compile deadlock, a wedge in native code, an OOM-frozen child -- hit `if self.is_alive(): continue` and looped forever, wedging every later Solve until the server was restarted.

## What changed

**1. Every request carries a uuid; the worker echoes it on every message it sends back**, progress included. One reader thread drains the response queue and files each message under the id it echoes; each caller waits only on its own id; a message nobody is waiting on is dropped at the reader (the only place that decision is made). The id, not a lock, is what makes the unlocked phase gate safe -- so `eval`'s lock is **dropped rather than widened**: widening it would serialize the slider behind a seconds-long Solve, and holding it across a wedged eval would block the next Solve's respawn for the whole deadline.

**2. Silence has a deadline.** `SOLVE_TIMEOUT_S = 900`, `EVAL_TIMEOUT_S = 120`; every message restarts the clock, so a job is killed only for going quiet, never for being long. Deliberately generous and read at call time (monkeypatchable): a false positive throws away a compile that was about to finish and looks, from the UI, exactly like the bug the deadline is there to fix. A first Solve is legitimately silent for tens of seconds (minutes on a big topology + cold cache); an eval is milliseconds but its first call can lazily compile plotters.

On expiry the parent terminates the process, replaces **both** queues (a process killed mid-write can leave a partial pickle in the pipe), respawns, and raises `WorkerTimeout` -- a `RuntimeError`, so `TuneSession.solve` surfaces it as the error phase and `/api/tune/eval` as a 409. A restart bumps a generation counter that releases any **other** in-flight request immediately, instead of leaving it to burn its own deadline and terminate the fresh worker in turn. A timed-out eval sets the session to `error`, since the respawned worker holds no compiled evaluator.

**3. The dropped `data_plots` message is fixed structurally**: the Solve's progress message is addressed to the Solve, so the eval never sees it and has nothing to drop.

## Testing

Five new tests drive a fake child that speaks the real queue protocol (no pytensor), with explicit ordering rather than sleeps:

- a response for a superseded request is ignored;
- a concurrent eval + Solve, answered out of order, each get their own payload, and the Solve's `data_plots` reaches its handler;
- a hung-but-alive worker is terminated and respawned inside its deadline;
- the restart releases a second in-flight request with a clear error;
- a timed-out eval leaves the session needing a re-Solve.

Verified the race tests bite: with the id routing replaced by the old FIFO behavior, the Solve's caller gets the eval's payload (`plots: "EVAL"`) and the eval thread hangs forever.

GUI suite: **85 passed** (`tests/test_gui_*.py tests/test_run_endpoints.py`).

**End-to-end smoke test** (real uvicorn server on a fresh port, real solve, driven over HTTP with urllib): kelt4 RV-only reached `solving -> compiling -> live` in 30.6 s with the data-only plots delivered mid-solve, 50 parameters / 2 panels; slider evals returned 2 updated panels in 20 ms; 60 evals hammered through a re-Solve produced no cross-wiring (59 cleanly refused by the phase gate with 409, the one that raced through returned its own payload), and the post-re-Solve eval was 200 with 2 panels.

No frontend files were touched, so no bundle rebuild.

## Deliberately out of scope

A **cancel endpoint**. Nothing lets a user abandon an in-flight Solve early; the deadline covers the wedged case, but a deliberate cancel needs a UI affordance and a request-scoped abort, not just `worker.close()`. Recorded in `gui.md`. Related small gap, also left alone: `TuneTab.doEval` swallows eval errors ("transient; sliders stay usable"), so a timed-out eval's 409 is only visible once the status poll runs again -- the server-side state is correct either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)