### PR TITLE
config: one owner for the params.yaml sub-key vocabulary (review 6.7)

### DIFF
--- a/src/exozippy/components/factory.py
+++ b/src/exozippy/components/factory.py
@@ -38,8 +38,19 @@ def discover_components():
     # 1. Start at the components directory
     components_dir = Path(__file__).parent
 
-    # 2. Use rglob to search recursively through all subfolders
-    for file in components_dir.rglob("*.py"):
+    # 2. Use rglob to search recursively through all subfolders.  Sorted, for
+    # the reason ConfigManager's two walks are (see config.py): rglob yields
+    # filesystem directory order, which is stable on one machine and differs
+    # between machines (ext4's hashed btree vs xfs/NFS), so it survives
+    # PYTHONHASHSEED randomization and looks reproducible until two boxes are
+    # compared.  Lower stakes here than there -- `registry` is keyed by
+    # yaml_key and System instantiates in the user's config key order -- so
+    # what this pins is module IMPORT order: PHYSICS_REGISTRY insertion order
+    # (and which of two colliding names its duplicate error blames),
+    # _IMPORT_FAILURES order, utilities/registry.all_utilities() order, and
+    # the last-wins tie-break if two Component subclasses ever declared the
+    # same yaml_key.  One word of insurance.
+    for file in sorted(components_dir.rglob("*.py")):
         # Skip infrastructure files
         if file.name in [
             "__init__.py",

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -16,6 +16,45 @@ import re
 
 from exozippy.linking import extract_links
 
+# --- The per-parameter sub-key vocabulary --------------------------------
+#
+# These are THE sub-keys a params.yaml entry may carry, i.e. exactly what
+# ConfigManager.resolve() below absorbs from a user override dict.  They live
+# at module scope because three places need the same answer and used to
+# restate it: resolve() itself, diagnostics.ModelAuditor.check_unused_yaml
+# (which warns that anything else "did not match any model parameter"), and
+# introspect._parameter_entry (which exposes the numeric fields to the GUI).
+# The copies drifted -- diagnostics was missing latex/description/
+# print_to_table/debug_print and so reported four legitimate keys as typos,
+# and introspect was missing bound_scale.  A false "ignored" warning is worse
+# than silence: it teaches users to disbelieve the startup check.  Add a new
+# sub-key here and to the loop in resolve() that consumes it, and every
+# consumer follows.  tests/test_known_keys.py cross-checks the constants
+# against what resolve() really reads, in both directions.
+
+# Preliminary conditioning only, never a posterior term.  init_scale is no
+# longer user-facing (ConfigManager strips it with a warning), but it stays in
+# the vocabulary: resolve() still fills it from defaults/hints, and pre-2026-07
+# mkprior restart files name it, so flagging it as a typo would be wrong.
+TUNING_KEYS = ("initval", "init_scale")
+
+# Keys that change the posterior.  bound_scale is one of them: it sets
+# soft-bound barrier steepness, a real posterior term (unlike init_scale).
+# A user entry touching any of these marks the parameter prior-modified.
+PHYSICS_KEYS = ("lower", "upper", "mu", "sigma", "bound_scale")
+
+# Every field resolve() reads as a number and scales by the element's unit.
+NUMERIC_KEYS = TUNING_KEYS + PHYSICS_KEYS
+
+# Passed through verbatim; per element when the parameter is a vector.
+STRING_KEYS = ("unit", "latex", "description")
+
+# Reporting switches; whole-parameter, not per element.
+BOOL_KEYS = ("print_to_table", "debug_print")
+
+# The union: the complete set of legal sub-keys.
+USER_PARAM_KEYS = NUMERIC_KEYS + STRING_KEYS + BOOL_KEYS
+
 
 class SymbolicTimeout(Exception):
     pass
@@ -995,12 +1034,11 @@ class ConfigManager:
             "debug_print": base.get("debug_print", None),
         }
 
-        tuning_keys = ["initval", "init_scale"]
-        # bound_scale is a physics key: it sets soft-bound barrier steepness,
-        # a real posterior term (unlike init_scale, which is preliminary
-        # conditioning only and not user-facing).
-        physics_keys = ["lower", "upper", "mu", "sigma", "bound_scale"]
-        all_numeric = tuning_keys + physics_keys
+        # The sub-key vocabulary is declared once at module scope (see
+        # USER_PARAM_KEYS); diagnostics.py and introspect.py read the same
+        # constants instead of restating them.
+        physics_keys = PHYSICS_KEYS
+        all_numeric = NUMERIC_KEYS
 
         for key in all_numeric:
             val = base.get(key)
