### PR TITLE
gui: DeleteInstance/DuplicateInstance are spelling-aware (review 11.10)

### DIFF
--- a/src/exozippy/gui/document.py
+++ b/src/exozippy/gui/document.py
@@ -181,6 +181,17 @@ def _instances_of(config, comp_type):
     return []
 
 
+def _instances_of_raw(config, comp_type):
+    """The component's list block VERBATIM (or []).
+
+    Unlike ``_instances_of`` this filters nothing, so positions here are the
+    element indices ``comp.<i>.param`` means -- dropping a stray non-dict
+    entry would shift every index after it.
+    """
+    block = config.get(comp_type)
+    return block if isinstance(block, list) else []
+
+
 def _find_instance(config, comp_type, name):
     """Return (list, index) of the named instance, or raise KeyError."""
     block = config.get(comp_type)
@@ -223,18 +234,46 @@ def _get_nested(tree, path):
 
 
 def _rename_top_keys(cmap, rename_fn):
-    """Rebuild a CommentedMap with top-level keys renamed, comments preserved."""
+    """Rebuild a CommentedMap with top-level keys renamed, comments preserved.
+
+    ``rename_fn`` returns the new key, or ``None`` to DROP the entry -- so one
+    pass can rename and delete together, which is what retargeting a params
+    file across an instance deletion needs (some keys go, some are respelled,
+    most are left exactly as the user wrote them).
+    """
     new = CommentedMap()
+    dropped = set()
     for key in list(cmap.keys()):
         new_key = rename_fn(key)
+        if new_key is None:
+            dropped.add(key)
+            continue
         new[new_key] = cmap[key]
     # Carry over per-key and block comments where the key survived.
     old_ca = getattr(cmap, "ca", None)
     if old_ca is not None:
         new.ca.comment = old_ca.comment
         for key, comment in old_ca.items.items():
-            new.ca.items[rename_fn(key)] = comment
+            if key in dropped:
+                continue
+            new_key = rename_fn(key)
+            if new_key is not None:
+                new.ca.items[new_key] = comment
     return new
+
+
+def _split_param_key(key, comp_type):
+    """``(instance, param)`` for a 3-part params key of ``comp_type``, else None.
+
+    The 2-part BROADCAST spelling (``star.teff``) deliberately returns None:
+    it is not specific to any instance, so no instance-level edit may touch
+    it -- it covers whatever elements remain, which is exactly what it said
+    before.
+    """
+    parts = str(key).split(".")
+    if len(parts) != 3 or parts[0] != comp_type:
+        return None
+    return parts[1], parts[2]
 
 
 # --- commands -----------------------------------------------------------------
@@ -252,7 +291,16 @@ class Command:
 
     def apply(self, doc):
         self._before = doc._snapshot()
-        self._do(doc)
+        try:
+            self._do(doc)
+        except Exception:
+            # A command that raises PART WAY THROUGH must leave nothing
+            # behind: it is not on the undo stack, so the user would have no
+            # way to take back (say) an appended clone whose params copy then
+            # refused. The snapshot restore we already own makes every
+            # command atomic for free.
+            doc._restore(self._before)
+            raise
         self._after = doc._snapshot()
 
     def revert(self, doc):
@@ -335,9 +383,13 @@ class DeleteInstance(Command):
         self.label = f"delete {comp_type} '{name}'"
 
     def _do(self, doc):
+        # Retarget the params file FIRST. Every decision there needs the
+        # PRE-deletion index of each entry's element, and the ``del`` below
+        # destroys exactly that: afterwards `star.A.teff` resolves to nothing
+        # and `star.0.teff` resolves to whichever star moved up.
+        doc._retarget_params_for_delete(self.comp_type, self.name)
         block, idx = _find_instance(doc.config, self.comp_type, self.name)
         del block[idx]
-        doc._drop_param_keys(self.comp_type, self.name)
 
 
 class RenameInstance(Command):
@@ -572,10 +624,189 @@ class ProjectDocument:
                 return key
         return path
 
