### PR TITLE
examples/DC2018: --adapt-ladder, --fix-u1, and the alpha-convention script

### DIFF
--- a/examples/DC2018/dc18_common.py
+++ b/examples/DC2018/dc18_common.py
@@ -94,12 +94,14 @@ def event_coords(data_dir, event):
     return float(info["ra"][idx[0]]), float(info["dec"][idx[0]])
 
 
-def load_truth(data_dir, event):
-    """Simulation truth for one event, with t_0 in full BJD.
+def load_master_row(data_dir, event):
+    """The raw master_file.txt row for one event, plus its class label.
 
-    Returns (params_dict, class_label): params has the PARAMS keys, class is
-    the challenge's event class scraped from the master-file row ('cassan'
-    for the 2L1S planet sample, 'cv' for cataclysmic variables, ...).
+    Exposed separately from load_truth because the row carries far more than
+    the seven lensing parameters -- lens/source distances, masses, radii and
+    galactic-frame proper motions -- which the physics-chain and
+    alpha-convention checks (scripts/dc18_alpha_convention.py,
+    examples/DC2018/dc128_truth_forward.py) need.  Returns (row, class).
     """
     ans = Path(data_dir) / "Answers"
     cols = np.genfromtxt(
@@ -124,7 +126,20 @@ def load_truth(data_dir, event):
     row = df.iloc[event - 1]
     with open(master) as f:
         line = f.readlines()[event]  # +1 for the header line
-    class_label = line.split(" ")[-2].split("_")[0]
+    return row, line.split(" ")[-2].split("_")[0]
+
+
+def load_truth(data_dir, event):
+    """Simulation truth for one event, with t_0 in full BJD.
+
+    Returns (params_dict, class_label): params has the PARAMS keys, class is
+    the challenge's event class scraped from the master-file row ('cassan'
+    for the 2L1S planet sample, 'cv' for cataclysmic variables, ...).
+
+    NOTE the alpha returned here is the master file's own value, which is
+    NOT convertible to the fitted convention -- see ALPHA_IS_UNMAPPABLE.
+    """
+    row, class_label = load_master_row(data_dir, event)
     truth = {
         "t_0": float(row["t0"]) + DC18_TIME_ORIGIN,
         "u_0": float(row["u0"]),

--- a/examples/DC2018/dc2018_long.job
+++ b/examples/DC2018/dc2018_long.job
@@ -1,0 +1,96 @@
+# /bin/sh
+# ----------------Parameters---------------------- #
+#$ -S /bin/sh
+#$ -pe mthread 64
+#$ -q lThC.q
+#$ -cwd
+#$ -j y
+#$ -N dc2018L
+#$ -o dc2018.$JOB_ID.$TASK_ID.log
+#
+# DC2018 pipeline job (adapted from examples/DC2018_128/dc128.job).
+#
+# One SGE task = one event: MMEXOFAST init -> EXOZIPPy fit -> truth
+# comparison, all inside run_event.py.
+#
+# ---------------- Supercomputer command reference ----------------
+#
+# One-time setup (in the exozippy conda env; needs the patched MMEXOFAST,
+# see examples/DC2018/README.md):
+#   conda activate exozippy
+#   pip install git+https://github.com/jenniferyee/MMEXOFAST.git
+#   pip install git+https://github.com/jenniferyee/sfit_minimizer.git emcee
+#
+# Test with a single event first:
+#   cd ~/python/EXOZIPPy/examples/DC2018
+#   qsub -v EVENT=128 dc2018.job
+#
+# Then run all 44 events (one task per line of events.txt):
+#   qsub -t 1-44 dc2018.job
+#
+# Watch progress / results per event:
+#   qstat; tail -f dc2018.<jobid>.<taskid>.log
+#   cat events/<NNN>/status.txt          # running mmexofast / running exozippy / ok / failed
+#   cat events/<NNN>/comparison.csv      # per-event fit vs truth
+#
+# After the jobs finish, collect everything into one table
+# (one light curve per row: params, errors, truth, pulls, rhat, ess):
+#   python collect_results.py            # -> dc2018_summary.csv
+#
+# Optional overrides (qsub -v NAME=value, comma-separated for several):
+#   BANDS=Z087            fit only the sparse Z087 curve (fast; default W149,Z087)
+#   EXTRA="--quick"       any extra run_event.py flags (--quick = smoke test;
+#                         --mmx-emcee = MMEXOFAST's emcee polish, hours --
+#                         off by default, PTDE is the polish)
+#   DC18_DATA=...         data tree, if not at $HOME/python/MMEXOFAST/data/2018DataChallenge
+#
+# Re-running a task reuses the cached MMEXOFAST JSON (delete
+# events/<NNN>/DC2018_<NNN>_mmexofast.json to force a fresh init) and
+# resamples by default (add EXTRA="--no-recompute" to only redo reports).
+# ------------------------------------------------------------------
+#
+# run_event.py reads $NSLOTS for the sampler's core count, so it always
+# matches the "-pe mthread N" grant above -- change them together anyway if
+# you edit the queue request (see the oversubscription note in
+# examples/DC2018_128/DC2018_128_hpc.yaml).
+#
+# ----------------Modules------------------------- #
+module purge
+module load tools/python/3.13
+
+export PATH="$HOME/miniconda3/bin:$PATH:$HOME/.local/bin"
+
+# Source conda and activate the exozippy environment (needs mmexofast:
+#   pip install git+https://github.com/jenniferyee/MMEXOFAST.git
+#   pip install git+https://github.com/jenniferyee/sfit_minimizer.git emcee)
+source $HOME/miniconda3/etc/profile.d/conda.sh
+conda activate exozippy
+
+# PyTensor's C-module compile cache uses fcntl.flock() for its lock file.
+# ~/.pytensor's default location is under NFS-mounted $HOME, and this
+# cluster's NFS client doesn't honor advisory locks reliably (ENOLCK /
+# ESTALE mid-compile). Point it at the job's local-disk scratch dir instead.
+export PYTENSOR_FLAGS="base_compiledir=${TMPDIR:-/tmp}/pytensor"
+
+which python
+
+# Navigate to the workflow directory
+cd $HOME/python/EXOZIPPy/examples/DC2018
+
+# Resolve the event number for this task
+if [ -n "$EVENT" ]; then
+    ev=$EVENT
+else
+    ev=$(sed -n "${SGE_TASK_ID}p" events.txt)
+fi
+if [ -z "$ev" ]; then
+    echo "No event for task ${SGE_TASK_ID:-<unset>} (events.txt has $(wc -l < events.txt) lines)" >&2
+    exit 1
+fi
+
+: "${DC18_DATA:=$HOME/python/MMEXOFAST/data/2018DataChallenge}"
+export DC18_DATA
+: "${BANDS:=W149,Z087}"
+
+echo "Running DC2018 event $ev (bands $BANDS, $NSLOTS cores)"
+python run_event.py "$ev" --bands "$BANDS" $EXTRA

--- a/examples/DC2018/run_event.py
+++ b/examples/DC2018/run_event.py
@@ -212,7 +212,7 @@ def build_config(name, files, prefix, mmx_json, args):
     return config
 
 
-def build_user_params(ra, dec):
+def build_user_params(ra, dec, fix_u1=False, bands_for_u1=()):
     """Fixed-parameter overrides, mirroring examples/DC2018_128.
 
     Coordinates come from event_info.txt. The Lens's radius/teff/feh fixes