@@ -1151,7 +1189,7 @@ class ConfigManager:
                                     f"{resolved[key][i]:g}."
                                 )
 
-                    for str_key in ["unit", "latex", "description"]:
+                    for str_key in STRING_KEYS:
                         if str_key in ov:
                             if n_elements > 1:
                                 if not isinstance(resolved[str_key], list):
@@ -1162,7 +1200,7 @@ class ConfigManager:
                             else:
                                 resolved[str_key] = ov[str_key]
 
-                    for bool_key in ["print_to_table", "debug_print"]:
+                    for bool_key in BOOL_KEYS:
                         if bool_key in ov:
                             resolved[bool_key] = ov[bool_key]
 

--- a/src/exozippy/diagnostics.py
+++ b/src/exozippy/diagnostics.py
@@ -2,6 +2,22 @@ from typing import Dict
 
 import numpy as np
 
+from .config import USER_PARAM_KEYS
+
+# Sub-keys that resolve() does NOT read but that legitimately appear in a
+# params file, so warning about them would be a false positive:
+#
+#   derived -- ConfigManager.finalize_user_params injects it into its OWN
+#   deepcopy of the entries when it writes a solved initval back.  The
+#   auditor reads system.user_params, the file as written, so this normally
+#   never appears there; it is accepted for the case where a caller of
+#   run_fit(config, user_params=...) round-trips an exported dict.
+_INERT_SUBKEYS = ("derived",)
+
+# What check_unused_yaml accepts.  Derived from config.py's own vocabulary,
+# never restated -- the two used to drift (see USER_PARAM_KEYS' comment).
+VALID_SUBKEYS = frozenset(USER_PARAM_KEYS) | frozenset(_INERT_SUBKEYS)
+
 
 class ModelAuditor:
     def __init__(self, model, system, transformed_inits):
@@ -83,23 +99,11 @@ class ModelAuditor:
                 unused_items.append(k)
 
         # 2. Ignored Sub-Keys (e.g., spelled 'intival' instead of 'initval')
-        # These are the exact and ONLY keys ConfigManager.resolve absorbs.
-        valid_subkeys = {
-            "initval",
-            "init_scale",
-            "lower",
-            "upper",
-            "mu",
-            "sigma",
-            "bound_scale",
-            "derived",
-            "unit",
-        }
-
+        # VALID_SUBKEYS is config.py's own vocabulary, not a second copy.
         for k, ov in self.user_params.items():
             if k in used_keys and isinstance(ov, dict):
                 for sub_k in ov.keys():
-                    if sub_k not in valid_subkeys:
+                    if sub_k not in VALID_SUBKEYS:
                         unused_items.append(f"{k} -> '{sub_k}'")
 
         return unused_items

--- a/src/exozippy/introspect.py
+++ b/src/exozippy/introspect.py
@@ -25,17 +25,14 @@ from pathlib import Path
 import yaml
 
 from .components.factory import discover_components
+from .config import NUMERIC_KEYS
 
 # Numeric parameter fields (in defaults.yaml) that a GUI cares about.