-    def _drop_param_keys(self, comp_type, name):
-        prefix = f"{comp_type}.{name}."
-        for key in [k for k in self.params if str(k).startswith(prefix)]:
-            del self.params[key]
+    def _instance_indices(self, comp_type):
+        """``(names_by_index, index_by_name)`` for a list component.
+
+        Only names that can actually be written back into a params key are
+        listed: a non-string or all-digit ``name:`` cannot serve as the NAME
+        spelling (``validate_instance_names`` bans both outright), and an
+        instance with no ``name:`` at all has only its index.
+        """
+        names_by_index = {}
+        index_by_name = {}
+        for i, entry in enumerate(_instances_of_raw(self.config, comp_type)):
+            if not isinstance(entry, dict):
+                continue
+            nm = entry.get("name")
+            if not isinstance(nm, str) or nm.isdigit():
+                continue
+            names_by_index[i] = nm
+            index_by_name.setdefault(nm, i)
+        return names_by_index, index_by_name
+
+    @staticmethod
+    def _element_index(instance, index_by_name, n_inst):
+        """Which instance INDEX an ``<instance>`` path segment addresses.
+
+        Returns ``(index, is_index_form)``, or ``(None, ...)`` when the
+        spelling names no instance this config defines (an orphan entry left
+        over from an earlier edit -- not ours to retarget).
+        """
+        if instance.isdigit():
+            idx = int(instance)
+            return (idx if idx < n_inst else None), True
+        return index_by_name.get(instance), False
+
+    def _retarget_params_for_delete(self, comp_type, name):
+        """Retarget the params file across the deletion of one instance.
+
+        MUST run while the instance is still in the config -- see the comment
+        at the ``DeleteInstance`` call site.
+
+        Three kinds of entry, three answers:
+
+        * **The deleted instance's own entries go, under BOTH specific
+          spellings.** ``star.A.teff`` and ``star.0.teff`` name the same
+          element; a name-prefix scan saw only the first, so every index-form
+          entry survived the delete and then silently applied to whichever
+          star moved up. That is a WRONG-ELEMENT bug, not litter.
+        * **A survivor's index-form entry whose index shifts is rewritten to
+          the NAME form** (``star.1.teff`` -> ``star.B.teff`` when B moves
+          from index 1 to 0). The name form means the same element before and
+          after any list mutation, so this converts a fragile spelling into a
+          stable one exactly where the fragility would otherwise bite.
+          Re-indexing would fix today's delete and leave the same trap set
+          for the next one; refusing the delete would gate an edit the GUI
+          can repair exactly. An UNNAMED instance has no name form, so its
+          keys are re-indexed instead -- the same guarantee by the only means
+          available.
+        * **Everything else is left byte-identical**: a survivor at an index
+          BELOW the deleted one still spells its own element correctly, the
+          name form was never index-dependent, and the 2-part BROADCAST form
+          (``star.teff``) was never specific to the deleted instance.
+
+        Link EXPRESSIONS inside the surviving entries get the same treatment
+        (they are parameter references too, and an index-form one retargets
+        just as silently), with one difference: a reference to the DELETED
+        instance is rewritten to its name form rather than removed, turning a
+        silent mis-address into the loud "no instance named 'A'" the name
+        form has always produced.
+        """
+        block, idx = _find_instance(self.config, comp_type, name)
+        n_inst = len(block)
+        names_by_index, index_by_name = self._instance_indices(comp_type)
+
+        def respelled(i, is_index_form):
+            """New instance segment, or None when the spelling still holds."""
+            if not is_index_form or i < idx:
+                return None
+            nm = names_by_index.get(i)
+            return nm if nm is not None else str(i - 1)
+
+        def rewrite_key(key):
+            split = _split_param_key(key, comp_type)
+            if split is None:
+                return key
+            instance, param = split
+            i, is_index_form = self._element_index(
+                instance, index_by_name, n_inst
+            )
+            if i is None:
+                return key
+            if i == idx:
+                return None  # the deleted instance, under either spelling
+            new_instance = respelled(i, is_index_form)
+            if new_instance is None:
+                return key
+            return f"{comp_type}.{new_instance}.{param}"
+
+        plan = {str(k): rewrite_key(k) for k in self.params}
+        self._reject_colliding_rewrites(plan)
+        self.params = _rename_top_keys(self.params, rewrite_key)
+
+        def rewrite_ref(instance, param):
+            i, is_index_form = self._element_index(
+                instance, index_by_name, n_inst
+            )
+            if i is None:
+                return None
+            if i == idx:
+                # Dangling either way now; spell it so it FAILS rather than
+                # quietly addressing the instance that took this index.
+                return str(name) if is_index_form else None
+            return respelled(i, is_index_form)
+
+        self._rewrite_param_link_paths(comp_type, rewrite_ref)
+
+    def _reject_colliding_rewrites(self, plan):
+        """Refuse a retarget that would leave one element spelled twice.
+
+        Only reachable from a params file that ALREADY names one element
+        under both specific spellings -- which ``ConfigManager`` refuses
+        outright (see CLAUDE.md's "Parameter naming convention"), so the
+        collision is a pre-existing fault this edit would otherwise bury.
+        """
+        landed = {}
+        for src, dst in plan.items():
+            if dst is None:
+                continue
+            prev = landed.get(dst)
+            if prev is not None:
+                raise ValueError(
+                    f"cannot retarget the params file: '{prev}' and '{src}' "
+                    f"would both become '{dst}', i.e. they are two spellings "
+                    f"of one parameter element. Keep exactly one of them "
+                    f"(merging any fields you need from both) and retry."
+                )
+            landed[dst] = src
+
+    def _copy_param_keys(self, comp_type, name, new_name):
+        """Copy one instance's param entries onto its freshly added duplicate.
+
+        The mirror image of the delete case, and it was wrong the same way:
+        a name-prefix scan reads only the NAME spelling, so duplicating an
+        instance whose entries the file spells by INDEX produced a clone with
+        none of its parameters -- silently, since a missing entry is a legal
+        params file.
+
+        Entries are read under both specific spellings and written under the
+        clone's NAME form. Never its index form: that is the fragile spelling
+        ``_retarget_params_for_delete`` exists to remove, correct only until
+        someone deletes an earlier instance. And exactly one spelling per
+        element -- naming one element twice is fatal in ``ConfigManager``.
+        """
+        block, idx = _find_instance(self.config, comp_type, name)
+        _, new_idx = _find_instance(self.config, comp_type, new_name)
+        n_inst = len(block)
+        _, index_by_name = self._instance_indices(comp_type)
+
+        source = {}
+        for key in list(self.params.keys()):
+            split = _split_param_key(key, comp_type)
+            if split is None:
+                continue
+            instance, param = split
+            i, _ = self._element_index(instance, index_by_name, n_inst)
+            if i == idx:
+                if param in source:
+                    raise ValueError(
+                        f"cannot duplicate '{name}': its '{param}' is named "
+                        f"twice in the params file ('{source[param][0]}' and "
+                        f"'{key}' are two spellings of one element). Keep "
+                        f"exactly one of them and retry."
+                    )
+                source[param] = (str(key), self.params[key])
+            elif i == new_idx:
+                raise ValueError(
+                    f"cannot duplicate '{name}' as '{new_name}': the params "
+                    f"file already has '{key}' for the new instance. Remove "
+                    f"or rename that entry and retry."
+                )
+
+        for param, (_, value) in source.items():
+            self.params[f"{comp_type}.{new_name}.{param}"] = copy.deepcopy(
+                value
+            )
 
     def _rename_param_keys(self, comp_type, old, new):
         prefix = f"{comp_type}.{old}."
