### PR TITLE
docs: comment accuracy in config/whitening/solve_api (review 7.7, 7.9, 7.10)

### DIFF
--- a/src/exozippy/components/parameter.py
+++ b/src/exozippy/components/parameter.py
@@ -998,13 +998,24 @@ class Parameter:
             sigma sets the whitening scale.
           - Unbounded with sigma > 0: raw ~ N(0,1), val = mu + sigma * raw.
             The raw prior IS the Gaussian; no separate potential needed.
+          - Unbounded with NO sigma: linear, val = initval + init_scale * raw.
+            Nothing cancels the raw N(0,1) here either, so this element's
+            prior IS N(initval, init_scale).  build_pymc warns about it (see
+            implicit_prior_idx below), because it is the one case where
+            init_scale is a modeling statement rather than conditioning.
 
         All raw variables are N(0,1). init_scale is always in physical units;
         for logit params it is converted to logit-space internally via the
-        Jacobian and affects only tuning/conditioning, never the posterior.
-        It is only PRELIMINARY: the whitening scales live in pytensor.shared
-        variables, and set_whitening() replaces them in place with the
-        probe-measured posterior scales before sampling (no rebuild needed).
+        Jacobian and affects only tuning/conditioning, never the posterior --
+        that is section C cancelling the raw N(0,1) for ANY scale, and it is
+        why the startup whitening rescale is provably posterior-preserving
+        THERE.  The claim is scoped to that branch and does not extend to the
+        two linear ones above, where the raw N(0,1) is the prior itself; so
+        on a logit element init_scale is only PRELIMINARY (the whitening
+        scales live in pytensor.shared variables, and set_whitening()
+        replaces them in place with the probe-measured posterior scales
+        before sampling, no rebuild needed), while on a linear element
+        set_whitening deliberately leaves the scale alone.
         """
         import pymc as pm
         import pytensor.tensor as pt

--- a/src/exozippy/config.py
+++ b/src/exozippy/config.py
@@ -446,11 +446,15 @@ It makes use of each component's symbolic_physics.py to derive the sampled param
 above, iteratively replacing the lowest ranked parameter with the re-derived value, and updating its weight the 
 average of its constituent weights. 
 
-It repeats the process for init_scale, automatically differentiating the relations in symbolic_physics.py
-to propagate uncertainties.  These scales are only PRELIMINARY (they seed the whitening probe, which
-measures the real per-parameter scales from the data -- see exozippy/whitening.py) and they set the
-soft-bound barrier steepness on derived parameters.  init_scale is NOT user-facing: entries in a user
-params file are stripped with a warning at construction.
+It repeats the process for init_scale, automatically differentiating each relation as it solves it
+(step 6 of _execute_solve) to propagate uncertainties.  These scales are only PRELIMINARY: they seed the
+whitening probe, which measures the real per-parameter scales from the data (see exozippy/whitening.py),
+and they set only the PRELIMINARY soft-bound barrier steepness, which whitening.measure_barrier_scales
+re-measures numerically from the whitened model.  The separate sympy forward and backward Jacobian scale
+PASSES that used to run after the solve loop -- filling derived-parameter scales for good, and
+back-propagating a user scale on a derived parameter to its sampled parents -- are deleted; see the note
+at the end of _execute_solve.  init_scale is NOT user-facing: entries in a user params file are stripped
+with a warning at construction.
 
 3) warns the user if there are conflicting user-specified constraints that cannot be reconciled.
 
@@ -1520,7 +1524,7 @@ class ConfigManager:
         # RANK_DERIVED_DATA; both fall back to the shared base_flat for any
         # path they do not touch), then run the relaxation engine once per
         # seed inside this single prepare() call so every seed shares one symbol
-        # environment (guards against the known cross-build nondeterminism).
+        # environment and one relation ordering.
         # Bounds/scales are taken from seed 0 only -- seeds move the START, never
         # the bounds -- so self.propagated_scales is restored to seed 0's after
         # the loop.
@@ -1888,10 +1892,13 @@ class ConfigManager:
         Reads only in-memory state left behind by finalize_user_params; it does
         NOT build the PyMC model.  Must be called after System.prepare().
 
-        Note: the relaxation engine has a known cross-build nondeterminism (two
-        identical prepares may pick different derived bounds), so the exported
-        bounds/values for solved quantities are one valid solution, not a
-        canonical one.  See the solve_api module docstring.
+        Note: the exported values for solved quantities are one valid
+        solution, not a canonical one -- a system of relations can admit
+        several and the engine picks by a fixed rule.  It is nonetheless
+        REPRODUCIBLE: the cross-build nondeterminism this note used to warn
+        about (unsorted free_symbols / rglob walks) is fixed.  Bounds were
+        never part of it either way; the engine only reads them.  See the
+        solve_api module docstring.
         """
 
         def _clean(x):