-# Order here is the order they are emitted in the schema.
-_NUMERIC_FIELDS = (
-    "initval",
-    "init_scale",
-    "lower",
-    "upper",
-    "sigma",
-    "mu",
-)
+# Exactly the numeric sub-keys ConfigManager.resolve() absorbs -- this used
+# to be a third hand-maintained copy and had already lost ``bound_scale``,
+# so a defaults.yaml that set a barrier width would not have shown it in the
+# schema.  Order here is the order they are emitted in the schema.
+_NUMERIC_FIELDS = NUMERIC_KEYS
 
 # Descriptive (non-numeric) fields we pass through verbatim when present.
 _DESCRIPTIVE_FIELDS = (

--- a/tests/test_known_keys.py
+++ b/tests/test_known_keys.py
@@ -1,14 +1,16 @@
 # tests/test_known_keys.py
-"""Anti-drift cover for the two hand-maintained "known key" vocabularies.
+"""Anti-drift cover for the hand-maintained "known key" vocabularies.
 
-EXOZIPPy warns about unrecognized keys in exactly two places:
+EXOZIPPy warns about unrecognized keys in exactly three places:
 
   * ``System.__init__`` -- top-level YAML keys that are neither a registered
     component nor in ``system.RESERVED_CONFIG_KEYS``;
   * ``run.warn_unknown_sampler_keys`` -- keys inside the ``sampler:`` block
-    that are not in ``run.KNOWN_SAMPLER_KEYS``.
+    that are not in ``run.KNOWN_SAMPLER_KEYS``;
+  * ``diagnostics.ModelAuditor.check_unused_yaml`` -- per-parameter SUB-keys
+    inside a params.yaml entry that are not in ``diagnostics.VALID_SUBKEYS``.
 
-Both warnings say the key "will be ignored". When the declared set falls
+All three warnings say the key "will be ignored". When the declared set falls
 behind the set the code actually consumes, that statement becomes false --
 worse than silence, because it teaches users to disbelieve the warnings.
 That is exactly what happened to ``modes``/``mkparam``/``gui`` (honored by
@@ -28,6 +30,9 @@ import pathlib
 
 import pytest
 
+from exozippy import config as config_mod
+from exozippy import diagnostics as diagnostics_mod
+from exozippy import introspect as introspect_mod
 from exozippy.components.factory import discover_components
 from exozippy.run import KNOWN_SAMPLER_KEYS, warn_unknown_sampler_keys
 from exozippy.system import RESERVED_CONFIG_KEYS, System
@@ -121,6 +126,175 @@ def _scan_sampler_cfg_keys():
         key: {f"run.py:{line}" for line in lines}
         for key, lines in _literal_keys_accessed(tree, {"sampler_cfg"}).items()
     }
+
+
+def _resolve_fn():
+    """The ``ConfigManager.resolve`` FunctionDef, parsed from config.py."""
+    tree = ast.parse((SRC / "config.py").read_text(encoding="utf-8"))
+    for cls in ast.walk(tree):
+        if isinstance(cls, ast.ClassDef) and cls.name == "ConfigManager":
+            for fn in cls.body:
+                if (
+                    isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and fn.name == "resolve"
+                ):
+                    return fn
+    raise AssertionError("ConfigManager.resolve not found in config.py")
+
+
+def _scan_resolved_subkeys():
+    """Every per-parameter sub-key ``ConfigManager.resolve`` reads.
+
+    Structural, in three steps, so the answer follows a refactor instead of
+    having to be re-typed after one:
+
+      1. find the locals resolve() binds from ``self.user_params`` -- those
+         hold ONE user override entry (``entry``, ``ov``);
+      2. collect every sub-key tested or subscripted against them, i.e.
+         ``"unit" in entry``, ``ov[key]``, ``ov.get(...)``;
+      3. where the sub-key is a loop variable, resolve it back through any
+         local alias to the module-level constant it iterates over and read
+         that constant's real value off the imported module.
+
+    Returns (keys, unresolved) -- the second is every name step 3 could not
+    resolve, which the test asserts is empty rather than silently shrinking
+    the vocabulary.
+    """
+    fn = _resolve_fn()
+
+    # (1) locals bound from self.user_params.
+    def _touches_user_params(node):
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Subscript):
+                if _expr_src(sub.value) == "self.user_params":
+                    return True
+            if isinstance(sub, ast.Call) and isinstance(
+                sub.func, ast.Attribute
+            ):
+                if _expr_src(sub.func.value) == "self.user_params":
+                    return True
+        return False
+
+    entry_names = set()
+    aliases = {}
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        if _touches_user_params(node.value):
+            entry_names.add(target.id)
+        elif isinstance(node.value, ast.Name):
+            # e.g. `all_numeric = NUMERIC_KEYS`
+            aliases[target.id] = node.value.id
+
+    assert entry_names, "no local in resolve() reads self.user_params"
+
+    # (3) loop variable -> the iterable it walks.
+    loop_iter = {}
+    for node in ast.walk(fn):
+        if isinstance(node, (ast.For, ast.comprehension)):
+            if isinstance(node.target, ast.Name) and isinstance(
+                node.iter, ast.Name
+            ):
+                loop_iter[node.target.id] = node.iter.id
+
+    def _constant_value(name):
+        seen = set()
+        while name in aliases and name not in seen:
+            seen.add(name)
+            name = aliases[name]
+        return getattr(config_mod, name, None)
+
+    keys = set()
+    unresolved = set()
+
+    def _record(node):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            keys.add(node.value)
+        elif isinstance(node, ast.Name):
+            value = _constant_value(loop_iter.get(node.id, node.id))
+            if isinstance(value, (list, tuple, set, frozenset)):
+                keys.update(value)
+            else:
+                unresolved.add(node.id)
+        else:
+            unresolved.add(_expr_src(node))
+
+    # (2) sub-keys read off those entries.
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Compare) and len(node.ops) == 1:
+            if (
+                isinstance(node.ops[0], ast.In)
+                and _expr_src(node.comparators[0]) in entry_names
+            ):
+                _record(node.left)
+        elif isinstance(node, ast.Subscript):
+            if _expr_src(node.value) in entry_names:
+                _record(node.slice)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and node.args
+            and _expr_src(node.func.value) in entry_names
+        ):
+            _record(node.args[0])
+
+    return keys, unresolved
+
+
+# One probe value per declared sub-key, used to prove resolve() really
+# applies it (test_no_dead_subkey_vocabulary). The target is star.distance:
+# defaults.yaml gives it initval 10, lower 0.001, upper 1e5, unit pc and no
+# mu/sigma/bound_scale, so 42 moves every numeric field -- apply_value keeps
+# max(lower) and min(upper), and 42 is strictly inside that bracket, so one
+# value serves both bounds. This is a table of VALUES, not of the
+# vocabulary: the vocabulary is still iterated off config.USER_PARAM_KEYS,
+# and a new key with no probe here fails the test by name.
+_SUBKEY_PROBES = {
+    "initval": 42.0,
+    "lower": 42.0,
+    "upper": 42.0,
+    "mu": 42.0,
+    "sigma": 42.0,
+    "bound_scale": 42.0,
+    "unit": "AU",
+    "latex": "D_{probe}",
+    "description": "probe",
+    "print_to_table": False,
+    "debug_print": True,
+}
+
+# Declared, legal in a params file, and deliberately NOT absorbed from a user
+# entry -- so the probe above cannot apply to them.
+_SUBKEYS_INERT_FROM_ENTRY = {
+    # ConfigManager._strip_user_init_scales deletes it at construction (with
+    # a warning) because the whitening scale is measured at startup now. It
+    # stays in the vocabulary so old mkprior restart files are not called
+    # typos, and resolve() still fills the field from defaults and hints.
+    "init_scale",
+}
+
+# Companion keys a probe needs to be a legal entry at all. The baseline is
+# resolved with the same context, so what the test measures is still the
+# effect of the probed key alone.
+_SUBKEY_PROBE_CONTEXT = {
+    # config.validate_sigma_has_center refuses a sigma with no center.
+    "sigma": {"mu": 5.0},
+}
+
+
+def _resolve_star_distance(entry):
+    """Resolve star.distance with ``entry`` as the user's params override."""
+    from exozippy.config import ConfigManager
+
+    user_params = {"star.0.distance": dict(entry)} if entry else {}
+    cm = ConfigManager(user_params, system_config={"star": [{"name": "A"}]})
+    resolved = cm.resolve("star", "distance", shape=(1,))
+    # numpy arrays do not compare with ==; repr is enough to spot a change.
+    return {k: repr(v) for k, v in resolved.items()}
 
 
 def _example_config_files():