@@ -589,30 +820,33 @@ class ProjectDocument:
 
         self.params = _rename_top_keys(self.params, rename)
 
-    def _copy_param_keys(self, comp_type, name, new_name):
-        prefix = f"{comp_type}.{name}."
-        new_prefix = f"{comp_type}.{new_name}."
-        additions = []
-        for key in list(self.params.keys()):
-            k = str(key)
-            if k.startswith(prefix):
-                additions.append(
-                    (new_prefix + k[len(prefix) :], self.params[key])
-                )
-        for new_key, value in additions:
-            self.params[new_key] = copy.deepcopy(value)
-
     def _rewrite_param_links(self, comp_type, old, new):
+        # An INDEX-form reference to the renamed instance still addresses it
+        # (a rename moves nothing), so only the name form is rewritten.
+        self._rewrite_param_link_paths(
+            comp_type,
+            lambda instance, param: str(new) if instance == str(old) else None,
+        )
+
+    def _rewrite_param_link_paths(self, comp_type, rewrite_ref):
+        """Rewrite ``comp.<instance>.<param>`` references inside link values.
+
+        ``rewrite_ref(instance, param)`` returns the new instance segment, or
+        None to leave that reference exactly as written. The character
+        classes are ``linking._PATH_3``'s, so this sees precisely the
+        references the link parser will -- index form included.
+        """
         pat = re.compile(
             r"(?<![\w.])"
             + re.escape(comp_type)
-            + r"\."
-            + re.escape(str(old))
-            + r"\.([A-Za-z_]\w*)"
+            + r"\.([A-Za-z0-9_][A-Za-z0-9_\-]*)\.([A-Za-z_]\w*)(?![\w.(])"
         )
 
         def repl(m):
