### PR TITLE
samplers: report the tempered direction, and stop overpromising more rungs

### DIFF
--- a/src/exozippy/samplers/_common.py
+++ b/src/exozippy/samplers/_common.py
@@ -585,6 +585,35 @@ class SpanTracker:
         """
         return [self._widest(k, key) for k in range(self.n_temps)]
 
+    def ratio_key(self, k_cold, k_hot):
+        """Variable whose k_hot/k_cold span RATIO is largest, or None.
+
+        The right selector for "is tempering doing any work?", and not the
+        same as the widest absolute span.  `widest_at(hot)` picks whichever
+        variable RANGES furthest at the top of the ladder, which in practice
+        is whichever has the broadest PRIOR: on DC2018 event 128 it reported
+        star.pm_ra (top/cold 2.1x) and then star.logmass (5.9x), both of them
+        galactic-prior dominated, and never lens.log_s -- the one direction
+        the run existed to measure, whose second basin sits ~296 sigma away.
+        A prior-dominated coordinate explores its prior at every rung, so its
+        ratio is near 1 and it carries no information about the barrier.
+
+        The ratio picks out the direction where the hot rungs reach somewhere
+        the cold rung cannot, which is exactly the reachability question.
+        """
+        best, best_key = -np.inf, None
+        for name in self.layout.keys:
+            hot, _ = self._widest(k_hot, name)
+            cold, _ = self._widest(k_cold, name)
+            if not np.isfinite(hot) or hot <= 0.0:
+                continue
+            # A cold span of zero would divide to inf and win trivially; floor
+            # it at the smallest span that has actually been observed.
+            r = hot / max(cold, 1e-12)
+            if r > best:
+                best, best_key = r, name
+        return best_key
+
     def widest_at(self, k):
         """Name of the widest-spanning variable at rung ``k``, or None.
 

--- a/src/exozippy/samplers/ptde.py
+++ b/src/exozippy/samplers/ptde.py
@@ -198,7 +198,17 @@ def ladder_health_report(temperatures, n_swap_accept, n_swap_propose):
             f"{1.0 - lam / max(n_temps - 1, 1):.2f}, which is what makes "
             f"Lambda higher than the spacing assumed. Lambda is measured, "
             f"so this recommendation is problem-specific; the formula "
-            f"cannot be."
+            f"cannot be. NOTE that this criterion is NECESSARY, not "
+            f"sufficient: measured on a 27-D Gaussian, round trips collapse "
+            f"far faster than the DEO ceiling 1/(2+2*Lambda) predicts -- 4x "
+            f"below it at Lambda=1.8, 13x at 4.1, and unobservable past "
+            f"Lambda~5 at any affordable budget. DC2018 event 128 SATISFIES "
+            f"2*Lambda+1 at n_temps=48 with Lambda=19.8 and still makes zero "
+            f"round trips, so more rungs alone will not restore transport at "
+            f"high Lambda; see notes/pt_round_trip_collapse.txt. Where "
+            f"Lambda is this large, between-mode traffic has to come from "
+            f"multi-seed starts, per-mode evidence weighting or explicit "
+            f"mode jumps rather than from tempering."
         )
     return lam
 