@@ -374,3 +548,181 @@ def test_no_example_config_triggers_the_ignored_warning():
     assert offenders == {}, (
         f"example configs using unreserved keys: {offenders}"
     )
+
+
+# ---------------------------------------------------------------------------
+# The third vocabulary: per-parameter SUB-keys inside a params.yaml entry.
+#
+# check_unused_yaml warns "did not match any model parameter" for anything it
+# does not recognize. Its set had drifted the dangerous way -- it was missing
+# latex/description/print_to_table/debug_print, four keys resolve() really
+# absorbs, so setting a LaTeX label on a parameter earned a typo warning about
+# a key that had been applied. There is also a THIRD copy of the same
+# vocabulary in introspect._NUMERIC_FIELDS, which had lost bound_scale.
+# ---------------------------------------------------------------------------
+
+
+def test_every_subkey_resolve_consumes_is_declared():
+    """
+    Given the sub-keys ConfigManager.resolve() really reads off a user
+      override entry, scanned out of config.py's own source,
+    When they are compared with diagnostics.VALID_SUBKEYS,
+    Then every one of them is declared.
+
+    The consumed-but-undeclared direction: an omission here is a FALSE
+    "ignored" warning about a key that was applied, which is worse than
+    silence. latex/description/print_to_table/debug_print were all missing.
+    """
+    # ARRANGE
+    consumed, unresolved = _scan_resolved_subkeys()
+
+    # ACT
+    undeclared = sorted(consumed - set(diagnostics_mod.VALID_SUBKEYS))
+
+    # ASSERT
+    assert unresolved == set(), (
+        f"sub-keys the scan could not resolve statically: {sorted(unresolved)}"
+        " -- the scan, not the vocabulary, needs updating"
+    )
+    assert undeclared == [], (
+        "resolve() absorbs these sub-keys but check_unused_yaml calls them "
+        f"typos: {undeclared}"
+    )
+
+
+def test_no_dead_subkey_vocabulary():
+    """
+    Given every sub-key config.USER_PARAM_KEYS declares,
+    When one is added to a params entry and star.distance is resolved,
+    Then the resolved parameter really changes.
+
+    The declared-but-unconsumed direction, and it has to be BEHAVIORAL: the
+    AST scan resolves ``for key in NUMERIC_KEYS`` to the constant's live
+    value, so it would agree with the constant whatever the constant said.
+    Actually resolving is what a declared-but-never-read key fails. Widening
+    the set to kill the false positives above must not blind the check --
+    accepting a key nothing reads means a real typo that happens to collide
+    with it passes silently.
+    """
+    # ARRANGE
+    vocabulary = set(config_mod.USER_PARAM_KEYS) - _SUBKEYS_INERT_FROM_ENTRY
+    missing_probe = sorted(vocabulary - set(_SUBKEY_PROBES))
+    assert missing_probe == [], (
+        f"no probe value declared for new sub-key(s) {missing_probe}; add "
+        "one to _SUBKEY_PROBES (and if the key cannot be probed because "
+        "nothing reads it off a user entry, that is the bug this test hunts)"
+    )
+
+    # ACT
+    inert = []
+    for key in sorted(vocabulary):
+        context = _SUBKEY_PROBE_CONTEXT.get(key, {})
+        baseline = _resolve_star_distance(context)
+        probed = _resolve_star_distance({**context, key: _SUBKEY_PROBES[key]})
+        if probed == baseline:
+            inert.append(key)
+
+    # ASSERT
+    assert inert == [], (
+        "sub-keys declared in config.USER_PARAM_KEYS that resolve() never "
+        f"applies; either wire them up or drop them: {inert}"
+    )
+
+
+def test_the_inert_subkeys_really_are_inert():
+    """
+    Given diagnostics._INERT_SUBKEYS -- the exemptions to the test above,
+    When each is compared with what resolve() consumes,
+    Then none of them is a key resolve() actually reads.
+
+    An exemption list is the one way to launder a genuine key into "we do
+    not check that one", so the list itself is checked: an entry here must
+    be inert, not merely unaudited.
+    """
+    # ARRANGE
+    consumed, _ = _scan_resolved_subkeys()
+
+    # ACT
+    live = sorted(set(diagnostics_mod._INERT_SUBKEYS) & consumed)
+
+    # ASSERT
+    assert live == [], f"exempted as inert but resolve() reads them: {live}"
+
+
+def test_the_three_subkey_vocabularies_share_one_owner():
+    """
+    Given config.USER_PARAM_KEYS, diagnostics.VALID_SUBKEYS and
+      introspect._NUMERIC_FIELDS,
+    When their provenance is inspected,
+    Then the two consumers are built FROM the config constants rather than
+      restating them.
+
+    Structural on purpose: a test that re-listed the strings would be edited
+    in lockstep with the next drift and catch nothing. Object identity for
+    introspect and a set equation for diagnostics are what a copy-paste
+    reintroduction fails.
+    """
+    # ARRANGE
+    owner = config_mod
+
+    # ACT / ASSERT -- the union is exactly its declared parts.
+    assert set(owner.USER_PARAM_KEYS) == (
+        set(owner.NUMERIC_KEYS) | set(owner.STRING_KEYS) | set(owner.BOOL_KEYS)
+    )
+    assert set(owner.NUMERIC_KEYS) == (
+        set(owner.TUNING_KEYS) | set(owner.PHYSICS_KEYS)
+    )
+
+    # introspect must be the constant itself, not a copy of its contents.
+    assert introspect_mod._NUMERIC_FIELDS is owner.NUMERIC_KEYS
+
+    # diagnostics must be the config vocabulary plus its documented inerts.
+    assert set(diagnostics_mod.VALID_SUBKEYS) == (
+        set(owner.USER_PARAM_KEYS) | set(diagnostics_mod._INERT_SUBKEYS)
+    )
+
+
+def test_a_valid_subkey_is_not_reported_but_a_typo_still_is():
+    """
+    Given a params entry carrying every legal sub-key plus one typo,
+    When check_unused_yaml classifies them,
+    Then only the typo is reported.
+
+    The user-facing half, independent of the AST scan. Both directions in
+    one assertion: on pre-fix src/ this reports latex, description,
+    print_to_table and debug_print alongside 'intival'.
+    """
+
+    # ARRANGE
+    class _FakeParam:
+        label = "star.teff"
+        shape = ()
+
+        def get_display_label(self, i):
+            return "star.A.teff"
+
+    entry = {k: 1 for k in config_mod.USER_PARAM_KEYS}
+    entry["intival"] = 5800
+
+    class _FakeSystem:
+        user_params = {"star.A.teff": entry}
+
+        def get_parameter_lookup(self):
+            return {}
+
+        def get_all_parameters(self):
+            return [_FakeParam()]
+
+    auditor = diagnostics_mod.ModelAuditor.__new__(
+        diagnostics_mod.ModelAuditor
+    )
+    system = _FakeSystem()
+    auditor.system = system
+    auditor.user_params = system.user_params
+    auditor.all_params = system.get_all_parameters()
+
+    # ACT
+    reported = auditor.check_unused_yaml()
+
+    # ASSERT
+    assert reported == ["star.A.teff -> 'intival'"]