-            return f"{comp_type}.{new}.{m.group(1)}"
+            new_instance = rewrite_ref(m.group(1), m.group(2))
+            if new_instance is None:
+                return m.group(0)
+            return f"{comp_type}.{new_instance}.{m.group(2)}"
 
         for entry in self.params.values():
             if not isinstance(entry, dict):

--- a/src/exozippy/gui/gui.md
+++ b/src/exozippy/gui/gui.md
@@ -81,6 +81,49 @@ push it into one of these contracts instead.
   whole original entry, `sigma` prior included. Only the two specific
   spellings are matched; a 2-part broadcast entry is a coarser statement that
   a specific entry legitimately refines.
+
+  **`DeleteInstance` and `DuplicateInstance` are spelling-aware too, and for a
+  sharper reason: the INDEX form does not survive a change to the instance
+  list.** `star.A.teff` follows its star wherever the list moves it;
+  `star.0.teff` follows the index, so deleting an earlier instance repoints it
+  at a different body. Both commands used to scan for the `comp.<name>.`
+  prefix, so deleting star "A" left every `star.0.*` entry in the file, now
+  silently applying to whichever star became index 0 -- a WRONG-ELEMENT bug,
+  not litter (review 11.10). The decided semantics, implemented in
+  `_retarget_params_for_delete` / `_copy_param_keys`:
+  - **The deleted instance's own entries go under BOTH specific spellings.**
+    `star.A.teff` and `star.0.teff` name one element; honouring only the first
+    leaves a live entry behind.
+  - **A survivor's index-form entry whose index shifts is rewritten to the
+    NAME form** (`star.1.teff` -> `star.B.teff`). The name form means the same
+    element before and after any list mutation, so this converts a fragile
+    spelling into a stable one exactly where the fragility would bite.
+    Re-indexing was rejected because it fixes today's delete and leaves the
+    same trap set for the next one; refusing the delete was rejected because
+    it gates an edit the GUI can repair exactly. An UNNAMED instance has no
+    name form, so its keys are re-indexed instead -- the same guarantee by the
+    only means available.
+  - **Everything else is byte-identical.** A survivor at an index *below* the
+    deleted one still spells its own element correctly, and the 2-part
+    BROADCAST form (`star.teff`) was never specific to the deleted instance --
+    it covers whatever elements remain, which is exactly what it said before.
+  - **Link expressions get the same treatment**, since a reference is a
+    parameter path too (`initval: star.2.teff` retargets just as silently),
+    with one difference: a reference to the DELETED instance is respelled to
+    its *name* rather than removed, turning a silent mis-address into the loud
+    "no instance named 'A'" the name form has always produced.
+  - **`DuplicateInstance` is the mirror case.** It reads the source's entries
+    under both specific spellings (the prefix scan matched none of an
+    index-spelled instance's, so the clone silently arrived with no
+    parameters) and writes them under the clone's NAME form -- never its index
+    form, and exactly one spelling per element.
+  - Either command **raises, atomically**, if the params file already names
+    one element under both specific spellings (which `ConfigManager` refuses
+    anyway): merging them silently would bury a fault carrying a value, a
+    bound or a prior. `Command.apply` restores its own before-snapshot when
+    `_do` raises, since a failed command is not on the undo stack and must
+    leave nothing behind.
+
   `RenameInstance` rewrites every cross-reference (orbit body groups, `band:`,
   `star_ndx`/`orbit:` keys, and `linking.py` expressions) purely from the
   schema -- no hardcoded component names. Undo uses TEXT snapshots, not

