### PR TITLE
samplers: ter Braak gamma=1 mode hop, and log the ladder measurement

### DIFF
--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -56,6 +56,7 @@ KNOWN_SAMPLER_KEYS = {
     "T_max",
     "n_chains",
     "adapt_ladder",
+    "de_mode_hop",
     "recompute_trace",
     "nthin",
     "measure_scales",
@@ -316,6 +317,11 @@ def _run_fit(config, gui, user_params=None):
     # round trip must cross every pair and more rungs cannot fix a badly
     # SHAPED ladder.
     adapt_ladder = bool(sampler_cfg.get("adapt_ladder", False))
+    # ter Braak 2006 mode hopping: probability of a gamma=1 DE proposal.  0
+    # (default) is off and bit-identical.  Forwarded to BOTH PTDE samplers --
+    # a knob one of them silently ignores is exactly the adapt_ladder bug
+    # (tests/test_sampler_kwarg_plumbing.py pins the symmetry).
+    de_mode_hop = float(sampler_cfg.get("de_mode_hop", 0.0) or 0.0)
     _n_temps_raw = sampler_cfg.get("n_temps", 8)
     n_temps = (
         _n_temps_raw if isinstance(_n_temps_raw, str) else int(_n_temps_raw)
@@ -630,6 +636,7 @@ def _run_fit(config, gui, user_params=None):
                     collect_rung_timing=collect_rung_timing,
                     swap_schedule=swap_schedule,
                     adapt_ladder=adapt_ladder,
+                    de_mode_hop=de_mode_hop,
                     progress_callback=gui.progress_callback,
                 )
             elif method == "ptde_async":
@@ -664,6 +671,7 @@ def _run_fit(config, gui, user_params=None):
                     collect_rung_timing=collect_rung_timing,
                     swap_schedule=swap_schedule,
                     adapt_ladder=adapt_ladder,
+                    de_mode_hop=de_mode_hop,
                     progress_callback=gui.progress_callback,
                 )
             elif method in ("numpyro", "blackjax"):

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -737,6 +737,7 @@ def ptde_sample(
     swap_schedule="deo",
     target_swap_rate=None,
     adapt_ladder=False,
+    de_mode_hop=0.0,
     rung_thin_factor=1,
     rung_thin_start=None,
     collect_rung_timing=False,
@@ -1099,6 +1100,13 @@ def ptde_sample(
         n_propose = np.zeros(n_temps)
         n_swap_accept = np.zeros(max(n_temps - 1, 1))
         n_swap_propose = np.zeros(max(n_temps - 1, 1))
+        # gamma=1 mode hops, tracked per rung so they can be REMOVED from the
+        # acceptance the gamma adapter reads: hops are deliberately over-sized
+        # and mostly rejected, and letting them depress that rate would make
+        # the adapter shrink gamma, degrading within-mode sampling as the
+        # price of attempting hops.
+        n_hop_propose = np.zeros(n_temps)
+        n_hop_accept = np.zeros(n_temps)
 
         # DEO schedule + round-trip diagnostics state. direction[k][i] tags the
         # configuration in slot (k, i) with the last extreme rung it visited;
@@ -1132,22 +1140,36 @@ def ptde_sample(
                 n_propose[:] = 0
                 n_swap_accept[:] = 0
                 n_swap_propose[:] = 0
+                n_hop_propose[:] = 0
+                n_hop_accept[:] = 0
 
             # 1. build DE proposals for every chain at every ACTIVE temperature
             #    (rung thinning skips hot rungs on most steps; see _active_rungs)
             props_vec = []  # packed, for the population
             props_flat = []  # unpacked, for the workers
+            props_hop = []  # was this proposal a gamma=1 mode hop?
             prop_map = []
             for k in _active_rungs(
                 step, n_temps, _rung_thin_start, _rung_thin_factor
             ):
                 pop_k = populations[k]
                 for i in range(n_chains):
+                    # ter Braak 2006's mode-hopping move: gamma = 1 on a
+                    # fraction of proposals.  Decided here rather than inside
+                    # RawLayout.propose, which documents bit-identical rng
+                    # draw order; the extra draw is consumed only when hops
+                    # are enabled, so de_mode_hop=0 is bit-identical.
+                    hop = de_mode_hop > 0.0 and rng.random() < de_mode_hop
                     vec = layout.propose(
-                        rng, pop_k, i, gamma, jitter=de_jitter
+                        rng,
+                        pop_k,
+                        i,
+                        1.0 if hop else gamma,
+                        jitter=de_jitter,
                     )
                     props_vec.append(vec)
                     props_flat.append(layout.unpack(vec))
+                    props_hop.append(hop)
                     prop_map.append((k, i))
             _t_build = time.time()
 
@@ -1166,12 +1188,16 @@ def ptde_sample(
                 T = temperatures[k]
                 lp_new = prop_lps[idx]
                 n_propose[k] += 1
+                if props_hop[idx]:
+                    n_hop_propose[k] += 1
                 if np.isfinite(lp_new) and rng.random() < np.exp(
                     min(0.0, (lp_new - logps[k][i]) / T)
                 ):
                     populations[k][i] = props_vec[idx]
                     logps[k][i] = lp_new
                     n_accept[k] += 1
+                    if props_hop[idx]:
+                        n_hop_accept[k] += 1
                     # Runaway-lp early detection (see LpPlausibilityGuard).
                     if k == 0:
                         lp_guard.check(i, lp_new)
@@ -1285,7 +1311,10 @@ def ptde_sample(
                     # here that is one log interval of a tempered sampler,
                     # where the T=1 rung can legitimately stall while the
                     # ladder is still equilibrating.
-                    ar_T1 = ar[0]
+                    # NON-hop T=1 rate: see n_hop_propose above.
+                    ar_T1 = (n_accept[0] - n_hop_accept[0]) / max(
+                        n_propose[0] - n_hop_propose[0], 1.0
+                    )
                     if ar_T1 > 0:
                         gamma_new = next_gamma(gamma, ar_T1, target_accept)
                         if abs(gamma_new - gamma) / gamma > 0.01:

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -108,6 +108,7 @@ def ptde_async_sample(
     gamma_adapt_window=None,
     adapt_ladder=False,
     ladder_adapt_window=None,
+    de_mode_hop=0.0,
     de_jitter=DE_JITTER,
     swap_interval=None,
     swap_schedule="deo",
@@ -159,6 +160,29 @@ def ptde_async_sample(
                only what accumulated since it last ran, and running it more
                often than this makes it re-space on noise (see the block
                that calls _update_ladder_barrier).
+    de_mode_hop : float -- probability of replacing the scaled DE gamma with
+               gamma = 1 on a given proposal (ter Braak 2006's mode-hopping
+               move; 0.1 is conventional). Default 0.0, i.e. OFF and
+               bit-identical to before -- the extra rng draw is consumed only
+               when this is nonzero.
+
+               Why it exists: the DE move is x_i + gamma*(x_j - x_k) with
+               gamma ~ 2.38/sqrt(2d) (0.32 at d=27, and the adapter drives it
+               lower still). When x_j and x_k straddle two modes their
+               difference IS the inter-mode vector -- but scaled by 0.32 the
+               proposal lands a third of the way across, in the valley, and
+               is rejected. So the DE move cannot cross modes at its own
+               optimal scale, and ALL between-mode transport falls to PT round
+               trips. At gamma = 1 the proposal translates by the full
+               difference vector and arrives in the other mode. Both kernels
+               are symmetric in (x_j, x_k), so the mixture needs no Hastings
+               correction.
+
+               Hop proposals are EXCLUDED from the gamma adaptation counters.
+               They are deliberately over-sized and mostly rejected, so
+               letting them into the measured T=1 acceptance would drive the
+               adapter to shrink gamma -- degrading within-mode sampling as
+               the price of attempting hops, which is precisely backwards.
     gamma_adapt_window : int | None -- adapt gamma once per this many
                completed T=1 proposals still within their own chain's tune
                phase. None -> max(n_chains, (tune * n_chains) // 20), i.e.
@@ -385,6 +409,15 @@ def ptde_async_sample(
     n_swap_propose = np.zeros(max(n_temps - 1, 1))
     n_swap_accept_cum = np.zeros(max(n_temps - 1, 1))
     n_swap_propose_cum = np.zeros(max(n_temps - 1, 1))
+    de_mode_hop = float(de_mode_hop or 0.0)
+    if not 0.0 <= de_mode_hop < 1.0:
+        raise ValueError(f"de_mode_hop must be in [0, 1), got {de_mode_hop}")
+    # Per-slot flag: was the in-flight proposal a gamma=1 hop?  Set when the
+    # proposal is built, read when its result is scored -- safe as plain
+    # state because the parent builds and scores in one thread.
+    hop_flag = [[False] * n_chains for _ in range(n_temps)]
+    n_hop_propose = [0]
+    n_hop_accept = [0]
     n_ladder_adapts = [0]  # re-spacing MEASUREMENTS, moved or not
     n_eval_timeouts = [0]
     n_swap_discards = [0]  # in-flight proposals invalidated by a swap
@@ -436,9 +469,21 @@ def ptde_async_sample(
         """The slot's next PACKED proposal (see _common.RawLayout)."""
         if current_lp[k][i] is None:
             # First evaluation for this slot: evaluate the start state itself.
+            hop_flag[k][i] = False
             return current_state[k][i].copy()
+        # The hop decision lives HERE rather than inside RawLayout.propose:
+        # that class documents bit-identical rng draw order as a property, and
+        # the caller is the only place that knows whether this proposal should
+        # be a hop.  The extra draw is taken only when hops are enabled, so
+        # de_mode_hop=0 leaves the stream exactly as it was.
+        hop = de_mode_hop > 0.0 and rng.random() < de_mode_hop
+        hop_flag[k][i] = hop
         return layout.propose(
-            rng, current_state[k], i, gamma_box[0], jitter=de_jitter
+            rng,
+            current_state[k],
+            i,
+            1.0 if hop else gamma_box[0],
+            jitter=de_jitter,
         )
 
     def _submit(k, i):
@@ -765,7 +810,12 @@ def ptde_async_sample(
                 accepted = np.isfinite(lp) and rng.random() < np.exp(
                     min(0.0, (lp - current_lp[k][i]) / T)
                 )
-                if k == 0 and iter_count[k][i] < tune:
+                if hop_flag[k][i]:
+                    n_hop_propose[0] += 1
+                    if accepted:
+                        n_hop_accept[0] += 1
+                elif k == 0 and iter_count[k][i] < tune:
+                    # NON-hop proposals only -- see de_mode_hop above.
                     n_propose_T1_window[0] += 1
                     if accepted:
                         n_accept_T1_window[0] += 1
@@ -894,10 +944,33 @@ def ptde_async_sample(
                     temperatures, n_swap_accept, n_swap_propose
                 )
                 if not np.allclose(new_T, temperatures):
+                    # Log the MEASUREMENT next to the decision it drove.
+                    # Without the per-pair acceptances this line says what
+                    # the ladder became but not why, and the acceptances
+                    # otherwise appear only on the progress line -- one per
+                    # n_slots*(tune+draws)//20 evaluations, which on
+                    # DC2018_128 is 7.1M evals against a re-spacing every
+                    # ~51k.  That is ~140 adaptations per glimpse of the
+                    # only data that says whether they are helping, and it
+                    # made "is the adaptation working?" unanswerable for
+                    # hours on a run whose whole purpose was to answer it.
+                    # Full precision on T for the same reason: at %.1f,
+                    # neighbouring cold rungs print identically and there is
+                    # no way to tell a genuinely crowded ladder from a
+                    # rounded one.
+                    acc_win = n_swap_accept / np.maximum(n_swap_propose, 1)
                     logger.info(
                         "PTDE-async ladder (barrier-equalized, from "
                         f"{n_measured} swap proposals): "
-                        f"T=[{', '.join(f'{t:.1f}' for t in new_T)}]"
+                        f"T=[{', '.join(f'{t:.4g}' for t in new_T)}]"
+                    )
+                    logger.info(
+                        "PTDE-async ladder measurement: swap accept="
+                        f"[{', '.join(f'{r:.2f}' for r in acc_win)}]  "
+                        f"mean={float(acc_win.mean()):.3f} "
+                        f"spread={float(acc_win.max() - acc_win.min()):.2f} "
+                        f"Lambda={float(np.sum(1.0 - acc_win)):.1f} "
+                        f"(target accept 0.50, i.e. equal barrier per pair)"
                     )
                     temperatures[:] = new_T
                 # Fresh measurement per adaptation window, as the sync
@@ -1088,6 +1161,15 @@ def ptde_async_sample(
         rate_unit="swap",
         extras=_extras,
     )
+    if de_mode_hop > 0.0:
+        logger.info(
+            f"PTDE-async DE mode hops (gamma=1, p={de_mode_hop:g}): "
+            f"{n_hop_accept[0]}/{n_hop_propose[0]} accepted "
+            f"({n_hop_accept[0] / max(n_hop_propose[0], 1):.4f}); excluded "
+            "from the gamma adaptation. Compare against the mode-change "
+            "count in the mode report: hops are the DE path between basins, "
+            "PT round trips are the other one."
+        )
     ladder_health_report(temperatures, n_swap_accept, n_swap_propose)
     if adapt_ladder and n_temps > 2 and not n_ladder_adapts[0]:
         logger.warning(

--- a/tests/test_de_mode_hop.py
+++ b/tests/test_de_mode_hop.py
@@ -1,0 +1,205 @@
+"""The DE move cannot cross modes at its own optimal scale; gamma=1 can.
+
+`RawLayout.propose` builds x_i + gamma*(x_j - x_k) with gamma ~ 2.38/sqrt(2d)
+-- 0.32 at d=27, and the gamma adapter drives it lower still.  When x_j and
+x_k sit in different modes their difference IS the inter-mode vector, but
+scaled by 0.32 the proposal lands a third of the way across, in the valley,
+and is rejected.  So the DE kernel is a good WITHIN-mode sampler that cannot
+move between modes, and every between-mode transition falls to PT round trips
+-- which on DC2018 event 128 were measured at ZERO even with a ladder whose
+swap acceptance had been equalized to 0.504 +/- 0.019.
+
+ter Braak (2006) prescribes the fix: use gamma = 1 on a fraction of proposals
+(conventionally 0.1), so the proposal translates by the FULL difference vector
+and lands in the other mode.  Both kernels are symmetric in (x_j, x_k), so the
+mixture needs no Hastings correction -- which is what makes this a ten-line
+change rather than a new acceptance ratio (contrast the snooker update, whose
+radial step needs an r^(d-1) Jacobian).
+
+Two properties are pinned here: the hop is OFF by default and bit-identical
+when off, and when on it actually reaches the other mode where the scaled
+gamma provably does not.
+"""
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import pytest
+
+from exozippy.samplers._common import RawLayout
+from exozippy.samplers.ptde_async import ptde_async_sample
+
+
+class _MinimalSystem:
+    active_components = {}
+
+    def get_raw_start(self, model):
+        return model.initial_point()
+
+
+def _bimodal_model(sep=8.0):
+    """Two well-separated Gaussian modes in one dimension.
+
+    `sep` is in units of the component sigma, so the valley between the modes
+    is deep: at sep=8 the midpoint sits 4 sigma from either centre.
+    """
+    with pm.Model() as model:
+        x = pm.Normal("x", mu=0.0, sigma=1.0)
+        # An EQUAL-WEIGHT mixture: logaddexp of the two components, minus the
+        # base RV's own logp so it is not double counted.  The first version
+        # of this added logp(N(sep,1)) - logp(N(0,1)), which cancels the base
+        # term and leaves a SINGLE mode at sep -- both runs then placed 100%
+        # of their draws "in the far mode" and the test was vacuous.
+        pm.Potential(
+            "bimodal",
+            pt.logaddexp(
+                pm.logp(pm.Normal.dist(mu=0.0, sigma=1.0), x),
+                pm.logp(pm.Normal.dist(mu=sep, sigma=1.0), x),
+            )
+            - pm.logp(pm.Normal.dist(mu=0.0, sigma=1.0), x),
+        )
+    return model
+
+
+def test_scaled_gamma_lands_in_the_valley_and_unity_gamma_does_not():
+    """
+    Given two population members in different modes,
+    When a proposal is built from their difference,
+    Then the scaled gamma lands between the modes while gamma=1 lands ON the
+      far mode.
+
+    This is the geometric core of the whole issue, with no sampler involved.
+    """
+    # Arrange: mode A at 0, mode B at 10, in a 27-dim space (DC2018-shaped).
+    d = 27
+    start = {"x": np.zeros(d)}
+    layout = RawLayout(start)
+    a = np.zeros(d)
+    b = np.full(d, 10.0)
+    pop = np.vstack([a, b, a])  # member 0 in A, member 1 in B, member 2 in A
+    gamma_scaled = 2.38 / np.sqrt(2 * d)
+
+    # Act: propose from member 0 (in mode A).  Members 1 and 2 straddle the
+    # modes, so the difference vector is +/- the inter-mode displacement.
+    rng = np.random.default_rng(0)
+    scaled = layout.propose(rng, pop, 0, gamma_scaled, jitter=0.0)
+    rng = np.random.default_rng(0)
+    unity = layout.propose(rng, pop, 0, 1.0, jitter=0.0)
+
+    # Assert: |scaled| is a fraction of the way; |unity| is all the way.
+    frac_scaled = abs(scaled[0]) / 10.0
+    frac_unity = abs(unity[0]) / 10.0
+    assert frac_scaled == pytest.approx(gamma_scaled, rel=1e-9)
+    assert frac_scaled < 0.35, "the scaled step should fall far short"
+    assert frac_unity == pytest.approx(1.0, rel=1e-9)
+
+
+def test_mode_hop_is_off_by_default_and_leaves_the_rng_stream_untouched():
+    """
+    Given de_mode_hop unset,
+    When two runs are made with the same seed, one passing 0.0 explicitly,
+    Then the posteriors are bit-identical.
+
+    The hop's rng draw is taken only when hops are enabled, precisely so that
+    turning the feature off is not merely statistically equivalent but
+    identical -- RawLayout documents bit-identical draw order as a property
+    and every existing config must keep it.
+    """
+    # Arrange / Act
+    out = []
+    for kwargs in ({}, {"de_mode_hop": 0.0}):
+        model = _bimodal_model()
+        idata = ptde_async_sample(
+            model,
+            _MinimalSystem(),
+            draws=25,
+            tune=25,
+            n_temps=2,
+            T_max=4.0,
+            n_chains=4,
+            cores=1,
+            seed=11,
+            log_interval=1000,
+            **kwargs,
+        )
+        out.append(np.asarray(idata.posterior["x"]))
+
+    # Assert
+    np.testing.assert_array_equal(out[0], out[1])
+
+
+def test_mode_hop_rejects_an_out_of_range_probability():
+    """A probability outside [0, 1) is a config error, not a clamp."""
+    model = _bimodal_model()
+    for bad in (-0.1, 1.0, 2.5):
+        with pytest.raises(ValueError, match="de_mode_hop"):
+            ptde_async_sample(
+                model,
+                _MinimalSystem(),
+                draws=5,
+                tune=5,
+                n_temps=2,
+                T_max=2.0,
+                n_chains=4,
+                cores=1,
+                seed=1,
+                log_interval=1000,
+                de_mode_hop=bad,
+            )
+
+
+def test_hops_reach_the_other_basin_where_the_scaled_gamma_cannot():
+    """
+    Given a population STRADDLING two well-separated basins in 27 dimensions,
+    When many proposals are generated with the scaled gamma and with gamma=1,
+    Then only the gamma=1 proposals land inside the other basin.
+
+    Tested at the PROPOSAL level rather than by running the sampler, for two
+    reasons.  It isolates the DE kernel from PT transport, which would
+    otherwise supply the crossings and mask the effect; and the dimension
+    matters -- the optimal gamma is 2.38/sqrt(2d), so in 1-D it is 1.68, LARGER
+    than one, and a low-dimensional toy shows no effect at all (the first
+    version of this test used a 1-D target and both arms crossed freely).
+
+    NOTE THE LIMITATION this makes explicit: a hop moves a chain between
+    basins the population ALREADY OCCUPIES, because the difference vector is
+    drawn from the population.  It is a mixing accelerator for known modes,
+    not a mode DISCOVERER.  That is exactly the right tool for our case --
+    MMEXOFAST seeds both members of the s <-> 1/s pair, and the mode weights
+    were reported UNRELIABLE (N_eff = 19, 2/10 chains never switching) --
+    but it will not find an unseeded third basin.
+    """
+    # Arrange: 27-D, two basins separated along axis 0, population split
+    # between them exactly as a two-seed start would leave it.
+    d, sep = 27, 30.0
+    layout = RawLayout({"x": np.zeros(d)})
+    rng = np.random.default_rng(3)
+    n_pop = 2 * d
+    pop = rng.standard_normal((n_pop, d))
+    pop[n_pop // 2 :, 0] += sep  # half in basin B
+    gamma_scaled = 2.38 / np.sqrt(2 * d)
+
+    def frac_crossing(gamma):
+        """Fraction of proposals from basin A that land inside basin B."""
+        hits = 0
+        trials = 400
+        for t in range(trials):
+            i = t % (n_pop // 2)  # always propose FROM basin A
+            v = layout.propose(rng, pop, i, gamma, jitter=0.0)
+            # "inside basin B" = within 5 units of its centre on axis 0.
+            if abs(v[0] - sep) < 5.0:
+                hits += 1
+        return hits / trials
+
+    # Act
+    frac_scaled = frac_crossing(gamma_scaled)
+    frac_unity = frac_crossing(1.0)
+
+    # Assert
+    assert frac_scaled == 0.0, (
+        f"the scaled gamma reached basin B on {frac_scaled:.3f} of proposals; "
+        f"it should never get there (step is {gamma_scaled:.2f} x the gap)"
+    )
+    assert frac_unity > 0.2, (
+        f"gamma=1 reached basin B on only {frac_unity:.3f} of proposals"
+    )


### PR DESCRIPTION
Two changes, both prompted by the DC2018-128 ladder run.

## 1. The re-spacing line now logs the measurement it acted on

It said what the ladder *became* and not *why*. The per-pair acceptances it
acted on appeared only on the progress line — one per
`n_slots*(tune+draws)//20` evaluations, which on DC2018_128 is **7.1M evals
against a re-spacing every ~51k**, i.e. ~140 adaptations per glimpse of the
only data that says whether they help.

That made "is the adaptation working?" unanswerable for hours on a run whose
entire purpose was to answer it — and I twice reached a confident *wrong*
conclusion from proxy statistics (log-T spacing, then β uniformity) before the
first acceptances arrived and showed the adaptation had reached
**0.504 ± 0.019 against a 0.50 target**, a 5× scatter reduction versus the
control's 0.456 ± 0.096.

Temperatures now print at `%.4g` for the same reason: at `%.1f`, neighbouring
cold rungs print identically and a genuinely crowded ladder cannot be
distinguished from a rounded one. That ambiguity also cost real analysis time.

## 2. `de_mode_hop` — ter Braak (2006) mode hopping

Probability of a `gamma = 1` DE proposal. **Default 0.0 — off, and
bit-identical**, because the extra rng draw is consumed only when nonzero.

The DE move is `x_i + gamma·(x_j − x_k)` with `gamma ~ 2.38/sqrt(2d)`: 0.32 at
d = 27, and on the run above the adapter drove it to **0.037**. When `x_j` and
`x_k` straddle two modes their difference *is* the inter-mode vector — but
scaled by 0.32 the proposal lands a third of the way across, in the valley, and
is rejected. **So the DE kernel cannot cross modes at its own optimal scale**,
and every between-mode transition falls to PT round trips, which were measured
at *zero* on that run even after its ladder was equalized to target.

At `gamma = 1` the proposal translates by the full difference vector and
arrives. Both kernels are symmetric in `(x_j, x_k)`, so the mixture needs no
Hastings correction — which is what makes this ten lines rather than a new
acceptance ratio (contrast the snooker update, whose radial step needs an
`r^(d−1)` Jacobian).

Design points:

* The hop decision is made in the **callers**, not in `RawLayout.propose`,
  which documents bit-identical rng draw order as a property and is the wrong
  place to know whether a given proposal should hop.
* **Hops are excluded from the gamma adaptation counters**, in both samplers.
  They are deliberately over-sized and mostly rejected, so letting them into
  the measured T=1 acceptance would drive the adapter to shrink gamma —
  degrading within-mode sampling as the price of attempting hops, which is
  precisely backwards.
* Forwarded to **both** samplers from `run.py`. A knob one of them silently
  ignores is exactly the `adapt_ladder` bug from #197, and
  `tests/test_sampler_kwarg_plumbing.py` pins the symmetry.

### Known limitation, made explicit in the tests

A hop moves a chain between basins the population **already occupies**, since
the difference vector comes from the population. It accelerates mixing among
known modes; it does **not** discover new ones. That is the right tool here —
MMEXOFAST seeds both members of the `s ↔ 1/s` pair and the mode weights came
back *UNRELIABLE* (N_eff = 19, 2 of 10 chains never switching) — but it will
not find an unseeded third basin.

Related: with unequal modes the hop is a one-way valve. DC2018-128's two modes
differ by `Δlp_max = 77` nats, so a hop *into* the worse mode is accepted with
probability ~e⁻⁷⁷ while a hop *out* is accepted always — the minor mode drains
and hops then go dead. That is correct behaviour (its 0.065 occupancy weight
reflected initialization, not posterior mass), but it means 128 is the wrong
event to *measure* two-way mixing on. `examples/ob140939` is the better test:
OGLE + Spitzer satellite parallax carries the four-fold degeneracy whose
branches sit at comparable chi2, and its `tune: 0` means `adapt_ladder` cannot
fire there, so the hop is measured without ladder adaptation confounding it.

### Tests

At the **proposal level**, which isolates the DE kernel from PT transport, and
in **27 dimensions** — the optimal gamma is 1.68 in 1-D, *larger* than one, so
a low-dimensional toy shows no effect at all (my first draft used a 1-D target
and both arms crossed freely; a second draft's "bimodal" potential cancelled
its own base term and was unimodal). Also pinned: off by default,
bit-identical when off, and a probability outside [0, 1) raises.

Full suite on the cluster at this commit: **2931 passed, 61 skipped, 1
xfailed, 0 failed**; targeted sampler files 67 passed.

`de_mode_hop` is a **prototype, not a recommendation** — it is safe to land
because it is inert by default, but there is no evidence yet that it *helps*.
The measurement that would justify enabling it is an ob140939 run with
`de_mode_hop: 0.1` against a baseline, comparing mode-change counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
