### PR TITLE
ptde_async: window the ladder adaptation, and fix what its resets blinded

### DIFF
--- a/src/exozippy/samplers/_common.py
+++ b/src/exozippy/samplers/_common.py
@@ -515,34 +515,84 @@ class SpanTracker:
         np.minimum(self.lo[k], vec, out=self.lo[k])
         np.maximum(self.hi[k], vec, out=self.hi[k])
 
-    def report(self):
+    def reset(self):
+        """Discard the accumulated extremes and start a fresh window.
+
+        The CUMULATIVE span cannot answer the question it appears to.
+        min/max only ever widens, so a rung's span is permanently set by the
+        widest excursion it ever made -- which early in a run is where the
+        chains were thrown at initialization, not where the rung explores at
+        equilibrium, and no amount of subsequent sampling washes that out.
+        Measured on DC2018 event 128 still in its tune phase, the cumulative
+        T=1 span read 5995 sigma: a burn-in transient, reported in the same
+        field and the same units as a posterior width.
+
+        Both windows are worth having and the samplers keep two trackers:
+        the cumulative one is the honest answer to "where has this rung ever
+        been" (the reachability question this class was written for), the
+        windowed one to "how far is it exploring now".
+        """
+        self.lo[:] = np.inf
+        self.hi[:] = -np.inf
+
+    def _slice_of(self, key):
+        """(start, stop) of ``key``'s elements in the packed vector."""
+        for name, (a, b, _) in zip(self.layout.keys, self.layout.slices):
+            if name == key:
+                return a, b
+        raise KeyError(f"{key!r} is not a raw variable of this layout")
+
+    def _key_of(self, j):
+        """Parameter that owns packed element ``j``."""
+        for key, (a, b, _) in zip(self.layout.keys, self.layout.slices):
+            if a <= j < b:
+                return key
+        return "-"
+
+    def _widest(self, k, key=None):
+        """(span, owning parameter) at rung ``k``, over one variable or all.
+
+        A keyed call keeps naming its variable even where the span is 0.0:
+        the caller asked about that one, and reporting "-" back would lose
+        which parameter the zero belongs to.
+        """
+        unvisited = "-" if key is None else key
+        a, b = (0, self.layout.total) if key is None else self._slice_of(key)
+        span = self.hi[k, a:b] - self.lo[k, a:b]
+        finite = np.isfinite(span)
+        if not finite.any():
+            return 0.0, unvisited
+        masked = np.where(finite, span, -np.inf)
+        j = int(np.argmax(masked))
+        best = float(masked[j])
+        if best <= 0.0:
+            return 0.0, unvisited
+        return best, key if key is not None else self._key_of(a + j)
+
+    def report(self, key=None):
         """[(widest span in sigma, which parameter)] per rung.
 
         A rung no slot has reported yet gives (0.0, "-") rather than nan or
         inf: an unvisited rung has no span, and a diagnostic that prints inf
         reads as a bug rather than as "no data yet".
+
+        With ``key``, report THAT variable's span at every rung instead of
+        each rung's own widest.  That is what makes a top/cold RATIO
+        meaningful: each rung's independent max is generally a different
+        parameter, so dividing one by the other is not a ratio of anything.
+        On event 128 the hot rung's widest was log_f_total and the cold
+        rung's was pm_ra, and the reported "3x" compared the two.
         """