--- a/tests/test_gui_document.py
+++ b/tests/test_gui_document.py
@@ -360,3 +360,292 @@ def test_to_json_shape(project):
     assert blob["config"]["star"][0]["name"] == "A"
     # booleans survive as real JSON booleans
     assert blob["config"]["star"][0]["mist"] is False
+
+
+# --- structural edits vs. the index spelling (review 11.10) -------------------
+#
+# An element has three legal spellings and only ONE of them survives a change
+# to the instance list: the NAME form.  `star.A.teff` follows its star wherever
+# the list moves it; `star.0.teff` follows the INDEX, so deleting an earlier
+# instance silently repoints it at a different body.  These tests pin what the
+# two structural commands do about that.
+
+
+def _three_stars(tmp_path, params_text):
+    """A three-star project (A, B, C) with a hand-written params file."""
+    config_path = tmp_path / "sys.yaml"
+    config_path.write_text(
+        "star:\n"
+        "  - name: A\n"
+        "  - name: B\n"
+        "  - name: C\n"
+        "parameter_file: p.params.yaml\n"
+    )
+    (tmp_path / "p.params.yaml").write_text(params_text)
+    return config_path
+
+
+def _teff_by_star_name(doc):
+    """{star name: initval} as the FIT would read the saved params file."""
+    config = yaml.safe_load(doc.config_text())
+    params = yaml.safe_load(doc.params_text())
+    names = [e["name"] for e in config["star"]]
+    out = {}
+    for key, entry in params.items():
+        parts = key.split(".")
+        if len(parts) != 3 or parts[0] != "star" or parts[2] != "teff":
+            continue
+        instance = parts[1]
+        if instance.isdigit():
+            i = int(instance)
+            name = names[i] if i < len(names) else f"<no star at index {i}>"
+        else:
+            name = instance
+        out[name] = entry["initval"]
+    return out
+
+
+def test_delete_instance_does_not_leave_index_keys_on_another_star(tmp_path):
+    """
+    Given a params file that spells all three stars by INDEX
+      (`star.0/1/2.teff`),
+    When the first star is deleted,
+    Then no surviving entry addresses a different star than it did before --
+      B still carries 6000 and C still carries 7000, and nothing carries the
+      deleted star's 5000.
+
+    This is the wrong-element half of review 11.10.  The old name-prefix scan
+    saw no `star.A.` key at all, so it deleted NOTHING: `star.0.teff` (the
+    deleted star's own entry, 5000) stayed in the file and, with A gone,
+    addressed B; `star.1.teff` addressed C; `star.2.teff` addressed nobody.
+    Every value silently moved one star over.
+    """
+    # Arrange
+    config_path = _three_stars(
+        tmp_path,
+        "star.0.teff:\n  initval: 5000\n"
+        "star.1.teff:\n  initval: 6000\n"
+        "star.2.teff:\n  initval: 7000\n",
+    )
+    doc = ProjectDocument.open(config_path)
+
+    # Act
+    doc.execute(DeleteInstance("star", "A"))
+
+    # Assert -- each star still carries the value it carried before.
+    assert _teff_by_star_name(doc) == {"B": 6000, "C": 7000}
+    assert 5000 not in _teff_by_star_name(doc).values()
+
+    # ...spelled in the one form that survives a list edit...
+    assert set(doc.params) == {"star.B.teff", "star.C.teff"}
+
+    # ...and the result is a params file ConfigManager accepts: a rewrite
+    # that produced two spellings of one element would be a fatal error.
+    ConfigManager(
+        yaml.safe_load(doc.params_text()),
+        system_config=yaml.safe_load(doc.config_text()),
+    )
+
+
+def test_delete_instance_drops_both_spellings_of_its_own_entries(tmp_path):
+    """
+    Given a params file naming the doomed star by NAME for one parameter and
+      by INDEX for another,
+    When that star is deleted,
+    Then both entries go.
+
+    `star.A.teff` and `star.0.teff` are two spellings of one element, so a
+    delete that honours only the first leaves a live entry behind.
+    """
+    # Arrange
+    config_path = _three_stars(
+        tmp_path,
+        "star.A.teff:\n  initval: 5000\n"
+        "star.0.radius:\n  initval: 0.9\n"
+        "star.B.teff:\n  initval: 6000\n",
+    )
+    doc = ProjectDocument.open(config_path)
+
+    # Act
+    doc.execute(DeleteInstance("star", "A"))
+
+    # Assert
+    assert set(doc.params) == {"star.B.teff"}
+
+
+def test_delete_instance_leaves_the_broadcast_form_alone(tmp_path):
+    """
+    Given a params file mixing all three spellings -- a 2-part BROADCAST
+      entry, a name-form entry and index-form entries on either side of the
+      doomed star,
+    When the first star is deleted,
+    Then the broadcast entry is untouched, entries that already spelled their
+      own element correctly are byte-identical, and only the shifted
+      index-form entry is respelled.
+
+    The broadcast form is not specific to any instance: it covers whatever
+    elements no specific entry claims, which is exactly what it still says
+    with one fewer star.
+    """
+    # Arrange
+    config_path = _three_stars(
+        tmp_path,
+        "star.teff:\n  initval: 5800\n"  # broadcast: every star
+        "star.A.radius:\n  initval: 0.9\n"  # doomed star, name form
+        "star.0.mass:\n  initval: 0.8\n"  # doomed star, index form
+        "star.2.teff:\n  initval: 7000\n"  # C, index form -- SHIFTS
+        "star.B.radius:\n  initval: 1.1\n",  # B, name form -- stable
+    )
+    doc = ProjectDocument.open(config_path)
+
+    # Act
+    doc.execute(DeleteInstance("star", "A"))
+
+    # Assert
+    assert dict(doc.params["star.teff"]) == {"initval": 5800}
+    assert set(doc.params) == {"star.teff", "star.C.teff", "star.B.radius"}
+    assert doc.params["star.C.teff"]["initval"] == 7000
+    assert doc.params["star.B.radius"]["initval"] == 1.1
+    ConfigManager(
+        yaml.safe_load(doc.params_text()),
+        system_config=yaml.safe_load(doc.config_text()),
+    )
+
+
+def test_delete_instance_keeps_index_keys_that_do_not_shift(tmp_path):
+    """
+    Given index-form entries BEFORE and AFTER the doomed star,
+    When the star is deleted,
+    Then only the one whose index shifts is respelled; the earlier one keeps
+      the user's own spelling.
+
+    The minimum intervention that guarantees correctness: an index below the
+    deleted one still means the same element, so rewriting it would churn the
+    user's file for nothing.
+    """
+    # Arrange
+    config_path = _three_stars(
+        tmp_path,
+        "star.0.teff:\n  initval: 5000\n"
+        "star.1.teff:\n  initval: 6000\n"
+        "star.2.teff:\n  initval: 7000\n",
+    )
+    doc = ProjectDocument.open(config_path)
+
+    # Act -- delete the MIDDLE star
+    doc.execute(DeleteInstance("star", "B"))
+
+    # Assert
+    assert set(doc.params) == {"star.0.teff", "star.C.teff"}
+    assert _teff_by_star_name(doc) == {"A": 5000, "C": 7000}
+
+
+def test_delete_instance_reindexes_when_a_survivor_has_no_name(tmp_path):
+    """
+    Given a survivor with no `name:` key at all,
+    When an earlier instance is deleted,
+    Then its index-form entry is RE-INDEXED, since there is no name form to
+      rewrite it to.
+
+    Same guarantee (the entry still addresses the same instance), by the only
+    means available.
+    """
+    # Arrange
+    config_path = tmp_path / "sys.yaml"
+    config_path.write_text(
+        "star:\n  - name: A\n  - teff: 6000\nparameter_file: p.params.yaml\n"
+    )
+    (tmp_path / "p.params.yaml").write_text("star.1.radius:\n  initval: 1.1\n")
+    doc = ProjectDocument.open(config_path)
+
+    # Act
+    doc.execute(DeleteInstance("star", "A"))
+
+    # Assert
+    assert set(doc.params) == {"star.0.radius"}
+    assert doc.params["star.0.radius"]["initval"] == 1.1
+
+
+def test_delete_instance_retargets_index_form_links(tmp_path):
+    """
+    Given a link expression that references a surviving star by INDEX,
+    When an earlier star is deleted,
+    Then the reference is respelled to that star's name.
+
+    A link VALUE is a parameter reference too: `star.2.teff` in an expression
+    retargets on a deletion exactly as a key does, and just as silently.
+    """
+    # Arrange
+    config_path = _three_stars(
+        tmp_path,
+        "star.B.teff:\n  initval: star.2.teff\n  sigma: 0\n",
+    )
+    doc = ProjectDocument.open(config_path)
+
+    # Act
+    doc.execute(DeleteInstance("star", "A"))
+
+    # Assert
+    assert doc.params["star.B.teff"]["initval"] == "star.C.teff"
+
+
+def test_duplicate_instance_copies_index_form_entries(tmp_path):
+    """
+    Given a params file that spells an instance's entries by INDEX,
+    When that instance is duplicated,
+    Then the clone carries copies of them, under its own NAME.
+
+    The mirror of the delete bug: the old name-prefix scan matched no
+    `star.A.` key, so the clone silently arrived with none of the parameters
+    it was supposed to be a copy of.  The clone's entries are written in the
+    name form -- never its index form, which is exactly the spelling the
+    delete path exists to repair -- and one element ends up with exactly one
+    spelling, since naming it twice is fatal in ConfigManager.
+    """
+    # Arrange
+    config_path = _three_stars(
+        tmp_path,
+        "star.0.teff:\n  initval: 5000\n  sigma: 100\n",
+    )
+    doc = ProjectDocument.open(config_path)
+
+    # Act
+    doc.execute(DuplicateInstance("star", "A", "A2"))
+
+    # Assert
+    assert set(doc.params) == {"star.0.teff", "star.A2.teff"}
+    assert dict(doc.params["star.A2.teff"]) == {"initval": 5000, "sigma": 100}
+    # The copy is deep: editing the clone must not touch the original.
+    doc.execute(SetParamField("star.A2.teff", "initval", 9999))
+    assert doc.params["star.0.teff"]["initval"] == 5000
+    ConfigManager(
+        yaml.safe_load(doc.params_text()),
+        system_config=yaml.safe_load(doc.config_text()),
+    )
+
+
+def test_structural_edit_refuses_a_pre_existing_duplicate_spelling(tmp_path):
+    """
+    Given a params file that already names one element under BOTH specific
+      spellings (which ConfigManager itself refuses),
+    When a delete would merge them onto one key,
+    Then the command raises and the document is left exactly as it was.
+
+    Silently keeping one of the two would bury a fault that carries a value,
+    a bound or a prior.  The restore is `Command.apply`'s: a command that
+    raises is not on the undo stack, so it must leave nothing behind.
+    """
+    # Arrange
+    config_path = _three_stars(
+        tmp_path,
+        "star.1.teff:\n  initval: 6000\n"
+        "star.B.teff:\n  initval: 6100\n  sigma: 50\n",
+    )
+    doc = ProjectDocument.open(config_path)
+    before = doc.params_text()
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="two spellings"):
+        doc.execute(DeleteInstance("star", "A"))
+    assert doc.params_text() == before
+    assert [e["name"] for e in doc.config["star"]] == ["A", "B", "C"]