@@ -2198,9 +2205,13 @@ class ConfigManager:
 
         # 1.7 LAYER IN USER-SPECIFIED SIGMAS AS SCALES (RANK_USER)
         # A user-supplied Gaussian prior width is also the best available
-        # preliminary scale for that parameter, and the forward Jacobian pass
-        # below propagates it into derived-parameter scales (which set the
-        # soft-bound barrier steepness on derived parameters).  User
+        # preliminary scale for that parameter, and the engine's per-relation
+        # Jacobian propagation (step 6 of _execute_solve) carries it into the
+        # scale of whatever gets solved from it.  The separate forward
+        # Jacobian PASS that used to run after the loop, filling every derived
+        # parameter's scale so it could set that parameter's soft-bound
+        # barrier steepness, is deleted -- those steepnesses are measured
+        # numerically now (whitening.measure_barrier_scales).  User
         # init_scale entries no longer exist at this point -- they are
         # stripped with a warning at construction (whitening scales are
         # measured from the data instead; see exozippy/whitening.py).
@@ -2568,19 +2579,17 @@ class ConfigManager:
 
         # 5. Calculate New Armor
         # Use min(input_ranks) so a chain is only as strong as its weakest link.
-        # Condition A floor is RANK_DEFAULT-1 so an indirectly-derived value
-        # (e.g. ecc from K when secosw/sesinw are unavailable) always yields to
-        # a proper expression-path derivation or a default in Condition B.
-        # Condition B floor is RANK_DEFAULT so conflict resolution never produces
-        # armor weaker than an unseeded default.
         inputs = [s for s in symbols_in_eq if s != target]
         min_input_rank = (
             min(get_rank(s) for s in inputs) if inputs else RANK_DEFAULT
         )
-        # Condition A floor: RANK_DEFAULT-1 so indirect derivations always yield
-        #   to expression-path derivations or defaults in Condition B.
-        # Condition B floor: 0 so low-rank inputs (e.g. pm defaults at rank 10)
-        #   produce low-rank results — preventing them from blocking higher-rank
+        # Condition A floor: RANK_DEFAULT-1 so an indirectly-derived value
+        #   (e.g. ecc from K when secosw/sesinw are unavailable) always yields
+        #   to an expression-path derivation or a default in Condition B.
+        # Condition B floor: 0, NOT RANK_DEFAULT -- a duplicate of this comment
+        #   sat directly above and claimed RANK_DEFAULT, which the line below
+        #   has never done.  0 lets low-rank inputs (e.g. pm defaults at rank
+        #   10) produce low-rank results, so they cannot block higher-rank
         #   derivations from the t_E/theta_E/pi_rel chain.
         rank_floor = RANK_DEFAULT - 1 if len(unknowns) == 1 else 0
         new_rank = max(rank_floor, min(RANK_DERIVED_USER, min_input_rank))

--- a/src/exozippy/solve_api.py
+++ b/src/exozippy/solve_api.py
@@ -21,13 +21,26 @@ workdir).  Data file paths inside a config are relative to workdir, so both
 functions chdir into it for the duration of the solve and restore the previous
 directory afterwards.
 
