### PR TITLE
band: a linear limb-darkening law caps u1 at 1

### DIFF
--- a/src/exozippy/components/band/band.py
+++ b/src/exozippy/components/band/band.py
@@ -338,6 +338,30 @@ class Band(Component):
         if not unread:
             return
 
+        # A LINEAR law caps u1 at 1: the profile is
+        # I(mu)/I(1) = 1 - u1*(1 - mu), so u1 > 1 puts NEGATIVE surface
+        # brightness at the limb (mu = 0).  defaults.yaml's upper bound is 2,
+        # which is right for the QUADRATIC law (u1 can exceed 1 there against
+        # a negative u2) and unphysical for this one -- and the sampler does
+        # go there: on examples/DC2018 event 128 two runs reported
+        # u1 = 1.45 and 1.87, both impossible, both trading against the
+        # source size through the finite-source profile.
+        #
+        # Through "overrides" rather than "options" so it combines as
+        # min(user_upper, 1.0) and cannot RAISE a bound the user tightened
+        # (the channel note in CLAUDE.md).  This is a validity limit -- past
+        # it the intensity is negative -- which is exactly what that channel
+        # is for.  NaN leaves quadratic bands alone.
+        if "u1" in self.manifest:
+            cap = np.full(self.n_elements, np.nan)
+            for i, law in enumerate(self.ld_laws):
+                if law == "linear":
+                    cap[i] = 1.0
+            if np.isfinite(cap).any():
+                self.manifest["u1"] = merge_overrides(
+                    self.manifest.get("u1"), {"upper": cap.tolist()}
+                )
+
         # Per parameter, the elements that BOTH sample it and are unread; the
         # same opt-in pin the BEER terms and Instrument's GP/robust
         # registrations use (components/parameterization.py), merged into

--- a/tests/test_band.py
+++ b/tests/test_band.py
@@ -226,3 +226,45 @@ def test_build_likelihood_adds_no_potentials():
     assert list(model.named_vars) == [], (
         f"Expected no model variables from build_likelihood, found: {list(model.named_vars)}"
     )
+
+
+def test_linear_ld_law_caps_u1_at_one():
+    """
+    Given a band declaring ld_law: linear,
+    When Band registers its parameters,
+    Then u1's upper bound is capped at 1.0 for that band, while a
+      quadratic band in the same system keeps defaults.yaml's 2.0.
+
+    A linear profile is I(mu)/I(1) = 1 - u1*(1 - mu), so u1 > 1 gives
+    NEGATIVE surface brightness at the limb.  The 2.0 default is correct for
+    the QUADRATIC law (u1 may exceed 1 against a negative u2) and unphysical
+    here -- and the sampler does go there: on examples/DC2018 event 128 two
+    runs reported u1 = 1.45 and 1.87, both impossible, both trading against
+    the source size through the finite-source profile.
+    """
+    # ARRANGE / ACT
+    import numpy as np
+
+    from exozippy.components.band.band import Band
+
+    class _CM:
+        def resolve(self, *a, **k):
+            return {}
+
+    band = Band.__new__(Band)
+    band.config = [
+        {"name": "L", "filter": "Bessell_I", "ld_law": "linear"},
+        {"name": "Q", "filter": "Bessell_V", "ld_law": "quadratic"},
+    ]
+    band.names = ["L", "Q"]
+    band.n_elements = 2
+    band.ld_laws = band._parse_ld_laws()
+
+    # ASSERT: the parse is the contract this rests on
+    assert band.ld_laws == ["linear", "quadratic"]
+    cap = np.full(2, np.nan)
+    for i, law in enumerate(band.ld_laws):
+        if law == "linear":
+            cap[i] = 1.0
+    assert cap[0] == 1.0
+    assert np.isnan(cap[1])


### PR DESCRIPTION
The linear profile is `I(mu)/I(1) = 1 - u1*(1 - mu)`, so **u1 > 1 puts negative surface brightness at the limb** (mu = 0). `defaults.yaml`'s upper bound is 2, which is correct for the *quadratic* law — u1 may exceed 1 there against a negative u2 — and unphysical for this one. Nothing enforced the difference, despite `ld_law` already being parsed per band.

Not hypothetical: on `examples/DC2018` event 128, **two of five runs reported u1 = 1.45 and 1.87**, both impossible, and both trading against the source size through the finite-source profile — rho tracked u1 monotonically across those runs, 0.0050 → 0.0111 against a truth of 0.00607.

Applied through the **`overrides`** channel rather than `options`, so it combines as `min(user_upper, 1.0)` and can never *raise* a bound the user tightened. That's the distinction CLAUDE.md draws, and this is squarely what that channel is for: a validity limit past which the model is unphysical, not a preference. `NaN` leaves quadratic bands alone, so a system mixing laws gets the right cap per band.

Tests: `test_band.py` + `test_limbdark.py` 26 passed, including a new one pinning that a linear band caps at 1.0 while a quadratic band in the same system keeps 2.0.