### PR TITLE
run: forward adapt_ladder to ptde_async, which accepted it and never got it

### DIFF
--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -663,6 +663,7 @@ def _run_fit(config, gui, user_params=None):
                     eval_timeout=eval_timeout,
                     collect_rung_timing=collect_rung_timing,
                     swap_schedule=swap_schedule,
+                    adapt_ladder=adapt_ladder,
                     progress_callback=gui.progress_callback,
                 )
             elif method in ("numpyro", "blackjax"):

--- a/tests/test_sampler_kwarg_plumbing.py
+++ b/tests/test_sampler_kwarg_plumbing.py
@@ -1,0 +1,126 @@
+"""Every sampler knob both PTDE samplers accept must reach BOTH of them.
+
+`adapt_ladder` was forwarded to `ptde_sample` and NOT to `ptde_async_sample`,
+which accepts it.  So `adapt_ladder: true` in a config was silently inert for
+ptde_async -- the recommended sampler for Op-based (microlensing) models, and
+the one the DC2018 fits actually use.  The knob had never once been reachable
+from a config, and nothing said so: no warning, no error, and the sampler
+simply took the parameter's own `False` default.
+
+That cost real time.  A 21-hour DC2018 event-128 run and a second one after it
+were launched specifically to test ladder re-spacing, both reported zero
+re-spacing events, and the absence was read as evidence about the adaptation
+ALGORITHM when it was really evidence that the algorithm was never switched on.
+
+The invariant pinned here is deliberately the SYMMETRY rather than a list of
+expected kwargs: a key that both functions accept but only one call site passes
+is exactly this bug's shape, needs no judgement about what "should" be
+forwarded, and stays correct as knobs are added.  Keys only one function
+accepts are excluded automatically, which is what makes the two documented
+asymmetries -- rung_thin_factor/rung_thin_start (ptde-only: thinning addresses
+the blocking problem async dispatch removes outright) and store_hot_chains
+(async-only) -- pass without an allowlist to maintain.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUN_PY = REPO_ROOT / "src" / "exozippy" / "run.py"
+SAMPLERS = {
+    "ptde_sample": REPO_ROOT / "src" / "exozippy" / "samplers" / "ptde.py",
+    "ptde_async_sample": (
+        REPO_ROOT / "src" / "exozippy" / "samplers" / "ptde_async.py"
+    ),
+}
+
+
+def _accepted_params(path, func_name):
+    """Parameter names of ``func_name`` as defined in ``path``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            return {a.arg for a in node.args.args + node.args.kwonlyargs} - {
+                "model",
+                "system",
+            }
+    raise AssertionError(f"{func_name} not found in {path}")
+
+
+def _forwarded_kwargs(func_name):
+    """Keyword names run.py passes at its ``func_name(...)`` call site."""
+    src = RUN_PY.read_text(encoding="utf-8")
+    # The call site, not the import: match "name(" preceded by "= " so the
+    # `from ... import name` line cannot be picked up.
+    start = src.index(f"= {func_name}(") + len(f"= {func_name}")
+    depth = 0
+    for end in range(start, len(src)):
+        if src[end] == "(":
+            depth += 1
+        elif src[end] == ")":
+            depth -= 1
+            if depth == 0:
+                break
+    return set(re.findall(r"^\s*(\w+)=", src[start:end], re.M))
+
+
+def test_both_ptde_samplers_are_defined_and_called():
+    """Guards the tests below from passing vacuously on a rename."""
+    for name, path in SAMPLERS.items():
+        assert _accepted_params(path, name)
+        assert _forwarded_kwargs(name)
+
+
+@pytest.mark.parametrize("func_name", sorted(SAMPLERS))
+def test_run_py_forwards_adapt_ladder_to_this_sampler(func_name):
+    """
+    Given a PTDE sampler that accepts adapt_ladder,
+    When run.py dispatches to it,
+    Then adapt_ladder is forwarded.
+
+    The specific regression: ptde_async accepted it and never received it.
+    """
+    # Arrange
+    accepted = _accepted_params(SAMPLERS[func_name], func_name)
+    assert "adapt_ladder" in accepted, (
+        f"{func_name} no longer accepts adapt_ladder; if that is deliberate, "
+        f"delete this test rather than weakening it."
+    )
+
+    # Act / Assert
+    assert "adapt_ladder" in _forwarded_kwargs(func_name), (
+        f"run.py does not pass adapt_ladder to {func_name}, so the sampler "
+        f"config key is silently inert for it."
+    )
+
+
+def test_no_shared_sampler_knob_reaches_only_one_of_them():
+    """
+    Given a keyword BOTH PTDE samplers accept,
+    When run.py's two call sites are compared,
+    Then neither passes it while the other does not.
+
+    The general form of the bug.  A knob only one function accepts is not an
+    asymmetry (rung_thin_* is ptde-only, store_hot_chains async-only) and is
+    excluded by the intersection, so this needs no maintained allowlist.
+    """
+    # Arrange
+    sync_accepts = _accepted_params(SAMPLERS["ptde_sample"], "ptde_sample")
+    async_accepts = _accepted_params(
+        SAMPLERS["ptde_async_sample"], "ptde_async_sample"
+    )
+    shared = sync_accepts & async_accepts
+
+    # Act
+    sync_passed = _forwarded_kwargs("ptde_sample") & shared
+    async_passed = _forwarded_kwargs("ptde_async_sample") & shared
+
+    # Assert
+    assert sync_passed == async_passed, (
+        "asymmetric plumbing for keywords BOTH samplers accept -- "
+        f"ptde only: {sorted(sync_passed - async_passed)}; "
+        f"ptde_async only: {sorted(async_passed - sync_passed)}"
+    )


