### PR TITLE
ptde_async: report the per-rung explored span while sampling

### DIFF
--- a/src/exozippy/samplers/_common.py
+++ b/src/exozippy/samplers/_common.py
@@ -406,6 +406,76 @@ def resolve_n_chains(n_chains, n_params, label, log):
 
 
 # ---------------------------------------------------------------------------
+# Per-rung explored span
+# ---------------------------------------------------------------------------
+
+
+class SpanTracker:
+    """Running min/max of every raw coordinate, per temperature rung.
+
+    The cheapest honest answer to "how far can this ladder actually reach?".
+    Raw space is whitened, so one unit is one measured posterior sigma and
+    the span is directly comparable to the distance to a candidate
+    alternative solution.
+
+    Why this rather than an inline mode search: on DC2018 event 128 the known
+    second basin (s = 0.854 against the posterior's 0.9755) sits 296 sigma
+    away in log_s.  A rung at temperature T explores a width ~sqrt(T) sigma,
+    so T_max=200 spans ~14 sigma -- 21 widths away, unreachable at any
+    runtime -- while T_max=8500 spans ~92 sigma, 3.2 widths, rare per step
+    but reachable across 54 chains.  Reporting the span per rung turns that
+    from an after-the-fact calculation into something visible WHILE the run
+    is going: if the top rung's span is not of order the distance to whatever
+    you hoped to find, more runtime will not find it and T_max is too low.
+
+    Updated only where a slot's state changes (first evaluation and accepted
+    moves), so the cost is two numpy ops on one parameter vector per accepted
+    proposal -- negligible against a logp evaluation.
+    """
+
+    def __init__(self, n_temps, raw_start):
+        self.lo = {
+            k: np.full((n_temps,) + np.shape(v), np.inf)
+            for k, v in raw_start.items()
+        }
+        self.hi = {
+            k: np.full((n_temps,) + np.shape(v), -np.inf)
+            for k, v in raw_start.items()
+        }
+        self.n_temps = n_temps
+
+    def update(self, k, state):
+        # Plain assignment, not `out=`: for a SCALAR parameter self.lo[key]
+        # has shape (n_temps,), so self.lo[key][k] is a numpy scalar rather
+        # than an array and `out=` raises "return arrays must be of
+        # ArrayType".  Every model has scalar parameters, so the out= form
+        # would have crashed on essentially any real run.
+        for key, v in state.items():
+            self.lo[key][k] = np.minimum(self.lo[key][k], v)
+            self.hi[key][k] = np.maximum(self.hi[key][k], v)
+
+    def report(self):
+        """[(widest span in sigma, which parameter)] per rung.
+
+        A rung no slot has reported yet gives (0.0, "-") rather than nan or
+        inf: an unvisited rung has no span, and a diagnostic that prints inf
+        reads as a bug rather than as "no data yet".
+        """
+        out = []
+        for k in range(self.n_temps):
+            best, best_key = 0.0, "-"
+            for key in self.lo:
+                span = self.hi[key][k] - self.lo[key][k]
+                if not np.all(np.isfinite(span)):
+                    continue
+                m = float(np.max(span))
+                if m > best:
+                    best, best_key = m, key
+            out.append((best, best_key))
+        return out
+
+
+# ---------------------------------------------------------------------------
 # Hot-rung retention (store_hot_chains)
 # ---------------------------------------------------------------------------
 

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -341,6 +341,10 @@ def ptde_async_sample(
 
     n_accept = np.zeros(n_temps)
     n_propose = np.zeros(n_temps)
+    # Per-rung explored span: see _common.SpanTracker for what it is for
+    # and the DC2018 event 128 numbers that motivate reporting it live.
+    spans = _common.SpanTracker(n_temps, raw_start)
+
     n_swap_accept = np.zeros(max(n_temps - 1, 1))
     n_swap_propose = np.zeros(max(n_temps - 1, 1))
     n_eval_timeouts = [0]
@@ -616,6 +620,7 @@ def ptde_async_sample(
                 # First evaluation for this slot: the start state itself.
                 current_state[k][i] = prop
                 current_lp[k][i] = lp
+                spans.update(k, prop)
             else:
                 T = temperatures[k]
                 n_propose[k] += 1
@@ -630,6 +635,7 @@ def ptde_async_sample(
                     current_state[k][i] = prop
                     current_lp[k][i] = lp
                     n_accept[k] += 1
+                    spans.update(k, prop)
                     # Runaway-lp early detection (see LpPlausibilityGuard).
                     if k == 0:
                         lp_guard.check(i, lp)
@@ -768,6 +774,14 @@ def ptde_async_sample(
                         if n_temps > 1
                         else ""
                     )
+                )
+                span_rep = spans.report()
+                logger.info(
+                    "PTDE-async explored span (raw sigma, running): "
+                    f"T=1 {span_rep[0][0]:.1f} ({span_rep[0][1]})  "
+                    f"T={temperatures[-1]:.0f} {span_rep[-1][0]:.1f} "
+                    f"({span_rep[-1][1]})  "
+                    f"top/cold={span_rep[-1][0] / max(span_rep[0][0], 1e-9):.0f}x"
                 )
 
             _maybe_stop()

--- a/tests/test_ptde_async_ladder.py
+++ b/tests/test_ptde_async_ladder.py
@@ -14,6 +14,7 @@ cannot fix that by getting longer.
 """
 
 import numpy as np
+import pytest
 
 from exozippy.samplers.ptde import _update_ladder_barrier
 
@@ -72,3 +73,62 @@ def test_async_accepts_adapt_ladder_and_defaults_it_off():
     sig = inspect.signature(ptde_async_sample)
     assert "adapt_ladder" in sig.parameters
     assert sig.parameters["adapt_ladder"].default is False
+
+
+# ---------------------------------------------------------------------------
+# Per-rung explored span (_common.SpanTracker)
+# ---------------------------------------------------------------------------
+
+
+def test_span_tracker_measures_per_rung_reach():
+    """
+    Given states visited at a cold and a hot rung,
+    When SpanTracker records them,
+    Then each rung reports its own widest span, in raw (whitened) sigma, and
+      names the parameter responsible.
+
+    This is what makes "can this ladder reach the thing I am looking for?"
+    answerable DURING a run.  On DC2018 event 128 the known second basin
+    (s = 0.854 against the posterior's 0.9755) sits 296 sigma away in log_s,
+    while a rung at temperature T explores ~sqrt(T) sigma: 14 sigma at
+    T_max=200 (21 widths -- unreachable at any runtime) against 92 sigma at
+    T_max=8500 (3.2 widths -- reachable across 54 chains).  Comparing the
+    reported span against that distance is the whole point.
+    """
+    # ARRANGE
+    from exozippy.samplers._common import SpanTracker
+
+    tr = SpanTracker(
+        n_temps=3, raw_start={"a": np.zeros(2), "b": np.zeros(())}
+    )
+
+    # ACT: rung 0 wanders +-1, rung 2 wanders +-50 in "a"
+    tr.update(0, {"a": np.array([-1.0, 0.0]), "b": np.array(0.0)})
+    tr.update(0, {"a": np.array([1.0, 0.5]), "b": np.array(0.2)})
+    tr.update(2, {"a": np.array([-50.0, 0.0]), "b": np.array(0.0)})
+    tr.update(2, {"a": np.array([50.0, 1.0]), "b": np.array(0.1)})
+    rep = tr.report()
+
+    # ASSERT
+    assert rep[0][0] == pytest.approx(2.0)  # a spans -1..1
+    assert rep[0][1] == "a"
+    assert rep[2][0] == pytest.approx(100.0)  # a spans -50..50
+    assert rep[2][1] == "a"
+    # the hot rung reaches 50x further than the cold one
+    assert rep[2][0] / rep[0][0] == pytest.approx(50.0)
+
+
+def test_span_tracker_reports_zero_for_an_unvisited_rung():
+    """An unvisited rung has no span; it must not print inf or nan.
+
+    A diagnostic that shows inf reads as a bug rather than as "no data yet",
+    and rung 1 here is genuinely unreported at this point in a run.
+    """
+    from exozippy.samplers._common import SpanTracker
+
+    tr = SpanTracker(n_temps=2, raw_start={"a": np.zeros(())})
+    tr.update(0, {"a": np.array(3.0)})
+
+    rep = tr.report()
+    assert rep[1] == (0.0, "-")
+    assert np.isfinite(rep[0][0])


### PR DESCRIPTION
"Can this ladder reach the thing I am looking for?" was only answerable
after a run, by hand, from the posterior. It should be visible *while* the
run is going, because the answer decides whether more runtime is worth
anything at all.

`_common.SpanTracker` keeps the running min/max of every raw coordinate per
temperature rung, and `ptde_async` logs the widest span per rung alongside
the existing progress line:

```
PTDE-async explored span (raw sigma, running): T=1 8.2 (lens.u_0_raw)
  T=8500 341.0 (lens.log_s_raw)  top/cold=42x
```

Raw space is whitened, so one unit is one measured posterior sigma and the
span is directly comparable to the distance to a candidate solution.

### Why it matters

On `examples/DC2018` event 128 the comparison is decisive. The known second
basin (s = 0.854 against the posterior's 0.9755) sits **296 sigma** away in
log_s, while a rung at temperature T explores a width ~sqrt(T) sigma:

| T_max | span | distance/span | per-step reach |
|---|---|---|---|
| 200 | 14 sigma | 20.9x | e^-218 — unreachable at any runtime |
| 8500 | 92 sigma | 3.2x | 6e-3 — rare but reachable across 54 chains |
| 42563 | 206 sigma | 1.4x | 0.36 — routine |

So T_max=8500 *was* correctly sized for that basin and T_max=200 never had
a chance — and that is not something the existing diagnostics could tell
you. Swap acceptance, Lambda and round trips all describe **transport along
the ladder** and say nothing about how far the hot end actually wanders. A
ladder can be perfectly provisioned (event 128 at n_temps=48: Lambda = 18.9
against the 39 the DEO criterion asks for, mean acceptance 0.598 against its
0.50 target) and still be searching too small a volume.

### Cost

Two numpy ops on one parameter vector per accepted proposal, updated only
where a slot's state changes, plus one log line per existing log interval.
Negligible against a logp evaluation.

### Details worth a reviewer's eye

- An unvisited rung reports `(0.0, "-")` rather than inf. A diagnostic that
  prints inf reads as a bug rather than as "no data yet", and early in a run
  the hot rungs genuinely have no span.
- The update uses plain assignment rather than `out=`: for a **scalar**
  parameter `self.lo[key]` has shape `(n_temps,)`, so `self.lo[key][k]` is a
  numpy scalar and `out=` raises `"return arrays must be of ArrayType"`.
  Every real model has scalar parameters, so the `out=` form would have
  crashed on essentially any run. It was caught by the unit test, which is
  why the tracker lives in `_common` as a testable class rather than as
  closures inside the sampling loop.

### Testing

`tests/test_ptde_async_ladder.py`: 5 passed (2 new for the tracker, 3 from
#188 for the ladder re-spacing). With `test_ptde.py` and `test_polish.py`:
59 passed. `ruff check` / `ruff format --check` clean.