-Determinism caveat: the relaxation engine has a known cross-build
-nondeterminism -- two identical prepares can pick different derived bounds for
-the same parameter (the lp for one raw point can differ across builds).  A
-SolveResult therefore reports ONE valid solution, not a canonical one; do not
-assume two solve() calls on the same input return byte-identical bounds for
-solved quantities.  This module does not attempt to fix that; it only exposes
-whatever the engine produced.
+Determinism: solve() IS reproducible, and this caveat used to say the
+opposite.  The relaxation engine had a cross-build nondeterminism -- unsorted
+walks of sympy `free_symbols` sets and an unsorted `rglob` of the component
+directories, so ordering followed PYTHONHASHSEED and the filesystem -- and it
+is fixed: every such walk is sorted, and a relation with several roots inside
+the bounds breaks ties by value rather than by sp.solve's arrival order.
+Two solve() calls on the same input return byte-identical values, bounds and
+scales; verified across PYTHONHASHSEED 0/1/7 on ob08092, ob140939, kelt4
+(rv+transit+sed) and DC2018_128, and tests/test_hashseed_determinism.py pins
+the one remaining leak of this kind (MulensModel's set-ordered magnification
+methods, patched in exozippy.compat).
+
+What survives is weaker and is not about determinism: a SolveResult is ONE
+valid solution, not a canonical one.  A system of relations can admit several,
+and the engine picks by a fixed rule (lowest-provenance symbol, then roots
+scored against the other relations) -- reproducible, but not unique.  Note
+this never applied to bounds in the first place: the engine only READS
+lower/upper, to reject roots outside the support.  It never writes them, so
+exported bounds come from defaults.yaml, the component override channel and
+the user's params file exactly as they would with no solve at all.
 
 solve() builds a fresh System (and therefore a fresh ConfigManager) on every
 call, so it is safe to call repeatedly in one process; it does not rely on any

--- a/src/exozippy/whitening.py
+++ b/src/exozippy/whitening.py
@@ -16,9 +16,19 @@ contour; see probe_scales.  Because one raw unit is one preliminary scale by
 construction, the measured step IS the multiplicative correction to the
 preliminary scale.  apply_measured_whitening() feeds it to
 Parameter.set_whitening(), which updates the pytensor.shared whitening scales
-in place -- no model rebuild, and the posterior is provably unchanged (the
-logit-uniform correction potential cancels the raw N(0,1) prior symbolically
-for any scale; the scale affects conditioning only).
+in place -- no model rebuild, and the posterior is provably unchanged.
+
+That proof covers the LOGIT branch only -- an element with two finite bounds,
+where section C of Parameter.build_pymc cancels the raw N(0,1) prior
+symbolically for any scale, so the scale affects conditioning alone.  It is
+exactly the set set_whitening rescales.  Every NON-logit element (anything
+without two finite bounds) is left untouched, because there the raw N(0,1) IS
+the prior: N(mu, sigma) when a sigma was given, and N(initval, init_scale)
+when the bounds are infinite and no sigma was -- the one place init_scale is
+a posterior term rather than conditioning, and one a data-measured multiplier
+would turn into a data-dependent prior width.  build_pymc warns when it builds
+such an element.  So the invariant holds for the pass as a whole, but only
+because the branch it does not hold for is never rescaled.
 
 After the rescale, every raw direction costs ~0.5 nats per unit step: the
 "curvature = -1" conditioning the retired curvature check used to ask users

--- a/tests/test_multiseed_config.py
+++ b/tests/test_multiseed_config.py
@@ -3,9 +3,9 @@
 
 A `params.yaml` entry of the form `initval: [v0, v1, ...]` asks the relaxation
 engine to solve K complete, mutually-consistent start points inside ONE