@@ -231,6 +231,23 @@ def build_user_params(ra, dec):
         "star.Lens.radius": {"sigma": 0.0},
         "planet.Companion.radius": {"sigma": 0},
     }
+    if fix_u1:
+        # The DC2018 light curves were simulated with gamma = 0 -- NO limb
+        # darkening -- in all 44 events (the master file's `gamma` column,
+        # and why run_mmexofast_step passes
+        # limb_darkening_coeffs_gamma = 0 to MMEXOFAST).  band.u1 is the
+        # linear u (op.py applies it via set_limb_coeff_u; gamma = 2u/(3-u),
+        # so gamma = 0 <=> u = 0 exactly).
+        #
+        # Left free it does not merely waste a parameter, it corrupts rho:
+        # limb darkening and source size both shape the finite-source peak
+        # and trade against each other.  Measured across five event-128 runs,
+        # u1(W149) ran 0.14 -> 1.87 (two of them physically impossible) and
+        # rho tracked it monotonically, 0.0050 -> 0.0111 against a truth of
+        # 0.00607.  For REAL data a prior is the right answer; for a dataset
+        # generated with zero limb darkening, zero is.
+        for b in bands_for_u1:
+            params[f"band.{b}.u1"] = {"initval": 0.0, "sigma": 0}
     return params
 
 