-        out = []
-        for k in range(self.n_temps):
-            span = self.hi[k] - self.lo[k]
-            finite = np.isfinite(span)
-            if not finite.any():
-                out.append((0.0, "-"))
-                continue
-            masked = np.where(finite, span, -np.inf)
-            j = int(np.argmax(masked))
-            best = float(masked[j])
-            if best <= 0.0:
-                out.append((0.0, "-"))
-                continue
-            # Map the winning element back to the parameter that owns it.
-            best_key = "-"
-            for key, (a, b, _) in zip(self.layout.keys, self.layout.slices):
-                if a <= j < b:
-                    best_key = key
-                    break
-            out.append((best, best_key))
-        return out
+        return [self._widest(k, key) for k in range(self.n_temps)]
+
+    def widest_at(self, k):
+        """Name of the widest-spanning variable at rung ``k``, or None.
+
+        The argument to pass back as ``report(key=...)`` when what is wanted
+        is one variable measured at both ends of the ladder.
+        """
+        _, key = self._widest(k)
+        return None if key == "-" else key
 
 
 # ---------------------------------------------------------------------------

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -107,6 +107,7 @@ def ptde_async_sample(
     adapt_gamma=True,
     gamma_adapt_window=None,
     adapt_ladder=False,
+    ladder_adapt_window=None,
     de_jitter=DE_JITTER,
     swap_interval=None,
     swap_schedule="deo",
@@ -150,6 +151,14 @@ def ptde_async_sample(
                stretch, and a geometric ladder cannot fix that by getting
                longer (measured on DC2018 event 128 -- see the block that
                calls _update_ladder_barrier below).
+    ladder_adapt_window : int | None -- re-space the ladder no more often
+               than once per this many swap PROPOSALS. None -> max(200,
+               20 * (n_temps - 1)), i.e. about 20 proposals per adjacent
+               pair. Unlike gamma's window this is not a cadence knob: the
+               adaptation zeroes the per-pair swap counters, so it measures
+               only what accumulated since it last ran, and running it more
+               often than this makes it re-space on noise (see the block
+               that calls _update_ladder_barrier).
     gamma_adapt_window : int | None -- adapt gamma once per this many
                completed T=1 proposals still within their own chain's tune
                phase. None -> max(n_chains, (tune * n_chains) // 20), i.e.
@@ -305,6 +314,14 @@ def ptde_async_sample(
         if gamma_adapt_window
         else max(n_chains, (tune * n_chains) // 20)
     )
+    # Enough swap proposals behind a per-pair rejection rate for it to mean
+    # anything: ~20 per adjacent pair, floored at 200 so a short ladder still
+    # accumulates a usable sample.  See the gating in the adaptation block.
+    ladder_adapt_window = (
+        max(1, int(ladder_adapt_window))
+        if ladder_adapt_window
+        else max(200, 20 * max(n_temps - 1, 1))
+    )
     # One async "step" = n_slots completed evaluations, the work of one
     # synchronous ptde.py step -- so log_interval means the same thing in
     # both samplers' configs.
@@ -351,9 +368,24 @@ def ptde_async_sample(
     # Per-rung explored span: see _common.SpanTracker for what it is for
     # and the DC2018 event 128 numbers that motivate reporting it live.
     spans = _common.SpanTracker(n_temps, raw_start, layout)
+    # Windowed twin, reset at every progress line.  The cumulative tracker
+    # can never shed the pre-equilibration transient, so on its own it
+    # answers "where has this rung ever been" and not "how far is it
+    # exploring now"; both are worth a column (SpanTracker.reset).
+    spans_window = _common.SpanTracker(n_temps, raw_start, layout)
 
+    # Swap counters, in two windows because two consumers need different
+    # ones.  The ADAPTATION window is zeroed by each re-spacing, because a
+    # re-spaced ladder's acceptances say nothing about the ladder that
+    # produced them -- and the wrap-up ladder_health_report wants exactly
+    # that window too, since its claim is about the FINAL ladder.  The
+    # progress line wants the opposite: a rate that does not collapse to
+    # noise every time the adaptation fires.
     n_swap_accept = np.zeros(max(n_temps - 1, 1))
     n_swap_propose = np.zeros(max(n_temps - 1, 1))
+    n_swap_accept_cum = np.zeros(max(n_temps - 1, 1))
+    n_swap_propose_cum = np.zeros(max(n_temps - 1, 1))
+    n_ladder_adapts = [0]  # re-spacing MEASUREMENTS, moved or not
     n_eval_timeouts = [0]
     n_swap_discards = [0]  # in-flight proposals invalidated by a swap
     rung_times = [[] for _ in range(n_temps)]
@@ -454,6 +486,7 @@ def ptde_async_sample(
         if lp_i is None or lp_j is None:
             return  # one side hasn't completed its first evaluation yet
         n_swap_propose[k] += 1
+        n_swap_propose_cum[k] += 1
         log_a = (lp_j - lp_i) * (
             1.0 / temperatures[k] - 1.0 / temperatures[k + 1]
         )
@@ -474,6 +507,7 @@ def ptde_async_sample(
             state_gen[k][i] += 1
             state_gen[k + 1][j] += 1
             n_swap_accept[k] += 1
+            n_swap_accept_cum[k] += 1
         # Update round-trip tags after every swap event (idempotent): a config
         # sitting at either extreme rung is tagged accordingly and a completed
         # cold -> hot -> cold excursion is counted.
@@ -724,6 +758,7 @@ def ptde_async_sample(
                 current_state[k][i] = prop
                 current_lp[k][i] = lp
                 spans.update(k, prop)
+                spans_window.update(k, prop)
             else:
                 T = temperatures[k]
                 n_propose[k] += 1
@@ -739,6 +774,7 @@ def ptde_async_sample(
                     current_lp[k][i] = lp
                     n_accept[k] += 1
                     spans.update(k, prop)
+                    spans_window.update(k, prop)
                     # Runaway-lp early detection (see LpPlausibilityGuard).
                     if k == 0:
                         lp_guard.check(i, lp)
@@ -832,18 +868,35 @@ def ptde_async_sample(
             # re-spacing once any chain is RECORDING would break invariance.
             # `temperatures` is mutated IN PLACE because _attempt_swap closes
             # over it by reference and never rebinds it.
+            # WINDOWED on the swap counters, and that gate is the whole
+            # correctness of this block, not a tuning preference.  The
+            # synchronous copy sits inside `if (step + 1) % log_every == 0`
+            # and so is windowed by construction; this one runs per completed
+            # EVALUATION, and since it zeroes the counters on the way out,
+            # `n_swap_propose.sum() > 0` meant it fired again on the very next
+            # proposal -- measuring a "barrier" from one or two swaps and
+            # re-spacing the ladder on it.  Observed on DC2018 event 128:
+            # zero re-spacing lines in 10 hours (every measurement said the
+            # ladder was already equalized, because a single accepted swap
+            # says every pair it touched is perfect), while the reported swap
+            # acceptances read 0.11-0.18 against 0.46-0.70 for the same
+            # ladder with adapt_ladder off -- the counters were being read
+            # one proposal after they were cleared.
             if (
                 adapt_ladder
                 and not gamma_frozen[0]
                 and n_temps > 2
-                and n_swap_propose.sum() > 0
+                and n_swap_propose.sum() >= ladder_adapt_window
             ):
+                n_measured = int(n_swap_propose.sum())
+                n_ladder_adapts[0] += 1
                 new_T = _update_ladder_barrier(
                     temperatures, n_swap_accept, n_swap_propose
                 )
                 if not np.allclose(new_T, temperatures):
                     logger.info(
-                        "PTDE-async ladder (barrier-equalized): "
+                        "PTDE-async ladder (barrier-equalized, from "
+                        f"{n_measured} swap proposals): "
                         f"T=[{', '.join(f'{t:.1f}' for t in new_T)}]"
                     )
                     temperatures[:] = new_T
@@ -855,7 +908,11 @@ def ptde_async_sample(
 
             if n_completed_total[0] % log_every_evals == 0:
                 ar = n_accept / np.maximum(n_propose, 1)
-                sr = n_swap_accept / np.maximum(n_swap_propose, 1)
+                # CUMULATIVE, and labelled as such below.  The adaptation
+                # window would read near zero for one line after every
+                # re-spacing, which is indistinguishable here from a ladder
+                # that has stopped communicating.
+                sr = n_swap_accept_cum / np.maximum(n_swap_propose_cum, 1)
                 rt_rate = round_trips[0] / max(n_swap_rounds[0], 1)
                 logger.info(
                     f"PTDE-async: {n_completed_total[0]} evals  "
@@ -865,21 +922,42 @@ def ptde_async_sample(
                     f"accept=[{', '.join(f'{r:.2f}' for r in ar)}]  "
                     f"gamma={gamma_box[0]:.4f}  "
                     + (
-                        f"swap=[{', '.join(f'{r:.2f}' for r in sr)}]  "
+                        f"swap(cum)=[{', '.join(f'{r:.2f}' for r in sr)}]  "
                         f"round_trips={round_trips[0]} "
                         f"(rate={rt_rate:.3f}/swap)"
                         if n_temps > 1
                         else ""
                     )
                 )
-                span_rep = spans.report()
-                logger.info(
-                    "PTDE-async explored span (raw sigma, running): "
-                    f"T=1 {span_rep[0][0]:.1f} ({span_rep[0][1]})  "
-                    f"T={temperatures[-1]:.0f} {span_rep[-1][0]:.1f} "
-                    f"({span_rep[-1][1]})  "
-                    f"top/cold={span_rep[-1][0] / max(span_rep[0][0], 1e-9):.0f}x"
-                )
+                # ONE variable -- whichever ranges widest at the HOT
+                # rung -- measured at both ends, so top/cold is a ratio of
+                # the same thing.  Each rung's own widest is generally a
+                # different parameter: on event 128 this divided the hot
+                # rung's log_f_total span by the cold rung's pm_ra span and
+                # printed "3x", which is a ratio of nothing.
+                hot_key = spans.widest_at(n_temps - 1)
+                if hot_key is None:
+                    # No accepted state at the hot rung yet, so there is no
+                    # variable to measure at both ends.  Say that, rather
+                    # than fall back to report(None) -- per-rung maxima are
+                    # exactly the incomparable pair this block removes.
+                    logger.info(
+                        "PTDE-async explored span: no states recorded at "
+                        f"T={temperatures[-1]:.0f} yet"
+                    )
+                else:
+                    cum = spans.report(hot_key)
+                    win = spans_window.report(hot_key)
+                    ratio = cum[-1][0] / max(cum[0][0], 1e-9)
+                    logger.info(
+                        f"PTDE-async explored span (raw sigma) [{hot_key}]: "
+                        f"cumulative T=1 {cum[0][0]:.1f}  "
+                        f"T={temperatures[-1]:.0f} {cum[-1][0]:.1f}  "
+                        f"(top/cold {ratio:.1f}x)  |  this window T=1 "
+                        f"{win[0][0]:.1f}  T={temperatures[-1]:.0f} "
+                        f"{win[-1][0]:.1f}"
+                    )
+                spans_window.reset()
 
             _maybe_stop()
             if not stopping[0]:
@@ -983,6 +1061,16 @@ def ptde_async_sample(
         _extras.append(f"  swap_discards={n_swap_discards[0]}")
     if n_eval_timeouts[0]:
         _extras.append(f"  eval_timeouts={n_eval_timeouts[0]}")
+    # Both the stamp below and the ladder_health_report after it are fed the
+    # ADAPTATION window, deliberately: each makes a claim about the ladder
+    # that is in `temperatures` NOW.  With adapt_ladder off nothing ever
+    # clears these counters and the window is the whole run (tune+draw --
+    # there is no global tune/draw boundary here to reset on, chains
+    # transition individually, which is why the synchronous sampler's
+    # reset-at-`step == tune` rule has no analog); with it on, the window
+    # runs from the last re-spacing, which is the only span over which the
+    # final ladder was the one being measured.  Feeding either the cumulative
+    # counters instead would average over every ladder the run ever had.
     _common.stamp_and_log_run_summary(
         idata,
         "PTDE-async",
@@ -1000,9 +1088,19 @@ def ptde_async_sample(
         rate_unit="swap",
         extras=_extras,
     )
-    # Async never resets the swap counters, so these stats span tune+draw;
-    # still the right order of magnitude for the barrier check.
     ladder_health_report(temperatures, n_swap_accept, n_swap_propose)
+    if adapt_ladder and n_temps > 2 and not n_ladder_adapts[0]:
+        logger.warning(
+            "PTDE-async: adapt_ladder was requested but the ladder was never "
+            f"re-spaced -- no {ladder_adapt_window}-swap-proposal window "
+            "completed before the first T=1 chain left its tune phase. The "
+            "ladder sampled is the one it started with. Lengthen tune, "
+            "shorten swap_interval (currently "
+            f"{swap_interval} evaluations per swap attempt), or pass a "
+            "smaller ladder_adapt_window -- but note the window exists so "
+            "the barrier is measured from enough swaps to mean anything, so "
+            "prefer the first two."
+        )
 
     if collect_rung_timing:
         _common.log_rung_timing(rung_times, temperatures, "PTDE-async", logger)

--- a/tests/test_ptde_async_ladder.py
+++ b/tests/test_ptde_async_ladder.py
@@ -13,6 +13,8 @@ every pair, so transport is set by the worst stretch; a geometric ladder
 cannot fix that by getting longer.
 """
 
+import logging
+
 import numpy as np
 import pytest
 
@@ -139,3 +141,238 @@ def test_span_tracker_reports_zero_for_an_unvisited_rung():
     rep = tr.report()
     assert rep[1] == (0.0, "-")
     assert np.isfinite(rep[0][0])
+
+
+def _packed(layout, **values):
+    """One packed raw state, so these tests speak the samplers' own form."""
+    return layout.pack(values)
+
+
+def test_span_window_resets_while_the_cumulative_span_does_not():
+    """
+    Given a rung that ranged far early and is confined afterwards,
+    When one tracker is reset and both then record only the confined region,
+    Then the reset one reports the RECENT span and the other still reports
+      the historical one.
+
+    Both numbers are wanted and they answer different questions, which is why
+    the samplers carry two trackers.  A running min/max only ever widens, so
+    a cumulative span is permanently set by the widest excursion the rung
+    ever made -- early in a run, where the chains were thrown at
+    initialization.  On DC2018 event 128 still in its tune phase the
+    cumulative T=1 span read 5995 sigma, which is a burn-in transient
+    reported in the same field and units as a posterior width.
+    """
+    # ARRANGE
+    from exozippy.samplers._common import RawLayout, SpanTracker
+
+    start = {"a": np.zeros(())}
+    layout = RawLayout(start)
+    cum = SpanTracker(n_temps=1, raw_start=start, layout=layout)
+    win = SpanTracker(n_temps=1, raw_start=start, layout=layout)
+    for v in (-500.0, 500.0):  # the early excursion, seen by both
+        cum.update(0, _packed(layout, a=np.array(v)))
+        win.update(0, _packed(layout, a=np.array(v)))
+    assert win.report()[0][0] == pytest.approx(1000.0)
+
+    # ACT: a fresh window, then only the confined region
+    win.reset()
+    for v in (-1.0, 1.0):
+        cum.update(0, _packed(layout, a=np.array(v)))
+        win.update(0, _packed(layout, a=np.array(v)))
+
+    # ASSERT
+    assert win.report()[0][0] == pytest.approx(2.0)
+    assert cum.report()[0][0] == pytest.approx(1000.0)
+
+
+def test_span_report_on_one_key_makes_a_top_cold_ratio_meaningful():
+    """
+    Given two rungs whose widest-ranging parameters DIFFER,
+    When the span is reported for one named parameter,
+    Then both rungs report that parameter, so top/cold compares like with
+      like.
+
+    Each rung's independent maximum is generally a different parameter, and
+    dividing one by the other is a ratio of nothing: on event 128 it divided
+    the hot rung's log_f_total span by the cold rung's pm_ra span and printed
+    "3x".
+    """
+    # ARRANGE
+    from exozippy.samplers._common import RawLayout, SpanTracker
+
+    start = {"tight": np.zeros(()), "loose": np.zeros(())}
+    layout = RawLayout(start)
+    tr = SpanTracker(n_temps=2, raw_start=start, layout=layout)
+    # rung 0: "loose" ranges widest (60 vs 2).  rung 1: "tight" does (200 vs 10).
+    for t, lo in ((-1.0, -30.0), (1.0, 30.0)):
+        tr.update(0, _packed(layout, tight=np.array(t), loose=np.array(lo)))
+    for t, lo in ((-100.0, -5.0), (100.0, 5.0)):
+        tr.update(1, _packed(layout, tight=np.array(t), loose=np.array(lo)))
+
+    # ACT
+    free = tr.report()
+    keyed = tr.report("tight")
+
+    # ASSERT: unkeyed, the two ends name different parameters
+    assert tr.widest_at(0) == "loose"
+    assert tr.widest_at(1) == "tight"
+    assert (free[0][1], free[1][1]) == ("loose", "tight")
+    # keyed, both ends are the same parameter and the ratio is 200/2
+    assert keyed[0][0] == pytest.approx(2.0)
+    assert keyed[1][0] == pytest.approx(200.0)
+    assert keyed[1][1] == keyed[0][1] == "tight"
+
+
+def test_span_report_on_a_key_no_rung_has_visited_is_zero_not_inf():
+    """An unvisited rung reports 0.0 for a named key too, never inf."""
+    from exozippy.samplers._common import RawLayout, SpanTracker
+
+    start = {"a": np.zeros(())}
+    layout = RawLayout(start)
+    tr = SpanTracker(n_temps=2, raw_start=start, layout=layout)
+    tr.update(0, _packed(layout, a=np.array(3.0)))
+
+    assert tr.report("a")[1][0] == 0.0
+    assert tr.widest_at(1) is None
+
+
+def test_widest_at_returns_none_before_any_state_is_recorded():
+    """No rung has a span yet, so there is no widest parameter to name."""
+    from exozippy.samplers._common import RawLayout, SpanTracker
+
+    start = {"a": np.zeros(2)}
+    tr = SpanTracker(n_temps=2, raw_start=start, layout=RawLayout(start))
+
+    assert tr.widest_at(0) is None
+
+
+# ---------------------------------------------------------------------------
+# The adaptation window (ptde_async)
+# ---------------------------------------------------------------------------
+
+
+class _MinimalSystem:
+    """Minimal system stub for ptde_async_sample (see test_ptde_async.py)."""
+
+    active_components = {}
+
+    def get_raw_start(self, model):
+        return model.initial_point()
+
+
+def _spy_on_adaptation(monkeypatch):
+    """Record the swap-proposal count behind every re-spacing measurement."""
+    from exozippy.samplers import ptde_async
+
+    seen = []
+    real = ptde_async._update_ladder_barrier
+
+    def spy(temperatures, accept, propose):
+        seen.append(float(np.sum(propose)))
+        return real(temperatures, accept, propose)
+
+    monkeypatch.setattr(ptde_async, "_update_ladder_barrier", spy)
+    return seen
+
+
+def _run_async(**kwargs):
+    import pymc as pm
+
+    from exozippy.samplers.ptde_async import ptde_async_sample
+
+    with pm.Model() as model:
+        pm.Normal("x", mu=0.0, sigma=1.0)
+        pm.Normal("y", mu=3.0, sigma=0.5)
+    return ptde_async_sample(
+        model,
+        _MinimalSystem(),
+        draws=20,
+        tune=40,
+        n_temps=4,
+        T_max=8.0,
+        n_chains=4,
+        cores=1,
+        seed=7,
+        swap_interval=1,
+        log_interval=1000,
+        adapt_ladder=True,
+        **kwargs,
+    )
+
+
+def test_ladder_adaptation_never_measures_a_barrier_from_a_short_window(
+    monkeypatch,
+):
+    """
+    Given adapt_ladder on,
+    When the sampler runs,
+    Then every re-spacing measurement is backed by at least
+      ladder_adapt_window swap proposals.
+
+    The gate is the correctness of the block, not a tuning preference.  The
+    adaptation ZEROES the per-pair swap counters on its way out and runs per
+    completed evaluation, so gating on `n_swap_propose.sum() > 0` -- as the
+    original port did -- fired it again on the very next proposal, measuring
+    a communication barrier from one or two swaps.  Observed on DC2018
+    event 128: zero re-spacing log lines in 10 hours, because a single
+    accepted swap says every pair it touched is already perfectly
+    equalized.
+    """
+    # ARRANGE
+    seen = _spy_on_adaptation(monkeypatch)
+    window = 60
+
+    # ACT
+    _run_async(ladder_adapt_window=window)
+
+    # ASSERT
+    assert seen, "the adaptation never ran at all; the test proves nothing"
+    assert min(seen) >= window, (
+        f"re-spaced on {min(seen):.0f} swap proposals against a window of "
+        f"{window}"
+    )
+
+
+def test_ladder_adaptation_does_not_run_at_all_below_one_window(
+    monkeypatch, caplog
+):
+    """
+    Given a window wider than the whole run,
+    When the sampler runs with adapt_ladder on,
+    Then the ladder is never re-spaced AND the run says so.
+
+    Two halves of one contract.  The gate must be capable of suppressing the
+    adaptation, otherwise passing it is decoration -- and windowing the gate
+    makes "adapt_ladder did nothing at all" reachable, where the unwindowed
+    version adapted (uselessly) on every proposal.  A knob that is silently
+    inert is the failure this codebase warns about everywhere else, so the
+    sampler warns and names the three ways out.
+    """
+    # ARRANGE
+    seen = _spy_on_adaptation(monkeypatch)
+
+    # ACT
+    with caplog.at_level(
+        logging.WARNING, logger="exozippy.samplers.ptde_async"
+    ):
+        _run_async(ladder_adapt_window=10**9)
+
+    # ASSERT
+    assert seen == []
+    assert any(
+        "adapt_ladder was requested but the ladder was never re-spaced"
+        in r.message
+        for r in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+def test_async_exposes_ladder_adapt_window_and_defaults_it_to_none():
+    """The knob exists and defaults to the measured-from-n_temps value."""
+    import inspect
+
+    from exozippy.samplers.ptde_async import ptde_async_sample
+
+    sig = inspect.signature(ptde_async_sample)
+    assert "ladder_adapt_window" in sig.parameters
+    assert sig.parameters["ladder_adapt_window"].default is None


### PR DESCRIPTION
Three defects in the `adapt_ladder` port to `ptde_async`, all found by the first
real run to use it (DC2018 event 128, T_max=8500, n_temps=48, 10 hours). All
three are mine, from #188/#189.

### 1. The adaptation was unwindowed, which made it worse than absent

The synchronous copy sits inside `if (step + 1) % log_every == 0` and is
windowed by construction. The port runs per completed **evaluation**, and it
zeroes the per-pair swap counters on its way out -- so `n_swap_propose.sum() > 0`
re-armed it on the very next proposal, and every measurement saw one or two
swaps.

That is not merely noisy, it is self-defeating: a single accepted swap says
every pair it touched is perfectly equalized, so the barrier looked flat and the
ladder was never re-spaced. **Zero re-spacing log lines in ten hours**, from code
whose only purpose is to re-space it.

Gated now on a new `ladder_adapt_window` (default `max(200, 20*(n_temps-1))`,
about 20 proposals per adjacent pair). Deliberately **not** a sampler-config
key, matching `gamma_adapt_window`: raising it only disables the adaptation,
which `adapt_ladder: false` already does, and lowering it reintroduces this bug.

### 2. The same resets blinded the diagnostics

The progress line read the counters one proposal after they were cleared. Its
reported swap acceptances of 0.11-0.18 are not comparable to the 0.46-0.70 the
same ladder gives with `adapt_ladder` off, and I quoted them in the run notes as
if they were. The live line now reads never-reset cumulative counters and says
`swap(cum)=` so it cannot be misread.

The wrap-up `ladder_health_report` and the trace stamp **keep** the adaptation
window, deliberately: their claim is about the ladder in `temperatures` now, and
the cumulative counters would average over every ladder the run ever had. This
is the same argument the synchronous sampler's `step == tune` reset comment
makes. The comment claiming "async never resets the swap counters" was true only
with `adapt_ladder` off, and is corrected.

### 3. The `top/cold` span ratio compared different parameters

`spans.report()` returns each rung's own widest span, and the two ends are
generally different variables -- on event 128 the hot rung's `log_f_total` over
the cold rung's `pm_ra`, printed as "3x". `SpanTracker.report(key)` now measures
one named variable at both ends, chosen as whatever ranges widest at the hot rung
(`widest_at`), so the ratio is a ratio of something.

### Also: the cumulative span can never shed the burn-in transient

min/max only widens, so a rung's span stays pinned to wherever the chains were
thrown at initialization. On event 128 mid-tune the cumulative T=1 span read
5995 sigma -- a burn-in excursion, in the same field and units as a posterior
width, and I read it as one. Both questions are worth answering, so the sampler
carries a windowed twin (`SpanTracker.reset`) and reports both.

### New failure mode, closed

Windowing the gate makes "`adapt_ladder` did nothing at all" reachable: a run
whose tune phase never accumulates one window now adapts zero times, where the
broken version adapted uselessly on every proposal. A silently inert knob is the
failure this codebase warns about everywhere else, so the sampler warns at
wrap-up and names the three ways out.

### Tests

The gate is covered **behaviorally** -- a spy on `_update_ladder_barrier` through
a real async run asserts every measurement is backed by at least a window's worth
of proposals, and that an oversized window suppresses the adaptation entirely and
warns. No source-string inspection. Plus `SpanTracker` reset / keyed-report /
`widest_at` unit coverage, including the keyed-but-unvisited and
nothing-recorded-yet paths.

Full suite run on the cluster at this commit in a clean worktree:
**2855 passed, 61 skipped, 1 xfailed, 0 failed** (2848 + the 7 tests added here;
`origin/master` measured at 2848 in the same configuration).

Rebuilt on current master rather than rebased: the `SpanTracker` packing refactor
obsoleted about half the original branch, including a `np.minimum(..., out=)`
crash on 0-d views that the packing dissolves on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