### PR DESCRIPTION
Fixes review item 11.10. Found by PR #168 while fixing the GUI's param writer and deliberately left for a separate change, because it needed a semantics decision first.

## The bug

An element has three legal spellings and only one of them survives a change to the instance list: the **NAME** form. `star.A.teff` follows its star wherever the list moves it; `star.0.teff` follows the **index**.

`_drop_param_keys` / `_copy_param_keys` scanned for the `comp.<name>.` prefix, so deleting star "A" from `[A, B, C]` left every `star.0.*` entry in the file -- and with A gone, index 0 addresses a **different** star. Measured on a three-star fixture spelled by index:

```
E       AssertionError: assert {'B': 5000, '...dex 2>': 7000} == {'B': 6000, 'C': 7000}
E         Differing items:
E         {'C': 6000} != {'C': 7000}
E         {'B': 5000} != {'B': 6000}
E         Left contains 1 more item:
E         {'<no star at index 2>': 7000}
```

Every value moved one body over, including the deleted star's own. A wrong-element bug, not litter.

## The two semantics decisions

**1. The deleted instance's own entries: drop both specific spellings.** `star.A.teff` and `star.0.teff` name one element; honouring only the first leaves a live entry behind.

**2. The survivors' index-form entries: rewrite the shifted ones to the NAME form.** (Options considered: re-index, rewrite to name form, refuse the delete.) The name form means the same element before and after any list mutation, so this converts a fragile spelling into a stable one exactly where the fragility would bite. Re-indexing would fix today's delete and leave the same trap set for the next structural edit -- and would need the same careful shift logic in every future command. Refusing would gate an edit the GUI can repair exactly, against the house "rope, not gates" ethos. An **unnamed** instance has no name form, so its keys are re-indexed instead: the same guarantee by the only means available.