@@ -282,6 +299,13 @@ def main(argv=None):
         help="PT temperature rungs: an integer or 'auto' "
         "(max(8, ceil(sqrt(D/2)*ln(T_max))); use when the ladder-health "
         "warning reports a communication-limited ladder)",
+    )
+    ap.add_argument(
+        "--fix-u1",
+        action="store_true",
+        help="Pin every band's linear limb-darkening u1 at 0. Correct for "
+        "DC2018, whose 44 events were all simulated with gamma = 0; leaving "
+        "u1 free lets it trade against rho through the finite-source profile",
     )
     ap.add_argument(
         "--adapt-ladder",
@@ -393,7 +417,9 @@ def main(argv=None):
         mmx_json = event_dir / f"{name}_mmexofast.json"
 
     config = build_config(name, files, prefix, mmx_json, args)
-    user_params = build_user_params(ra, dec)
+    user_params = build_user_params(
+        ra, dec, fix_u1=args.fix_u1, bands_for_u1=bands
+    )
 
     # Reproducibility dump: `cd <event_dir> && exozippy DC2018_NNN.yaml`
     params_yaml = event_dir / f"{name}.params.yaml"

--- a/examples/DC2018/run_event.py
+++ b/examples/DC2018/run_event.py
@@ -185,6 +185,16 @@ def build_config(name, files, prefix, mmx_json, args):
             # to 8 on an unchanged 20-rung ladder.  Set n_chains down when
             # setting n_temps up to hold the slot count roughly fixed.
             "n_chains": args.n_chains,
+            # Re-space the ladder during tune to equalize the per-pair
+            # communication barrier (Syed+2022).  Worth turning on when the
+            # per-rung swap acceptances are non-uniform: a round trip must
+            # cross EVERY pair, so transport is throttled by the worst
+            # stretch and a geometric ladder cannot fix that by getting
+            # longer.  Measured on event 128 at n_temps=48 (a correctly
+            # provisioned ladder: Lambda=18.9 vs the 39 the DEO criterion
+            # asks): acceptance 0.46-0.52 cold against 0.66-0.70 hot, and
+            # zero round trips in 21 h.
+            "adapt_ladder": bool(args.adapt_ladder),
             "cores": args.cores,
             "tune": args.tune,
             "draws": args.draws,
@@ -272,6 +282,14 @@ def main(argv=None):
         help="PT temperature rungs: an integer or 'auto' "
         "(max(8, ceil(sqrt(D/2)*ln(T_max))); use when the ladder-health "
         "warning reports a communication-limited ladder)",
+    )
+    ap.add_argument(
+        "--adapt-ladder",
+        action="store_true",
+        help="Re-space the PT ladder during tuning to equalize the per-pair "
+        "communication barrier (sampler key adapt_ladder). Use when the "
+        "per-rung swap acceptances reported by the ladder-health line are "
+        "non-uniform",
     )
     ap.add_argument(
         "--n-chains",

--- a/scripts/dc18_alpha_convention.py
+++ b/scripts/dc18_alpha_convention.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Is the 2018 Roman Data Challenge answer key's alpha convertible to ours?
+
+Answer, measured over all 44 events: NO.  This script is the measurement,
+kept because the conclusion is a negative one and negatives rot -- the next
+person to notice a 2000-sigma alpha pull should be able to re-run this in an
+hour rather than re-derive it.
+
+    poetry run python scripts/dc18_alpha_convention.py
+
+WHAT IT DOES.  For every 2L1S event it holds the answer key's own t_0, u_0,
+t_E, rho, s and q fixed, scans alpha over [0, 360) in MulensModel's
+convention (which is EXOZIPPy's -- see components/mulensing/op.py, and
+mmexofast_support maps MMEXOFAST's alpha to ours by the identity), fits the
+source fluxes linearly at each step, and takes the alpha the light curve
+itself prefers.  It then asks whether ANY global transformation carries the
+master file's alpha onto that.
+
+WHY THE u_0 SIGN IS TAKEN FROM THE MASTER FILE AND NOT SCANNED.  These
+events have |pi_E| ~ 0.02, so parallax is negligible, and without it
+(u_0, alpha) -> (-u_0, -alpha) is an EXACT mirror symmetry of the light
+curve: event 128 gives byte-identical chi2 at (+0.1418, 308.15) and
+(-0.1418, 51.85).  Scanning both signs therefore adds no information and
+actively hurts -- `min` picks arbitrarily between two exactly tied minima,
+so the recovered alpha flips between branches at random and washes out any
+constant that might be there.  An earlier version of this script did scan
+both signs and produced a strictly noisier answer.  Alpha is only ever
+determined up to that reflection, which is why the reflected hypothesis is
+tested explicitly below rather than by flipping u_0.
+
+THE RESULT (44 events; circular concentration R, where 1.0 would mean "this
+IS the rule" and ~0.15 is what 44 random angles give):
+
+    fit - alpha_key                                       R = 0.09
+    fit + alpha_key   (a reflection)                      R = 0.10
+    either, with the galactic->equatorial PA removed      R = 0.11 - 0.19
+    either, with PA(mu_rel) removed                       R = 0.03 - 0.19
+
+That last one was the best physical guess: that the key's alpha is a sky
+POSITION ANGLE of the binary axis (which is how BAGLE defines its alpha)
+rather than an angle relative to the source trajectory, in which case the
+two differ by the position angle of the relative proper motion -- and that
+IS computable from the key's own galactic-frame proper motions.  It does
+not concentrate either.
+
+Restricting to the twelve events where the anomaly pins alpha hardest does
+not help: R = 0.22 and 0.41, against ~0.29 expected from twelve random
+angles.  So this is a property of the answer key, not of a weak constraint
+or of the wrong sign branch.
+
+CONSEQUENCE, already applied in examples/DC2018/dc18_common.py: alpha is
+reported with NO truth value and NO pull.  The sign/+-180 search that used
+to map it could not fail visibly -- it always returned its nearest
+candidate, so an unmappable truth came back as a confident number.  On
+event 128 it printed a 2034-sigma pull while the fitted alpha sat 0.3 deg
+from the light curve's own optimum.
+
+A plausible explanation, unconfirmed: the key carries a, inc, phase and
+period -- a full orbit -- but no node angle, so if alpha is defined in the
+orbital frame there is no way to reach a sky angle without Omega.  Matt
+Penny (who generated the simulations) has been asked.
+"""
+
+import json
+import multiprocessing as mp
+import os
+import sys
+from pathlib import Path
+
+import astropy.units as u
+import MulensModel as mm
+import numpy as np
+from astropy.coordinates import SkyCoord
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "examples" / "DC2018"))
+import dc18_common as dc  # noqa: E402
+
+DATA = Path(os.environ.get("DC18_DATA", dc.DEFAULT_DATA_DIR))
+BANDS = ("W149", "Z087")
+COARSE = 360  # 1 deg
+FINE_HALFWIDTH = 1.5  # deg either side of the coarse minimum
+FINE_N = 61
+
+
+def wrap(x):
+    return (np.asarray(x, float) + 180) % 360 - 180
+
+
+def concentration(v):
+    """Circular mean, scatter and resultant length R.
+
+    A plain std is meaningless near the 0/360 wrap, and the whole question
+    is whether a set of angles clusters.
+    """
+    v = np.asarray(v, float)
+    v = v[np.isfinite(v)]
+    if v.size == 0:
+        return np.nan, np.inf, 0.0
+    c, s = np.mean(np.cos(np.radians(v))), np.mean(np.sin(np.radians(v)))
+    R = float(np.hypot(c, s))
+    mean = float(np.degrees(np.arctan2(s, c)))
+    scat = float(np.degrees(np.sqrt(-2 * np.log(R)))) if R > 0 else np.inf
+    return mean, scat, R
+
+
+def _frame_basis(ra, dec):
+    """Galactic (l, b) unit vectors at (ra, dec), in equatorial (E, N)."""
+    c = SkyCoord(ra=ra * u.deg, dec=dec * u.deg, frame="icrs")
+    g = c.galactic
+    eps = 1e-5
+    cosd = np.cos(np.radians(dec))
+
+    def icrs_of(lon, lat):
+        s = SkyCoord(l=lon * u.deg, b=lat * u.deg, frame="galactic").icrs
+        return s.ra.deg, s.dec.deg
+
+    r1, d1 = icrs_of(g.l.deg + eps / np.cos(g.b.rad), g.b.deg)
+    r2, d2 = icrs_of(g.l.deg, g.b.deg + eps)
+    e_l = np.array([(r1 - ra) * cosd, d1 - dec]) / eps
+    e_b = np.array([(r2 - ra) * cosd, d2 - dec]) / eps
+    return e_l / np.hypot(*e_l), e_b / np.hypot(*e_b)
+
+
+def galactic_north_pa(ra, dec):
+    """Position angle of galactic north, east of equatorial north."""
+    _, e_b = _frame_basis(ra, dec)
+    return float(np.degrees(np.arctan2(e_b[0], e_b[1])))
+
+
+def pa_mu_rel(row, ra, dec):
+    """PA of mu_rel (lens - source) in galactic and equatorial frames.
+
+    The key gives proper motions in galactic (l, b), so the equatorial PA
+    needs the frame basis above.  This is the quantity that would separate
+    a trajectory-relative alpha from a sky position angle.
+    """
+    mu_l = float(row["lmu_l"]) - float(row["smu_l"])
+    mu_b = float(row["lmu_b"]) - float(row["smu_b"])
+    pa_gal = float(np.degrees(np.arctan2(mu_l, mu_b)))
+    e_l, e_b = _frame_basis(ra, dec)
+    v = mu_l * e_l + mu_b * e_b
+    return pa_gal, float(np.degrees(np.arctan2(v[0], v[1])))
+
+
+def one_event(event):
+    """Scan alpha for one event at the key's own other parameters."""
+    try:
+        truth, cls = dc.load_truth(DATA, event)
+        if (
+            not np.isfinite(truth["s"])
+            or not np.isfinite(truth["q"])
+            or truth["q"] <= 0
+        ):
+            return dict(event=event, cls=cls, status="no 2L1S truth")
+
+        datasets = []
+        for b in BANDS:
+            f = DATA / f"n20180816.{b}.WFIRST18.{event:03d}.txt"
+            if not f.exists():
+                continue
+            t, flux, err = np.loadtxt(f, unpack=True)
+            datasets.append(
+                mm.MulensData(data_list=[t, flux, err], phot_fmt="flux")
+            )
+        if not datasets:
+            return dict(event=event, cls=cls, status="no data")
+
+        window = (
+            truth["t_0"] - 3 * truth["t_E"],
+            truth["t_0"] + 3 * truth["t_E"],
+        )
+        # u_0 keeps the key's own SIGN -- see the module docstring.
+        base = {k: truth[k] for k in ("t_0", "u_0", "t_E", "rho", "s", "q")}
+
+        def chi2(alpha):
+            try:
+                model = mm.Model(dict(base, alpha=float(alpha)))
+                model.set_magnification_methods([window[0], "VBBL", window[1]])
+                return float(
+                    mm.Event(datasets=datasets, model=model).get_chi2()
+                )
+            except Exception:
+                return np.inf
+
+        grid = np.linspace(0.0, 360.0, COARSE, endpoint=False)
+        curve = np.array([chi2(a) for a in grid])
+        if not np.isfinite(curve).any():
+            return dict(event=event, cls=cls, status="all chi2 non-finite")
+        a0 = grid[int(np.nanargmin(curve))]
+        fine = np.linspace(a0 - FINE_HALFWIDTH, a0 + FINE_HALFWIDTH, FINE_N)
+        fcurve = np.array([chi2(a) for a in fine])
+        best = float(fine[int(np.nanargmin(fcurve))])
+        best_chi2 = float(np.nanmin(fcurve))
+
+        ra, dec = dc.event_coords(DATA, event)
+        master, _ = dc.load_master_row(DATA, event)
+        pg, pe = pa_mu_rel(master, ra, dec)
+        n = sum(len(d.time) for d in datasets)
+        return dict(
+            event=event,
+            cls=cls,
+            status="ok",
+            alpha_master=truth["alpha"],
+            alpha_fit=best,
+            offset=float(wrap(best - truth["alpha"])),
+            offset_reflected=float(wrap(best + truth["alpha"])),
+            # How sharply the light curve pins alpha at all: a weak anomaly
+            # leaves the whole grid within a few chi2 and its "best alpha"
+            # is noise that must not be allowed to vote.
+            contrast=float(np.nanmedian(curve) - best_chi2),
+            pa_gal_north=galactic_north_pa(ra, dec),
+            pa_murel_gal=pg,
+            pa_murel_eq=pe,
+            chi2=best_chi2,
+            chi2_per_n=best_chi2 / n,
+            n_points=n,
+            u_0=truth["u_0"],
+            s=truth["s"],
+            q=truth["q"],
+        )
+    except Exception as exc:
+        return dict(event=event, status=f"failed: {type(exc).__name__}: {exc}")
+
+
+def main():
+    events = [
+        int(x)
+        for x in open(REPO_ROOT / "examples" / "DC2018" / "events.txt")
+        if x.strip()
+    ]
+    ncpu = int(os.environ.get("NSLOTS", 0)) or max(1, mp.cpu_count() // 2)
+    print(
+        f"scanning alpha for {len(events)} events on {ncpu} workers\n",
+        flush=True,
+    )
+    with mp.Pool(ncpu) as pool:
+        rows = pool.map(one_event, events)
+
+    ok = [r for r in rows if r.get("status") == "ok"]
+    print(f"{len(ok)}/{len(rows)} events gave a 2L1S alpha scan\n")
+    print(
+        f"{'ev':>4s} {'cls':>10s} {'master':>9s} {'fit':>9s} "
+        f"{'offset':>9s} {'refl':>9s} {'contrast':>10s} {'chi2/N':>8s}"
+    )
+    for r in rows:
+        if r.get("status") != "ok":
+            print(
+                f"{r['event']:>4d} {str(r.get('cls', '?')):>10s}   "
+                f"{r['status']}"
+            )
+            continue
+        print(
+            f"{r['event']:>4d} {r['cls']:>10s} {r['alpha_master']:9.3f} "
+            f"{r['alpha_fit']:9.3f} {r['offset']:+9.3f} "
+            f"{r['offset_reflected']:+9.3f} {r['contrast']:10.1f} "
+            f"{r['chi2_per_n']:8.4f}"
+        )
+
+    def report(name, v):
+        mean, scat, R = concentration(v)
+        flag = "   <== THIS IS THE RULE" if R > 0.7 else ""
+        print(
+            f"  {name:36s} n={np.size(v):3d}  mean {mean:+8.2f}  "
+            f"scatter {scat:7.2f}  R={R:.4f}{flag}"
+        )
+
+    for cut in (0.0, 1000.0):
+        sub = [r for r in ok if r["contrast"] >= cut]
+        print("\n" + "=" * 74)
+        print(
+            f"CONVENTION HYPOTHESES   (contrast >= {cut:g}; {len(sub)} events)"
+        )
+        print("=" * 74)
+        if not sub:
+            continue
+        off = np.array([r["offset"] for r in sub])
+        refl = np.array([r["offset_reflected"] for r in sub])
+        pgn = np.array([r["pa_gal_north"] for r in sub])
+        pmg = np.array([r["pa_murel_gal"] for r in sub])
+        pme = np.array([r["pa_murel_eq"] for r in sub])
+        report("fit - master", off)
+        report("fit + master  (reflection)", refl)
+        report("fit - master -/+ PA(gal north)", wrap(off - pgn))
+        report("fit + master -/+ PA(gal north)", wrap(refl + pgn))
+        if np.isfinite(pmg).any():
+            report("fit - master - PA_gal(mu_rel)", wrap(off - pmg))
+            report("fit + master - PA_gal(mu_rel)", wrap(refl - pmg))
+            report("fit - master - PA_eq(mu_rel)", wrap(off - pme))
+            report("fit + master - PA_eq(mu_rel)", wrap(refl - pme))
+
+    print("\n  R near 1 (scatter << 20 deg) would identify the convention.")
+    print("  Nothing concentrates, at any contrast cut -- which is why")
+    print("  dc18_common reports alpha with no truth and no pull.")
+
+    out = REPO_ROOT / "dc18_alpha_convention.json"
+    json.dump(rows, open(out, "w"), indent=2)
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dc18_alpha_convention.py
+++ b/scripts/dc18_alpha_convention.py
@@ -61,6 +61,7 @@ orbital frame there is no way to reach a sky angle without Omega.  Matt
 Penny (who generated the simulations) has been asked.
 """
 
+import argparse
 import json
 import multiprocessing as mp
 import os
@@ -223,13 +224,58 @@ def one_event(event):
         return dict(event=event, status=f"failed: {type(exc).__name__}: {exc}")
 
 
-def main():
-    events = [
-        int(x)
-        for x in open(REPO_ROOT / "examples" / "DC2018" / "events.txt")
-        if x.strip()
-    ]
-    ncpu = int(os.environ.get("NSLOTS", 0)) or max(1, mp.cpu_count() // 2)
+def _parse_args(argv=None):
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--events",
+        default=None,
+        help="comma-separated event numbers (default: every line of "
+        "examples/DC2018/events.txt)",
+    )
+    ap.add_argument(
+        "--data-dir",
+        default=None,
+        help="2018DataChallenge tree (default $DC18_DATA, else the "
+        "MMEXOFAST source checkout)",
+    )
+    ap.add_argument(
+        "--ncpu",
+        type=int,
+        default=int(os.environ.get("NSLOTS", 0)) or None,
+        help="worker processes (default $NSLOTS, else half the machine)",
+    )
+    ap.add_argument(
+        "--contrast-cuts",
+        default="0,1000",
+        help="comma-separated minimum chi2 contrast for an event to vote in "
+        "the hypothesis tests: a weak anomaly leaves alpha unconstrained and "
+        "its best-fit value is noise (default 0,1000)",
+    )
+    ap.add_argument(
+        "--out",
+        default=str(REPO_ROOT / "dc18_alpha_convention.json"),
+        help="where to write the per-event JSON",
+    )
+    return ap.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    global DATA
+    if args.data_dir:
+        DATA = Path(args.data_dir)
+    if args.events:
+        events = [int(x) for x in args.events.split(",") if x.strip()]
+    else:
+        events = [
+            int(x)
+            for x in open(REPO_ROOT / "examples" / "DC2018" / "events.txt")
+            if x.strip()
+        ]
+    ncpu = args.ncpu or max(1, mp.cpu_count() // 2)
     print(
         f"scanning alpha for {len(events)} events on {ncpu} workers\n",
         flush=True,
@@ -265,7 +311,7 @@ def main():
             f"scatter {scat:7.2f}  R={R:.4f}{flag}"
         )
 
-    for cut in (0.0, 1000.0):
+    for cut in [float(c) for c in args.contrast_cuts.split(",")]:
         sub = [r for r in ok if r["contrast"] >= cut]
         print("\n" + "=" * 74)
         print(
@@ -293,7 +339,7 @@ def main():
     print("  Nothing concentrates, at any contrast cut -- which is why")
     print("  dc18_common reports alpha with no truth and no pull.")
 
-    out = REPO_ROOT / "dc18_alpha_convention.json"
+    out = Path(args.out)
     json.dump(rows, open(out, "w"), indent=2)
     print(f"\nwrote {out}")
 


### PR DESCRIPTION
DC2018 tooling and driver flags. No library code; the `u1 <= 1` bound fix
that came out of the same investigation is separated into #191.

### `--adapt-ladder` and a long-queue job

Forwards the sampler key added in #188. The measurement it exists for: at
T_max=8500 with n_temps=48 — a **correctly provisioned** ladder by the DEO
criterion (Λ = 18.9 against the 39 rungs 2Λ+1 asks for, mean swap acceptance
0.598 at its 0.50 target) — per-rung acceptance was 0.46–0.52 across the cold
pairs against 0.66–0.70 hot, and round trips stayed at **zero for 21 hours**.
A round trip must cross every pair, so transport is throttled by the worst
stretch, and a geometric ladder cannot fix that by getting longer.

`dc2018_long.job` is `dc2018.job` on `lThC.q` (h_rt 1440:15:00, 60 days)
instead of `mThC.q` (288:15:00, 12 days). A 48-rung run is 2.4× the slot count
of the 20-rung baseline, ~13.1 days at the measured eval rate — so on
`mThC.q` it is killed at ~92% of draws with **nothing written**, which is
exactly what the first attempt was heading for.

Recorded there too, since it cost time to discover: `qsig` is not installed on
this cluster, so a graceful stop means `ssh <node> kill -TERM <pid>` (the
samplers route SIGTERM to a stop-after-this-step via
`_common.install_stop_handlers`); `qdel` is a plain SIGKILL here because
`terminate_method` is `NONE`.

### `scripts/dc18_alpha_convention.py` — shipping a negative result

The conclusion is already applied (`dc18_common`'s `ALPHA_IS_UNMAPPABLE`:
the answer key's alpha is reported with no truth and no pull), but the
measurement behind it was never committed — and a negative result with no
reproducible script is one somebody re-derives from scratch the next time a
2000-sigma alpha pull appears.

Over all 44 events, nothing concentrates: R = 0.09 for a plain offset, 0.10
for a reflection, 0.11–0.19 with the galactic→equatorial PA removed, 0.03–0.19
with PA(mu_rel) removed (the best physical guess — that the key's alpha is a
sky *position angle* of the binary axis, which is how BAGLE defines its
alpha). Restricting to the 26 events where the anomaly pins alpha hardest
does not help.

**u_0 keeps the key's own sign and is not scanned**, which is why this is the
version shipped. With |pi_E| ~ 0.02 parallax is negligible, and without it
`(u_0, alpha) -> (-u_0, -alpha)` is an exact mirror symmetry — event 128 gives
byte-identical chi2 at (+0.1418, 308.15) and (−0.1418, 51.85). Scanning both
signs adds no information and actively hurts, since `min` picks arbitrarily
between two tied minima. A draft that did so produced a strictly noisier
answer; the reflection is tested as a *hypothesis* instead.

`dc18_common` grows `load_master_row`, factored out of `load_truth`: the row
carries the distances, masses, radii and galactic-frame proper motions the
alpha-convention and physics-chain checks need. An earlier draft guarded that
call with `hasattr` and silently fell back to NaN — quietly skipping two of
the eight hypotheses.

Verified: the shipped script reproduces the original numbers (R = 0.0937,
0.0968, …) on all 44 events.

### `--fix-u1`

All 44 DC2018 events carry `gamma = 0` in the answer key — the simulations
contain **no limb darkening at all**, which is already why
`run_mmexofast_step` passes `limb_darkening_coeffs_gamma = 0` to MMEXOFAST.
EXOZIPPy's side never got the same treatment.

`band.u1` is the linear *u* (`op.py` applies it via `set_limb_coeff_u`;
gamma = 2u/(3−u), so gamma = 0 ⟺ u = 0 exactly). Left free it does not merely
waste a parameter — limb darkening and source size both shape the
finite-source peak and trade against each other. Across five event-128 runs
u1(W149) ran 0.14 → 1.87 while **rho tracked it monotonically**, 0.0050 →
0.0111 against a truth of 0.00607: a 2.2× spread on the quantity that carries
theta_E and hence the lens mass.

For real data a prior is the right answer, and a Claret/LDC lookup driven by
the SED's own Teff/logg better still. For a dataset generated with zero limb
darkening, zero is.