### PR DESCRIPTION
`ptde_async_sample` takes an `adapt_ladder` parameter and `run.py`'s dispatch
never passed it, so the sampler silently used the parameter's own `False`
default. **`adapt_ladder: true` in a config has been inert for `ptde_async`
since the knob was added** — and `ptde_async` is the recommended sampler for
Op-based models, i.e. every microlensing fit. The synchronous `ptde_sample`
branch, four lines away, passes it.

```python
                    collect_rung_timing=collect_rung_timing,
                    swap_schedule=swap_schedule,
+                   adapt_ladder=adapt_ladder,
                    progress_callback=gui.progress_callback,
```

### Why nothing caught it

Three independent silences line up:

* the key is in `KNOWN_SAMPLER_KEYS`, so it does not trip the unknown-key warning;
* the sampler cannot distinguish "not requested" from "requested but not plumbed";
* the feature's only visible symptom is the **absence** of re-spacing log lines —
  which is also exactly what a healthy, already-equalized ladder looks like.

### What it cost

Two multi-day DC2018 event-128 runs were launched specifically to test ladder
re-spacing. Both reported zero re-spacing events. I read that as evidence about
the adaptation **algorithm**, and diagnosed and fixed three real defects in it
(#195) on the strength of a symptom the algorithm never produced — because it
never ran. Those defects are real and the fixes stand; the causal story attached
to them in #195's description does not, and I have corrected it there.

### The test

It pins the **symmetry** rather than a list of expected kwargs: a keyword that
*both* PTDE samplers accept must appear at both call sites. That is this bug's
exact shape, needs no judgement about what "should" be forwarded, and stays
correct as knobs are added. Keys only one function accepts drop out of the
intersection automatically, so the two deliberate asymmetries —
`rung_thin_factor`/`rung_thin_start` (ptde-only: thinning addresses the blocking
problem async dispatch removes outright) and `store_hot_chains` (async-only) —
pass with no allowlist to maintain.

Verified to fail on the unfixed tree before being trusted:

```
asymmetric plumbing for keywords BOTH samplers accept --
ptde only: ['adapt_ladder']; ptde_async only: []
```

Full suite submitted on the cluster at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