### PR DESCRIPTION
Fixes review item **6.7** (`diagnostics.py`'s `valid_subkeys` should come from config.py's actual key lists), plus one adjacent one-word determinism fix flagged separately below.

## The item's diagnosis had inverted

6.7 reported that `valid_subkeys` had drifted to include `derived` and `init_scale`. Verifying that first: **both are fine and both stay.**

- `diagnostics` reads `system.user_params`, the user's file **as written** (`config.py` deepcopies before stripping), so `init_scale` legitimately appears in any pre-2026-07 mkprior restart file. It is stripped from ConfigManager's own copy, with its own warning; calling it a typo as well would be a second, worse message.
- `derived` is injected only into that deepcopy by `finalize_user_params`, so it never reaches the auditor. Dead, but harmless.

**The live defect is the opposite direction**: four keys `resolve()` genuinely absorbs were **missing** from the set, so they were reported as typos on any real build.

### Before (origin/master), after (this branch)

`examples/ob08092` with `star.Lens.teff` carrying every legal sub-key plus one real typo (`intival`). No shipped example sets `latex`/`description`/`print_to_table`, so the params entry is a scratch one:

```
# origin/master
UNUSED: ["star.Lens.teff -> 'debug_print'", "star.Lens.teff -> 'description'",
         "star.Lens.teff -> 'intival'", "star.Lens.teff -> 'latex'",
         "star.Lens.teff -> 'print_to_table'"]

# this branch
UNUSED: ["star.Lens.teff -> 'intival'"]
```