Corollaries, all pinned by tests:

- **The 2-part BROADCAST form is untouched.** `star.teff` was never specific to the deleted instance; it covers whatever elements remain, which is exactly what it said before. Consistent with PR #168's writer, which makes the same distinction.
- **An index BELOW the deleted one is left byte-identical.** It still spells its own element correctly, so rewriting it would churn the user's file for nothing. The minimum intervention that guarantees correctness.
- **Link expressions get the same treatment.** A reference is a parameter path too, and `initval: star.2.teff` retargets just as silently as a key. One difference: a reference to the **deleted** instance is respelled to its *name* rather than removed, turning a silent mis-address into the loud "no instance named 'A'" the name form has always produced.
- **`DuplicateInstance` is the mirror case**, and was wrong the same way: the prefix scan matched none of an index-spelled instance's entries, so the clone silently arrived with **no** parameters. It now reads the source under both specific spellings and writes the clone's entries under its **NAME** form -- never its index form, which is the fragile spelling this PR exists to remove, and exactly one spelling per element (naming one element twice is fatal in `ConfigManager`).
- **Either command raises on a pre-existing duplicate spelling**, rather than merging two entries onto one key and burying a fault that may carry a value, a bound or a prior. `Command.apply` now restores its own before-snapshot when `_do` raises: a failed command is not on the undo stack, so it must leave nothing behind.
- **`DeleteInstance` retargets the params BEFORE the `del`.** Every decision needs the pre-deletion index, which the `del` destroys.

## Verification

Every new test fails on master (8 failures, output above for the headline one). Each delete/duplicate test also re-loads its result through `ConfigManager`, so PR #168's duplicate-spelling raise acts as an independent check that the rewrite is well formed.

`tests/test_gui_document.py` 16 -> 24 tests; full GUI suite (`test_gui_app`, `test_gui_data`, `test_gui_document`, `test_gui_run_crash`, `test_gui_tune`) **81 passed**. `test_param_specificity`, `test_inspect_start` and `test_linked_params` pass too. No frontend file touched, so no `npm run build`. `ruff check` + `ruff format` clean. `gui.md` documents the decided semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)