### PR TITLE
fix: drop the phantom "TESS" author from getdata (review 11.2)

### DIFF
--- a/src/exozippy/utilities/getdata.py
+++ b/src/exozippy/utilities/getdata.py
@@ -29,12 +29,22 @@ import numpy as np
 # exposure time present in EXPTIME_PRIORITY, and among those the first author
 # present in AUTHOR_PRIORITY. Both are ordered best-first and both are read by
 # the same _highest_priority() helper, so the tables are the documentation.
+#
+# AUTHOR_PRIORITY is also the set of authors run() asks MAST for, so the ranked
+# set and the searched set cannot drift apart. Every entry must be readable --
+# in AUTHOR_MISSION -- or listed in UNSUPPORTED_AUTHORS and ranked below every
+# readable one, or the tie-break can hand run() a product it then discards.
+# "TESS" used to head this table and was neither: it is a lightkurve *mission*
+# ("Kepler", "K2", "TESS"), not an author. Official TESS pipeline products are
+# authored "SPOC" (lightkurve's own search_lightcurve docstring), MAST has no
+# observation with provenance_name = "TESS" (author is a synonym for
+# provenance_name), and lightkurve's AUTHOR_LINKS / result-sort tables do not
+# list it either. So it ranked a value that cannot be returned, first.
 
 # Short cadence first (120, 200, 20 s), then the long-cadence FFI products.
 EXPTIME_PRIORITY = (120, 200, 20, 300, 600, 1800)
 
 AUTHOR_PRIORITY = (
-    "TESS",
     "SPOC",
     "TESS-SPOC",
     "QLP",
@@ -42,6 +52,10 @@ AUTHOR_PRIORITY = (
     "K2SFF",
     "EVEREST",
     "K2",
+    # readable authors above this line; the rest are recognized but unreadable
+    # (UNSUPPORTED_AUTHORS) and so must stay last -- they are ranked at all
+    # only so that a sector offering nothing else is skipped with their own
+    # message rather than the ambiguous-tie one.
     "CDIPS",
     "TASOC",
 )
@@ -350,20 +364,10 @@ def run(args):
     t0 = datetime.datetime(2000, 1, 1)
     jd0 = 2451544.5
 
-    search_results = lk.search_lightcurve(
-        args.id,
-        author=(
-            "SPOC",
-            "TESS-SPOC",
-            "QLP",
-            "TASOC",
-            "CDIPS",
-            "Kepler",
-            "K2",
-            "K2SFF",
-            "EVEREST",
-        ),
-    )
+    # The ranked set IS the searched set: asking for an author nothing ranks
+    # would return products the tie-break then drops, and ranking one nothing
+    # asks for is a dead row. lightkurve does not care about the order here.
+    search_results = lk.search_lightcurve(args.id, author=AUTHOR_PRIORITY)
 
     if len(search_results) == 0:
         print(

--- a/tests/test_getdata.py
+++ b/tests/test_getdata.py
@@ -335,7 +335,6 @@ def test_matching_tic_id_still_selects_its_light_curves(patched, tmp_path):
 
 EXPECTED_EXPTIME_ORDER = [120, 200, 20, 300, 600, 1800]
 EXPECTED_AUTHOR_ORDER = [
-    "TESS",
     "SPOC",
     "TESS-SPOC",
     "QLP",
@@ -513,20 +512,86 @@ def test_cdips_and_tasoc_are_recognized_but_unreadable():
         assert author not in getdata.AUTHOR_MISSION
 
 
-def test_the_author_named_tess_is_ranked_but_has_no_reader():
+# ---------------------------------------------------------------- 11.2
+#
+# The invariant that "TESS" broke: it headed AUTHOR_PRIORITY while appearing in
+# neither AUTHOR_MISSION nor UNSUPPORTED_AUTHORS, so the highest-ranked author
+# was the one guaranteed to be discarded with "unrecognized author". It is a
+# lightkurve *mission*, not an author (MAST has no product with that
+# provenance_name), so it was removed from the chain rather than mapped.
+#
+# These three tests are structural: they read the tables against each other, so
+# a future author added to one and forgotten in the others fails here.
+
+
+def test_every_ranked_author_is_one_run_can_dispose_of():
     """
     Given the author priority table,
-    When it is compared against the authors run() can actually read,
-    Then "TESS" is the one entry with no mission and no unsupported-listing:
-      it sorts first, yet a sector offering only "TESS" products is skipped
-      with the unrecognized-author warning. Pre-existing behavior, pinned
-      here so a future mapping for it is a deliberate change.
+    When it is compared against the authors run() knows what to do with,
+    Then every entry is either readable (in AUTHOR_MISSION) or explicitly
+      listed as unreadable (in UNSUPPORTED_AUTHORS) -- no entry can win the
+      tie-break and then fall through to the unrecognized-author warning.
     """
     # Arrange
-    readable = set(getdata.AUTHOR_MISSION) | set(getdata.UNSUPPORTED_AUTHORS)
+    disposable = set(getdata.AUTHOR_MISSION) | set(getdata.UNSUPPORTED_AUTHORS)
 
     # Act
-    unreadable = set(getdata.AUTHOR_PRIORITY) - readable
+    unrecognized = set(getdata.AUTHOR_PRIORITY) - disposable
 
     # Assert
-    assert unreadable == {"TESS"}
+    assert unrecognized == set()
+
+
+def test_no_unreadable_author_outranks_a_readable_one():
+    """
+    Given that CDIPS and TASOC are ranked but cannot be read,
+    When their positions in the chain are compared with the readable authors',
+    Then every unreadable author sorts below every readable one, so a sector
+      offering both never picks the copy it has to throw away.
+    """
+    # Arrange
+    ranks = {a: i for i, a in enumerate(getdata.AUTHOR_PRIORITY)}
+    readable = [
+        a for a in getdata.AUTHOR_PRIORITY if a in getdata.AUTHOR_MISSION
+    ]
+    unreadable = [
+        a for a in getdata.AUTHOR_PRIORITY if a in getdata.UNSUPPORTED_AUTHORS
+    ]
+
+    # Act
+    worst_readable = max(ranks[a] for a in readable)
+    best_unreadable = min(ranks[a] for a in unreadable)
+
+    # Assert
+    assert best_unreadable > worst_readable
+
+
+def test_run_asks_mast_for_exactly_the_authors_it_ranks(
+    patched, monkeypatch, tmp_path
+):
+    """
+    Given the priority table,
+    When run() searches MAST,
+    Then it requests exactly that set of authors -- an author searched for but
+      unranked would be fetched only to lose the tie-break, and one ranked but
+      never searched for is a dead row.
+    """
+    # Arrange
+    asked = {}
+
+    def recording_search(target_id, **kwargs):
+        asked.update(kwargs)
+        return make_search_result(
+            patched["target_names"], patched["lightcurves"]
+        )
+
+    monkeypatch.setattr(lk, "search_lightcurve", recording_search)
+    args = getdata.build_parser().parse_args(
+        ["TIC375506058", "-n", "-1", "-p", str(tmp_path)]
+    )
+
+    # Act
+    getdata.run(args)
+
+    # Assert
+    assert set(asked["author"]) == set(getdata.AUTHOR_PRIORITY)


### PR DESCRIPTION
Review item **11.2**, found by PR #157 while table-driving `getdata.py`'s priority chains and pinned there rather than fixed.

## The bug

`"TESS"` headed `AUTHOR_PRIORITY` but appeared in neither `AUTHOR_MISSION` (the author -> mission reader dispatch) nor `UNSUPPORTED_AUTHORS`. A sector whose only products carried it would win the author tie-break and then be dropped by `run()` with `WARNING: Skipping lightcurve with unrecognized author` -- the highest-priority choice was the one guaranteed to fail. Pre-existing: the pre-table code had the same rank (its first `np.where(... == 'TESS')`) and the same missing reader branch.

## What `"TESS"` actually is

Established against the installed **lightkurve 2.6.0**, not from memory:

- lightkurve's own `search_lightcurve` docstring: *"Official Kepler, K2, and TESS pipeline products have author names `'Kepler'`, `'K2'`, and `'SPOC'`"*.
- In lightkurve's source `"TESS"` only ever appears as a **mission/project** value (`mission=("Kepler", "K2", "TESS")`). It is in neither `AUTHOR_LINKS` nor the internal `SearchResult` `sort_priority` table -- the two places that enumerate author values.
- `author` is a synonym for the MAST `provenance_name`. A live `Observations.query_criteria(obs_collection=<TESS|Kepler|K2>, provenance_name="TESS")` returns **0 rows** in all three collections.
- Live unfiltered `search_lightcurve` on TIC 261136679 and Kepler-10 returns authors `SPOC`, `QLP`, `TARS`, `TESS-SPOC`, `GSFC-ELEANOR-LITE`, `TASOC`, `TGLC`, `Kepler`, `CDIPS`, `KBONUS-BKG` -- no `"TESS"`.

It is a mission name, not an author. So it gets neither a mission mapping nor an unsupported listing: it is **removed from the chain**, because there is nothing to rank.

## User-visible behaviour change

**None.** MAST cannot return that author, and `run()`'s own `author=` filter never asked for it -- two independent reasons the entry was dead. No sector's fate changes.

## Also in this PR

`run()` now searches for exactly `AUTHOR_PRIORITY` instead of a hand-written tuple listing the same nine authors in a different order (lightkurve does not care about the order of `author=`), so the ranked set and the searched set cannot drift apart. That drift is the same bug class: an author searched for but unranked would be fetched only to lose the tie-break, and one ranked but never searched for is a dead row.

## Tests

The PR #157 pinning test `test_the_author_named_tess_is_ranked_but_has_no_reader` -- which asserted `set(AUTHOR_PRIORITY) - readable == {"TESS"}` -- is **replaced** by three structural tests:

- `test_every_ranked_author_is_one_run_can_dispose_of` -- every entry in `AUTHOR_PRIORITY` is in `AUTHOR_MISSION` or `UNSUPPORTED_AUTHORS`. This is the invariant that was violated; a future author added to one table and forgotten in the others fails here instead of silently dropping a sector.
- `test_no_unreadable_author_outranks_a_readable_one` -- `CDIPS`/`TASOC` are ranked (so a sector offering only them is skipped with their own message rather than the ambiguous-tie one) but must sort below everything readable.
- `test_run_asks_mast_for_exactly_the_authors_it_ranks` -- pins the ranked-set == searched-set coupling above.

`EXPECTED_AUTHOR_ORDER` in the test file loses its `"TESS"` head.

`tests/test_getdata.py` (27 passed) plus the neighbouring `test_mkticsed.py`, `test_scripts_smoke.py`, `test_utilities_registry.py`, `test_introspect.py` (116 passed) run clean; `ruff check` + `ruff format` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)