Those five reach the user as *"The following parameters in the parameter.yaml file did not match any model parameter and were not applied: [...] This can be safely ignored if intentional, but check for typos."* Four of the five had been applied. That is the failure mode this file's own docstring names: a false "ignored" warning teaches users to disbelieve the check, and the check's whole job is catching the fifth one.

## One owner

The vocabulary now lives at module scope in `config.py`, where `resolve()` itself reads it:

| constant | keys |
|---|---|
| `TUNING_KEYS` | `initval`, `init_scale` |
| `PHYSICS_KEYS` | `lower`, `upper`, `mu`, `sigma`, `bound_scale` |
| `NUMERIC_KEYS` | `TUNING_KEYS + PHYSICS_KEYS` |
| `STRING_KEYS` | `unit`, `latex`, `description` |
| `BOOL_KEYS` | `print_to_table`, `debug_print` |
| `USER_PARAM_KEYS` | the union |

`resolve()`'s internals are otherwise untouched (the local `physics_keys` / `all_numeric` names remain, bound to the constants), so this should not conflict with the concurrent `resolve()` work.

## The third copy: `introspect._NUMERIC_FIELDS`

It was missing `bound_scale`. **No user-visible GUI consequence today**: `_parameter_entry` only emits fields a parameter's `defaults.yaml` block actually carries, and no shipped `defaults.yaml` sets `bound_scale` (grep: the only hits are prose). The bug was latent -- the first component to declare a barrier width would have found it silently absent from the schema. It is now `NUMERIC_KEYS` itself, by identity.