--- a/src/exozippy/samplers/ptde_async.py
+++ b/src/exozippy/samplers/ptde_async.py
@@ -1008,7 +1008,14 @@ def ptde_async_sample(
                 # different parameter: on event 128 this divided the hot
                 # rung's log_f_total span by the cold rung's pm_ra span and
                 # printed "3x", which is a ratio of nothing.
-                hot_key = spans.widest_at(n_temps - 1)
+                # Largest hot/cold RATIO, not the widest absolute span:
+                # the latter reports whichever variable has the broadest
+                # prior and explores it at every rung, which on DC2018
+                # event 128 meant star.pm_ra and star.logmass rather than
+                # lens.log_s.  See SpanTracker.ratio_key.
+                hot_key = spans.ratio_key(0, n_temps - 1) or spans.widest_at(
+                    n_temps - 1
+                )
                 if hot_key is None:
                     # No accepted state at the hot rung yet, so there is no
                     # variable to measure at both ends.  Say that, rather

--- a/tests/test_ptde_async_ladder.py
+++ b/tests/test_ptde_async_ladder.py
@@ -376,3 +376,64 @@ def test_async_exposes_ladder_adapt_window_and_defaults_it_to_none():
     sig = inspect.signature(ptde_async_sample)
     assert "ladder_adapt_window" in sig.parameters
     assert sig.parameters["ladder_adapt_window"].default is None
+
+
+def test_ratio_key_finds_the_tempered_direction_not_the_broadest_prior():
+    """
+    Given a prior-dominated variable that ranges widely at EVERY rung and a
+      likelihood-dominated one that only the hot rung reaches,
+    When the span selector is asked which variable to report,
+    Then the ratio selector names the tempered one while the widest-absolute
+      selector names the prior-dominated one.
+
+    This is the flaw the DC2018-128 run exposed in the reporting added by
+    #195.  `widest_at(hot)` picks whichever variable RANGES furthest at the
+    top of the ladder, which in practice is whichever has the broadest prior:
+    that run reported star.pm_ra (top/cold 2.1x) and then star.logmass (5.9x),
+    both galactic-prior dominated, and never lens.log_s -- the one direction
+    the run existed to measure, whose second basin sits ~296 sigma away.  A
+    prior-dominated coordinate explores its prior at every rung, so its ratio
+    is near 1 and it says nothing about reachability.
+    """
+    # ARRANGE
+    from exozippy.samplers._common import RawLayout, SpanTracker
+
+    start = {"broad_prior": np.zeros(()), "tempered": np.zeros(())}
+    layout = RawLayout(start)
+    tr = SpanTracker(n_temps=2, raw_start=start, layout=layout)
+    # Cold rung: the prior-dominated variable already spans 500, the
+    # likelihood-dominated one only 2.
+    for bp, tv in ((-250.0, -1.0), (250.0, 1.0)):
+        tr.update(
+            0, _packed(layout, broad_prior=np.array(bp), tempered=np.array(tv))
+        )
+    # Hot rung: the prior one barely widens (600), the tempered one reaches
+    # 200 -- a 100x ratio against the prior variable's 1.2x.
+    for bp, tv in ((-300.0, -100.0), (300.0, 100.0)):
+        tr.update(
+            1, _packed(layout, broad_prior=np.array(bp), tempered=np.array(tv))
+        )
+
+    # ACT
+    widest = tr.widest_at(1)
+    ratio = tr.ratio_key(0, 1)
+
+    # ASSERT
+    assert widest == "broad_prior", (
+        "precondition: the absolute-span selector should pick the prior "
+        "variable, which is the behaviour this test exists to improve on"
+    )
+    assert ratio == "tempered", (
+        f"ratio selector picked {ratio!r}; it must find the direction the hot "
+        f"rung reaches and the cold one does not"
+    )
+
+
+def test_ratio_key_is_none_before_anything_is_recorded():
+    """No spans yet means no direction to name, rather than a spurious pick."""
+    from exozippy.samplers._common import RawLayout, SpanTracker
+
+    start = {"a": np.zeros(())}
+    tr = SpanTracker(n_temps=2, raw_start=start, layout=RawLayout(start))
+
+    assert tr.ratio_key(0, 1) is None


### PR DESCRIPTION
Two corrections to reporting I added in #195, both backed by a benchmark run
tonight (`examples/DC2018/pt_transport_bench.py`, jobs 15355260/15355389;
write-up in `notes/pt_round_trip_collapse.txt`).

## 1. The span selector reported the broadest prior, not the tempered direction

`widest_at(hot)` picks whichever variable *ranges* furthest at the top of the
ladder — and in practice that is whichever has the widest **prior**. DC2018
event 128 reported `star.pm_ra` (top/cold 2.1×), then `star.logmass` (5.9×),
and **never** `lens.log_s` — the one direction the run existed to measure,
whose second basin sits ~296 sigma away. A prior-dominated coordinate explores
its prior at every rung, so its ratio sits near 1 and it says nothing about
reachability.

`SpanTracker.ratio_key(cold, hot)` selects on the hot/cold span **ratio**
instead: the direction where the hot rungs reach somewhere the cold rung
cannot, which is the actual reachability question. `ptde_async` uses it, with a
fallback to the old selector before any ratio is measurable.

## 2. `ladder_health_report` implied more rungs would restore transport

It says *"Round trips … are the mixing bottleneck; set `n_temps: N` and
rerun"* whenever `n_temps < 2Λ+1`. Measured on a 27-D Gaussian, round trips
collapse far faster than the DEO ceiling `1/(2+2Λ)` predicts:

| Λ | round trips | vs DEO ceiling |
|---|---|---|
| 1.8 | 1742 | 4× below |
| 4.1 | 146 | 13× below |
| 12.6 | **0** | >1000× below |

Past Λ ≈ 5 they are unobservable at any affordable budget. **Event 128
satisfies `2Λ+1` at `n_temps=48` with Λ=19.8** — after the adaptation had
equalized per-pair acceptance to 0.504 ± 0.019 and pulled Λ down from 25.6 —
and still makes zero round trips at 35M evaluations. The criterion is
**necessary, not sufficient**, and the message now says so and points at the
alternatives (multi-seed starts, per-mode evidence weighting, explicit mode
jumps) instead of promising that rungs will fix it.

## What the benchmark ruled out

Each was plausible, and naming them is the useful part:

* **The round-trip counter** — unit-tested, and the async swap does carry the
  direction tags with the state.
* **The async swap mechanics** — I predicted that picking one pair *and one
  random chain* per swap event destroys DEO's non-reversibility, unlike the
  sync sampler which sweeps every chain at every pair. **Refuted**: async
  makes 1742 round trips on a 4-rung ladder and **sync makes zero** on the
  48-rung one. Both samplers behave the same.
* **`swap_interval`** — 87× more swap attempts (8.8 → 765 per replica), still
  zero. Worth testing, since `_attempt_swap` reads stored `current_lp` and
  never evaluates the model, so swaps are free.
* **`n_chains`**, and **the barrier itself** — unimodal and bimodal targets
  behave identically, as they should for temperature rather than mode
  transport.

So the ladder work in #195/#197 was correct and measurable, and it was fixing
a bottleneck that was never the binding one. "Λ improved" and "transport
improved" are different claims; this separates them.

## Tests

The selector test pins the *old* behaviour as its precondition and the new
behaviour as its assertion, so it would fail on either half being wrong. Plus
the no-data path.

Full suite on the cluster at this commit: **2933 passed, 61 skipped, 1
xfailed, 0 failed**; targeted sampler files 69 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