-prepare() call (sharing one symbol environment -- see the module docstring
-in config.py's finalize_user_params and the project's known relaxation-engine
-cross-build nondeterminism note). Bounds/scales resolve once, from seed 0.
+prepare() call (sharing one symbol environment and one relation ordering --
+see the comment in config.py's finalize_user_params). Bounds/scales resolve
+once, from seed 0.
 """
 
 import numpy as np


### PR DESCRIPTION
Fixes items 7.7, 7.9, 7.10 and 7.11 from section 7 (COMMENT / DOCSTRING ACCURACY) of the 2026-08-08 review. Each claim was verified against current master before acting -- two had gone stale in the reviewers favour and one was already fixed outright.

**Doc-only. The diff touches no executable line.**

## Per-item verdicts

### 7.7 `whitening.py` / `parameter.py` -- "posterior provably unchanged / init_scale never affects the posterior"
**TRUE BUT UNDER-QUALIFIED.** Both halves the review named have moved:
- The `scales <= 1e-12` pin is gone (commit `5d88b90`, "parameter: drop the undocumented init_scale pin").
- `Parameter.set_whitening` now rescales **only** `use_logit` elements and says so at the branch itself, so the invariant does hold for the whitening pass as a whole.

What remained wrong is the *statement* of it. `whitening.py` gave the logit-branch argument without saying it was one, and `build_pymc`s "Sampling cases" list had two entries where the code has three -- it omitted the unbounded, no-sigma element whose prior IS `N(initval, init_scale)`, which is exactly the branch the review flagged. Added the missing case and scoped the claim in both docstrings; the "provably unchanged" argument is kept, since it is real and load-bearing for the logit branch.

### 7.9 -- three sub-claims
**(a) Deleted sympy forward-Jacobian pass: PARTLY STALE.** PR #166 already fixed the `propagated_scales` declaration and `add_scale_hint`. Two sites remained and both pointed at a "forward Jacobian pass below" that no longer exists: the `ConfigManager` class docstring and the `# 1.7 LAYER IN USER-SPECIFIED SIGMAS AS SCALES` comment. Rewritten to name what is actually there -- the per-relation Jacobian propagation in step 6 of `_execute_solve`, which is still live, and `whitening.measure_barrier_scales` for the barrier steepnesses the deleted pass used to set.

**(b) Condition-B rank floor: STILL TRUE.** Two adjacent comment blocks disagreed -- one said the Condition B floor is `RANK_DEFAULT`, the next said `0`. The code says `0` (`rank_floor = RANK_DEFAULT - 1 if len(unknowns) == 1 else 0`). Merged into one accurate block.

**(c) Seed-hint rank: ALREADY TRUE, untouched.** Bug 2.1.2 was fixed by PR #91 and the prose was updated with it. `add_seed_hints` and `mmexofast_support` both document `RANK_DERIVED_DATA`, and `_execute_solve` applies exactly that. `seed_hint_rank` itself no longer exists anywhere in `src/` or `tests/`, and no prose survived it.

### 7.10 `solve_api.py` determinism caveat -- **STALE, and wrong in a second way**
The nondeterminism the caveat describes is fixed (PR #57s sorted `free_symbols` walks and by-value root ties, PR #92s sorted `rglob`s). Measured rather than assumed: two in-process `solve()` calls, and separate interpreters at `PYTHONHASHSEED` 0/1/7, return byte-identical `value`/`lower`/`upper`/`init_scale`/`sigma` for every parameter on `ob08092`, `ob140939`, `kelt4` (rv+transit+sed) and `DC2018_128`.

The caveat was also wrong about its own subject: it blamed "different derived bounds", and the engine has never derived a bound. It only *reads* `lower`/`upper`, to reject roots outside the support -- there is no write anywhere in `config.py`.

Rewritten rather than deleted, because one part is still true and worth saying: a `SolveResult` is one valid solution, not a canonical one (a relation system can admit several roots and the engine picks by a fixed, reproducible rule). The same stale claim appeared in three other places -- `ConfigManager.export_solution`, the multi-seed comment in `finalize_user_params`, and `tests/test_multiseed_config.py`s module docstring -- so all four now agree.

### 7.11 `system.py` `apply_polished_starts` -- **ALREADY TRUE, no change**
Bug 1.18 was fixed by PR #80. `inspect_start` takes `np.atleast_1d(raw_v).copy()`, is documented as a read-only diagnostic at the exact line the mutation used to happen, and treats the `user_params` entry as a fallback rather than re-asserting it. `apply_polished_starts` docstring describes precisely that behaviour, including the `set_whitening` pinning of a nonzero `raw_initval`.

## No code problems found
Nothing in these four items turned out to be a code bug; every live finding was prose describing a state the code left behind.

## Tests
`ruff check` + `ruff format` clean. Run with `-n0`: `test_config_discovery_order`, `test_config_healing`, `test_config_hint_paths`, `test_config_provenance`, `test_config_units`, `test_solve_api`, `test_multiseed_config`, `test_param_specificity`, `test_hashseed_determinism` (62 passed); `test_whitening`, `test_whitening_probe`, `test_inspect_start`, `test_bad_user_input`, `test_initial_solver`, `test_linked_params` (127 passed); `test_gui_app`, `test_gui_data`, `test_gui_document`, `test_gui_run_crash`, `test_gui_tune`, `test_multiseed_system` (74 passed). Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)