One cosmetic side effect: `mu` and `sigma` swap positions in the emitted schema dict (the old copy listed `sigma` before `mu`). `tests/test_introspect.py` and `test_gp.py` read fields by name, and `full_schema()` round-trips through JSON either way.

## The drift test is structural in both directions

In `tests/test_known_keys.py`, which was already this file's subject for the other two "known key" vocabularies. Both halves of the drift are covered, and neither restates the strings:

- **consumed-but-undeclared** -- an `ast` scan of `config.py` finds the locals `resolve()` binds from `self.user_params`, collects every sub-key tested or subscripted against them, and resolves loop variables back through local aliases to the module constants they iterate. Adding a literal sub-key handler to `resolve()` without extending the constants fails it.
- **declared-but-unconsumed** -- **behavioral**, and it has to be: the scan resolves `for key in NUMERIC_KEYS` to the constant's live value, so it would agree with the constant whatever the constant said. Each declared key is instead set on a real params entry and `star.distance` is resolved; a key that changes nothing fails. `init_scale` is the one documented exemption (stripped at construction) and `_INERT_SUBKEYS` gets its own test proving its entries really are inert, so the exemption list cannot launder a live key.
- plus a user-facing test that a full legal entry reports nothing and `intival` still reports.

Verified by breaking it three ways -- restoring the pre-fix hardcoded set, adding a never-read key to `BOOL_KEYS`, and moving a live key into `_INERT_SUBKEYS` -- each fails the corresponding test.

## Adjacent one-word fix (flagged as requested)

`components/factory.py` now sorts its `rglob("*.py")` sweep -- the same cross-machine determinism concern as item 6.3, fixed for `ConfigManager`'s two walks in #92 (`f59574f`), whose rationale comment this imitates.

**Can it actually matter?** Not today, and lower stakes than 6.3 by construction: `registry` is keyed by `yaml_key` and `System` instantiates in the user's *config* key order, and `introspect` sorts the registry at every use. What the sweep really pins is module **import** order, whose observable consequences are `PHYSICS_REGISTRY` insertion order (and which of two colliding names its duplicate error blames -- the raise itself is order-independent), `_IMPORT_FAILURES` ordering, `utilities/registry.all_utilities()` ordering, and the last-wins tie-break if two `Component` subclasses ever declared the same `yaml_key`. I checked for that last one: no collision exists (13 keys, 13 distinct classes). On this box the sorted and unsorted sweeps produce the identical registry order. So: one word of insurance, not a bug fix.

## Nothing else moves

All 19 shipped example configs prepared on `origin/master` and on this branch, dumping the fully resolved parameter state per example -- `export_solution`, provenance and scale provenance, resolved values, solved-by relations, manifests, derived set, PyMC build order, structural hash -- plus a static dump of the component registry (sorted and in sweep order), the physics registry, and `introspect.full_schema()`. `diff -r` over the two trees: **byte-identical, zero differences.**

Targeted suites (CI runs the full one): `test_known_keys` `test_introspect` `test_factory` `test_config_discovery_order` `test_config_healing` `test_config_hint_paths` `test_config_provenance` `test_config_units` `test_gui_document` `test_inspect_start` `test_physics_registry` -- 96 passed; `test_examples_prepare` -- 20 passed. `ruff check` + `ruff format` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
