### PR TITLE
Surgical coordinate swaps 2 and 3: fitpirel and fitthetae

### DIFF
--- a/src/exozippy/components/mulensing/defaults.yaml
+++ b/src/exozippy/components/mulensing/defaults.yaml
@@ -112,6 +112,25 @@ lens:
       default:
         func_name: "calc_theta_E"
         deps: [ "star.mass[lens_map]", "pi_rel" ]
+      # Selected by `fitthetae: true` (swap 3): theta_E becomes the
+      # sampled coordinate (as log_theta_E) and the HOST star's logmass
+      # is derived instead (see star.py).  In log coordinates the map is
+      # LINEAR (logM = 2 log theta_E - log kappa pi_rel - log(1+q)), so
+      # unlike fitpirel there is no Jacobian potential: |J| = 2, constant.
+      from_log_theta_E:
+        func_name: "calc_theta_E_from_log"
+        deps: [ "log_theta_E" ]
+  log_theta_E:
+    # Sampled ONLY when the lens sets `fitthetae: true`; otherwise absent.
+    # Log coordinate: theta_E spans ~1e-2 mas (FFP) to ~10 mas (nearby
+    # stellar lens).  NO initval (the mu_rel lesson, 4745cd7e): the
+    # engine back-solves the start through theta_E <-> log_theta_E.
+    lower: -4.0
+    upper: 2.0
+    unit: ""
+    internal_unit: ""
+    latex: "\\log\\theta_E"
+    description: "log10 Einstein radius"
   # mu_ra_rel / mu_dec_rel / mu_rel_mag are HELIOCENTRIC: differences of the
   # stars' barycentric proper motions (the frame the galactic kinematic
   # prior and Gaia priors constrain).  The *_geo trio below converts to the

--- a/src/exozippy/components/mulensing/defaults.yaml
+++ b/src/exozippy/components/mulensing/defaults.yaml
@@ -89,14 +89,23 @@ lens:
         deps: [ "log_pi_rel" ]
   log_pi_rel:
     # Sampled ONLY when the lens sets `fitpirel: true`; otherwise absent.
-    # Log coordinate: pi_rel spans decades (0.1 uas for a bulge-bulge
-    # event to ~1 arcsec for a lens at 1 pc).  NO initval here (the
+    # Log coordinate: pi_rel spans decades.  NO initval here (the
     # engine's default-armor registers every defaults initval for every
     # config -- the mu_rel lesson, commit 4745cd7e); the relaxation
     # engine back-solves the start from the distances through the
     # pi_rel <-> log_pi_rel relation.
+    #
+    # Upper = 10 mas (lens beyond ~100 pc): in physical coordinates the
+    # galactic d^2 volume prior made nearer lenses vanishingly rare, but
+    # a flat-in-log measure up to the old arcsecond ceiling handed the
+    # hot tempering chains ~40% of the coordinate range with pi_E ~ 10
+    # -- wildly looping parallax trajectories in VBM's most expensive
+    # regime.  The first fitpirel A/B arm (job 15363587) drowned in
+    # eval_timeouts within minutes, the same operational signature as
+    # log_rho's cap (1e162a1a).  A genuinely nearby lens is exotica the
+    # user can override per event.
     lower: -4.0
-    upper: 3.0
+    upper: 1.0
     unit: ""
     internal_unit: ""
     latex: "\\log\\pi_{rel}"

--- a/src/exozippy/components/mulensing/defaults.yaml
+++ b/src/exozippy/components/mulensing/defaults.yaml
@@ -81,6 +81,26 @@ lens:
       default:
         func_name: "calc_pi_rel"
         deps: [ "star.distance[lens_map]", "star.distance[source_map]"]
+      # Selected by `fitpirel: true` (swap 2 of the surgical coordinate
+      # plan): pi_rel becomes the sampled coordinate (as log_pi_rel) and
+      # the LENS star's distance is derived instead (see star.py).
+      from_log_pi_rel:
+        func_name: "calc_pi_rel_from_log"
+        deps: [ "log_pi_rel" ]
+  log_pi_rel:
+    # Sampled ONLY when the lens sets `fitpirel: true`; otherwise absent.
+    # Log coordinate: pi_rel spans decades (0.1 uas for a bulge-bulge
+    # event to ~1 arcsec for a lens at 1 pc).  NO initval here (the
+    # engine's default-armor registers every defaults initval for every
+    # config -- the mu_rel lesson, commit 4745cd7e); the relaxation
+    # engine back-solves the start from the distances through the
+    # pi_rel <-> log_pi_rel relation.
+    lower: -4.0
+    upper: 3.0
+    unit: ""
+    internal_unit: ""
+    latex: "\\log\\pi_{rel}"
+    description: "log10 rel. parallax"
   theta_E:
     lower: 0.0
     upper: 1000.0

--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -363,6 +363,24 @@ class Lens(Component):
                 ),
             },
             {
+                "key": "fitpirel",
+                "kind": "option",
+                "accepts": None,
+                "required": False,
+                "doc": (
+                    "Sample the lens-source relative parallax directly (as "
+                    "log_pi_rel) -- the combination the light curve "
+                    "measures -- and derive the lens star's distance as "
+                    "D_l = 1000/(pi_rel + 1000/D_s), automatically inside "
+                    "(0, D_s). A coordinate choice like fitvcve; the "
+                    "nonlinear map's Jacobian potential is added in "
+                    "build_likelihood so the joint density is unchanged. "
+                    "Single-source lenses only (per-source pi_rel would "
+                    "overdetermine the shared lens distance). "
+                    "Default False."
+                ),
+            },
+            {
                 "key": "star_constrains_rho",
                 "kind": "option",
                 "accepts": None,
@@ -728,13 +746,30 @@ class Lens(Component):
                 self.config_manager.add_scale_hint(f"lens.{j}.mu_ra_rel", 1.0)
                 self.config_manager.add_scale_hint(f"lens.{j}.mu_dec_rel", 1.0)
 
+        # fitpirel (swap 2): sample log_pi_rel, derive pi_rel from it, and
+        # the star component derives the lens distance (see star.py).
+        # Single-source only: per-source pi_rel would overdetermine the
+        # shared lens distance.
+        fitpirel = bool(self.config[0].get("fitpirel", False))
+        if fitpirel and self.n_sources > 1:
+            logger.warning(
+                "lens: fitpirel is set on a multi-source event -- "
+                "per-source pi_rel would overdetermine the shared lens "
+                "distance; ignoring it."
+            )
+            fitpirel = False
+        self._fitpirel = fitpirel
+        if fitpirel:
+            self.config_manager.add_scale_hint("lens.0.log_pi_rel", 0.1)
+
         self.manifest = {
             "t_0": per_source(),
             "u_0": per_source(),
-            "pi_rel": per_source("default"),
+            "pi_rel": per_source("from_log_pi_rel" if fitpirel else "default"),
             "theta_E": per_source("default"),
             "mu_ra_rel": murel_entry(),
             "mu_dec_rel": murel_entry(),
+            **({"log_pi_rel": per_source()} if fitpirel else {}),
             "mu_rel_mag": per_source("default"),
             "mu_ra_rel_geo": per_source("default"),
             "mu_dec_rel_geo": per_source("default"),
@@ -1367,6 +1402,25 @@ class Lens(Component):
         """Stage 7: Observational penalties on the lensing geometry."""
         self._validate_q_start()
         self._validate_pspl_start()
+
+        # fitpirel's change of variables is NONLINEAR (unlike fitmurel's),
+        # so preserving the joint density needs the Jacobian of the
+        # replaced physical coordinate with respect to the sampled one:
+        # D_l = 1000/(pi_rel + 1000/D_s)  =>
+        # |dD_l/dlog_pi_rel| = ln10 * pi_rel * D_l^2 / 1000.
+        # Without this term the swap would silently reweight the lens
+        # distance by exactly that factor.  The sampled-side uniform
+        # measure and logit corrections are Parameter.build_pymc's, as for
+        # every sampled coordinate; this potential is only the map's own
+        # stretch factor.
+        if getattr(self, "_fitpirel", False):
+            l_idx = int(self.lens_bodies[0][0][1])
+            d_l = system.star.distance.value[l_idx]
+            pi_rel_v = self.pi_rel.value[0]
+            pm.Potential(
+                f"{self.prefix}.fitpirel_jacobian",
+                pt.log(np.log(10.0) * pi_rel_v * d_l**2 / 1000.0),
+            )
 
         # GEOCENTRIC mu_rel: the event-rate selection is the sky-sweep rate
         # in the frame the event is observed in (rp.py used the geocentric

--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -381,6 +381,22 @@ class Lens(Component):
                 ),
             },
             {
+                "key": "fitthetae",
+                "kind": "option",
+                "accepts": None,
+                "required": False,
+                "doc": (
+                    "Sample the Einstein radius directly (as log_theta_E) "
+                    "and derive the HOST star's logmass from "
+                    "theta_E^2 = kappa * M_tot * pi_rel (M_host = "
+                    "M_tot/(1+q) with a log_q companion). A coordinate "
+                    "choice like fitvcve; log-linear map, constant "
+                    "Jacobian, no correction potential. Single-source "
+                    "lenses with at most one log_q companion. "
+                    "Default False."
+                ),
+            },
+            {
                 "key": "star_constrains_rho",
                 "kind": "option",
                 "accepts": None,
@@ -762,14 +778,53 @@ class Lens(Component):
         if fitpirel:
             self.config_manager.add_scale_hint("lens.0.log_pi_rel", 0.1)
 
+        # fitthetae (swap 3): sample log_theta_E, derive theta_E from it,
+        # and the star component derives the HOST logmass (see star.py).
+        # Constraints: single source (theta_E is per-source), and at most
+        # one companion, which must carry a sampled log_q (the inverse
+        # needs M_host = M_tot/(1+q) with q available as a coordinate).
+        fitthetae = bool(self.config[0].get("fitthetae", False))
+        if fitthetae:
+            reason = None
+            if self.n_sources > 1:
+                reason = "multi-source events are not supported"
+            elif self.n_companions > 1:
+                reason = "more than one companion is not supported"
+            elif self.n_companions == 1:
+                c_type, c_idx = self.lens_bodies[0][1]
+                if c_type != "planet":
+                    reason = f"the companion is a '{c_type}', not a planet"
+                else:
+                    mp = "log_q"
+                    comp = getattr(system, "planet", None)
+                    if comp is not None:
+                        mp = comp.config[c_idx].get(
+                            "mass_parameterization", "log_q"
+                        )
+                    if mp != "log_q":
+                        reason = (
+                            "the companion samples a linear mass, not log_q"
+                        )
+            if reason is not None:
+                logger.warning(
+                    f"lens: fitthetae is set but {reason}; ignoring it."
+                )
+                fitthetae = False
+        self._fitthetae = fitthetae
+        if fitthetae:
+            self.config_manager.add_scale_hint("lens.0.log_theta_E", 0.1)
+
         self.manifest = {
             "t_0": per_source(),
             "u_0": per_source(),
             "pi_rel": per_source("from_log_pi_rel" if fitpirel else "default"),
-            "theta_E": per_source("default"),
+            "theta_E": per_source(
+                "from_log_theta_E" if fitthetae else "default"
+            ),
             "mu_ra_rel": murel_entry(),
             "mu_dec_rel": murel_entry(),
             **({"log_pi_rel": per_source()} if fitpirel else {}),
+            **({"log_theta_E": per_source()} if fitthetae else {}),
             "mu_rel_mag": per_source("default"),
             "mu_ra_rel_geo": per_source("default"),
             "mu_dec_rel_geo": per_source("default"),
@@ -834,9 +889,10 @@ class Lens(Component):
                 "shape": (1,),
                 "deps": ["star.mass[primary_lens_map]"] + companion_mass_deps,
             }
-            theta_entry = dict(self.manifest["theta_E"])
-            theta_entry["deps"] = ["mlens_total", "pi_rel"]
-            self.manifest["theta_E"] = theta_entry
+            if not fitthetae:
+                theta_entry = dict(self.manifest["theta_E"])
+                theta_entry["deps"] = ["mlens_total", "pi_rel"]
+                self.manifest["theta_E"] = theta_entry
 
         if self.n_companions >= 2:
             # The symbolic relaxation engine only knows the binary mass-sum

--- a/src/exozippy/components/mulensing/physics.py
+++ b/src/exozippy/components/mulensing/physics.py
@@ -458,6 +458,13 @@ def calc_alpha(xalpha, yalpha):
 
 
 @register_physics
+def calc_pi_rel_from_log(log_pi_rel):
+    # Sampled coordinate for `fitpirel: true` lenses (swap 2): pi_rel
+    # spans decades, so the free coordinate is log10(pi_rel).
+    return pt.power(10.0, log_pi_rel)
+
+
+@register_physics
 def calc_rho_from_log(log_rho):
     # Sampled coordinate for `star_constrains_rho: false` lenses: rho spans decades
     # (1e-4 .. 0.5 across published events), so the free coordinate is

--- a/src/exozippy/components/mulensing/physics.py
+++ b/src/exozippy/components/mulensing/physics.py
@@ -465,6 +465,12 @@ def calc_pi_rel_from_log(log_pi_rel):
 
 
 @register_physics
+def calc_theta_E_from_log(log_theta_E):
+    # Sampled coordinate for `fitthetae: true` lenses (swap 3).
+    return pt.power(10.0, log_theta_E)
+
+
+@register_physics
 def calc_rho_from_log(log_rho):
     # Sampled coordinate for `star_constrains_rho: false` lenses: rho spans decades
     # (1e-4 .. 0.5 across published events), so the free coordinate is

--- a/src/exozippy/components/mulensing/symbolic_physics.py
+++ b/src/exozippy/components/mulensing/symbolic_physics.py
@@ -21,6 +21,7 @@ lens_pm_dec, source_pm_dec = sp.symbols("lens_pm_dec source_pm_dec")
 pi_E_N, pi_E_E = sp.symbols("pi_E_N pi_E_E")
 rho, source_radius = sp.symbols("rho source_radius")
 log_rho = sp.symbols("log_rho", real=True)
+log_pi_rel = sp.symbols("log_pi_rel", real=True)
 q_lens, companion_mass = sp.symbols("q_lens companion_mass")
 alpha, xalpha, yalpha = sp.symbols("alpha xalpha yalpha")
 # Projected separation: log_s is sampled, s is derived (s = 10**log_s).  The
@@ -142,6 +143,10 @@ def get_symbol_map(lens_config_list):
         if not lens_config_list.get("star_constrains_rho", True):
             result["log_rho"] = f"lens.{j}.log_rho"
 
+        # log_pi_rel exists only under fitpirel (swap 2).
+        if lens_config_list.get("fitpirel"):
+            result["log_pi_rel"] = f"lens.{j}.log_pi_rel"
+
         maps.append(result)
 
     return maps
@@ -190,6 +195,10 @@ RELATIONS = [
     # (log_rho mapped in get_symbol_map there; inert otherwise).  Lets a
     # user or MMEXOFAST rho seed back-solve to a log_rho start.
     sp.Eq(rho, 10**log_rho),
+    # pi_rel reparameterization, active only for `fitpirel: true` lenses
+    # (swap 2); inert otherwise.  Lets the distance-derived pi_rel seed
+    # back-solve to a log_pi_rel start.
+    sp.Eq(pi_rel, 10**log_pi_rel),
     # Binary lens mass ratio: q = M_companion / M_primary
     # companion_mass/primary_lens_mass are only in the symbol map for binary
     # events, so these relations are automatically inert for PSPL (relaxation

--- a/src/exozippy/components/mulensing/symbolic_physics.py
+++ b/src/exozippy/components/mulensing/symbolic_physics.py
@@ -22,6 +22,7 @@ pi_E_N, pi_E_E = sp.symbols("pi_E_N pi_E_E")
 rho, source_radius = sp.symbols("rho source_radius")
 log_rho = sp.symbols("log_rho", real=True)
 log_pi_rel = sp.symbols("log_pi_rel", real=True)
+log_theta_E = sp.symbols("log_theta_E", real=True)
 q_lens, companion_mass = sp.symbols("q_lens companion_mass")
 alpha, xalpha, yalpha = sp.symbols("alpha xalpha yalpha")
 # Projected separation: log_s is sampled, s is derived (s = 10**log_s).  The
@@ -147,6 +148,10 @@ def get_symbol_map(lens_config_list):
         if lens_config_list.get("fitpirel"):
             result["log_pi_rel"] = f"lens.{j}.log_pi_rel"
 
+        # log_theta_E exists only under fitthetae (swap 3).
+        if lens_config_list.get("fitthetae"):
+            result["log_theta_E"] = f"lens.{j}.log_theta_E"
+
         maps.append(result)
 
     return maps
@@ -199,6 +204,9 @@ RELATIONS = [
     # (swap 2); inert otherwise.  Lets the distance-derived pi_rel seed
     # back-solve to a log_pi_rel start.
     sp.Eq(pi_rel, 10**log_pi_rel),
+    # theta_E reparameterization, active only for `fitthetae: true` (swap
+    # 3); inert otherwise.
+    sp.Eq(theta_E, 10**log_theta_E),
     # Binary lens mass ratio: q = M_companion / M_primary
     # companion_mass/primary_lens_mass are only in the symbol map for binary
     # events, so these relations are automatically inert for PSPL (relaxation

--- a/src/exozippy/components/star/defaults.yaml
+++ b/src/exozippy/components/star/defaults.yaml
@@ -87,6 +87,17 @@ star:
     internal_unit: "pc"
     latex: "D"
     description: "Distance"
+    expressions:
+      # Selected per element by Star.register_parameters when the lens
+      # sets `fitpirel: true` (swap 2): the LENS star's distance becomes
+      # derived from the sampled relative parallax and the sampled source
+      # distance (self-guarding: 0 < D_l < D_s).  The star.distance dep
+      # is a same-parameter element reference (pre-patch tensor; only
+      # sampled elements may be referenced).  The nonlinear map's
+      # Jacobian potential is Lens.build_likelihood's.
+      from_mulens_pirel:
+        func_name: "calc_dl_from_pirel"
+        deps: [ "star.distance[murel_source_map]", "lens.pi_rel[murel_traj_map]" ]
   # --- Sampled Parameters ---
   radius:
     lower: 0.1

--- a/src/exozippy/components/star/defaults.yaml
+++ b/src/exozippy/components/star/defaults.yaml
@@ -24,6 +24,17 @@ star:
     internal_unit: "dex(solMass)"
     latex: "\\log{M}"
     description: "Log of Mass"
+    expressions:
+      # Selected per element by Star.register_parameters when the lens
+      # sets `fitthetae: true` (swap 3): the HOST star's logmass becomes
+      # derived from the sampled log_theta_E (through lens.theta_E) and
+      # pi_rel.  Log-linear map, constant Jacobian, no potential needed.
+      from_mulens_thetae:
+        func_name: "calc_logmass_from_thetae"
+        deps: [ "lens.theta_E[murel_traj_map]", "lens.pi_rel[murel_traj_map]" ]
+      from_mulens_thetae_binary:
+        func_name: "calc_logmass_from_thetae_binary"
+        deps: [ "lens.theta_E[murel_traj_map]", "lens.pi_rel[murel_traj_map]", "planet.log_q[murel_companion_map]" ]
   mass:
     unit: "solMass"
     internal_unit: "solMass"

--- a/src/exozippy/components/star/physics.py
+++ b/src/exozippy/components/star/physics.py
@@ -1,6 +1,12 @@
 import pytensor.tensor as pt
 
-from ...constants import DENSITY_CONST, FBOL_CONST, LOGG_CONST, LUM_CONST
+from ...constants import (
+    DENSITY_CONST,
+    FBOL_CONST,
+    KAPPA,
+    LOGG_CONST,
+    LUM_CONST,
+)
 from ...physics_registry import register_physics
 
 
@@ -83,3 +89,23 @@ def calc_dl_from_pirel(d_source, pi_rel):
     # NONLINEAR: the |dD_l/dlog_pi_rel| Jacobian potential lives in
     # Lens.build_likelihood (unlike fitmurel's |J| = 1 swap).
     return 1000.0 / (pi_rel + 1000.0 / d_source)
+
+
+@register_physics
+def calc_logmass_from_thetae(theta_E, pi_rel):
+    # fitthetae inverse (swap 3), single lens body: the HOST star's
+    # logmass derived from the sampled Einstein radius and the relative
+    # parallax, theta_E^2 = kappa * M * pi_rel.  Log-linear in the
+    # sampled coordinate (|J| = 2, constant), so no Jacobian potential.
+    return pt.log10(theta_E**2 / (KAPPA * pt.maximum(pi_rel, 1e-12)))
+
+
+@register_physics
+def calc_logmass_from_thetae_binary(theta_E, pi_rel, log_q):
+    # fitthetae inverse, star + one log_q companion: theta_E references
+    # the TOTAL lens mass, so M_host = M_tot / (1 + q).
+    return pt.log10(
+        theta_E**2
+        / (KAPPA * pt.maximum(pi_rel, 1e-12))
+        / (1.0 + pt.power(10.0, log_q))
+    )

--- a/src/exozippy/components/star/physics.py
+++ b/src/exozippy/components/star/physics.py
@@ -70,3 +70,16 @@ def calc_pm_from_murel(pm_source, mu_rel_component):
     # pre-patch tensor of the very parameter being built -- see
     # OwnPrePatchRef in components/parameter.py.
     return pm_source + mu_rel_component
+
+
+@register_physics
+def calc_dl_from_pirel(d_source, pi_rel):
+    # fitpirel inverse (swap 2): the LENS star's distance derived from
+    # the sampled log-relative-parallax and the sampled source distance.
+    # pi_rel[mas] = 1000/D_l - 1000/D_s  =>  D_l = 1000/(pi_rel + 1000/D_s),
+    # automatically 0 < D_l < D_s for pi_rel > 0 (the self-guarding map).
+    # d_source arrives through a same-parameter element dep
+    # (star.distance[murel_source_map]); see OwnPrePatchRef.
+    # NONLINEAR: the |dD_l/dlog_pi_rel| Jacobian potential lives in
+    # Lens.build_likelihood (unlike fitmurel's |J| = 1 swap).
+    return 1000.0 / (pi_rel + 1000.0 / d_source)

--- a/src/exozippy/components/star/star.py
+++ b/src/exozippy/components/star/star.py
@@ -863,6 +863,29 @@ class Star(Component):
         self.murel_traj_map = np.zeros(n, dtype=int)
         return {"expr_key": {"from_mulens_murel": [int(l_idx)]}}
 
+    def _distance_manifest_entry(self, system):
+        """distance entry: sampled everywhere, except that a single-source
+        lens with `fitpirel: true` flips its PRIMARY lens star's element to
+        derived, D_l = 1000/(pi_rel + 1000/D_s) -- swap 2 of the surgical
+        coordinate plan.  Same staging and maps as _pm_manifest_entry; the
+        map builder there runs first when both flags are set.
+        """
+        lens = getattr(system, "lens", None)
+        if lens is None or not getattr(lens, "lens_bodies", None):
+            return None
+        if not bool(lens.config[0].get("fitpirel", False)):
+            return None
+        if int(getattr(lens, "n_sources", 1)) > 1:
+            return None  # lens.py warns; the flag is ignored there too
+        l_type, l_idx = lens.lens_bodies[0][0]
+        s_type, s_idx = lens.source_bodies[0][0]
+        if l_type != "star" or s_type != "star":
+            return None
+        n = self.n_elements
+        self.murel_source_map = np.full(n, int(s_idx), dtype=int)
+        self.murel_traj_map = np.zeros(n, dtype=int)
+        return {"expr_key": {"from_mulens_pirel": [int(l_idx)]}}
+
     def register_parameters(self, system):
         """Stage 3: Declare the manifest and push to ConfigManager."""
 
@@ -989,7 +1012,7 @@ class Star(Component):
                     "dec": None,
                     "pm_ra": self._pm_manifest_entry(system),
                     "pm_dec": self._pm_manifest_entry(system),
-                    "distance": None,
+                    "distance": self._distance_manifest_entry(system),
                 }
             )
         elif astrom_modes:

--- a/src/exozippy/components/star/star.py
+++ b/src/exozippy/components/star/star.py
@@ -886,13 +886,59 @@ class Star(Component):
         self.murel_traj_map = np.zeros(n, dtype=int)
         return {"expr_key": {"from_mulens_pirel": [int(l_idx)]}}
 
+    def _logmass_thetae_entry(self, system):
+        """expr_key flip for `fitthetae: true` (swap 3): the HOST star's
+        logmass derived from the sampled log_theta_E (through lens.theta_E)
+        and pi_rel; with a log_q companion, M_host = M_tot/(1+q).  Same
+        staging rules as _pm_manifest_entry.  Lens.register_parameters
+        enforces the same guards and warns; this mirror keeps the two
+        components' answers identical without cross-stage reads.
+        """
+        lens = getattr(system, "lens", None)
+        if lens is None or not getattr(lens, "lens_bodies", None):
+            return None
+        if not bool(lens.config[0].get("fitthetae", False)):
+            return None
+        if int(getattr(lens, "n_sources", 1)) > 1:
+            return None
+        bodies = lens.lens_bodies[0]
+        if len(bodies) > 2:
+            return None
+        l_type, l_idx = bodies[0]
+        if l_type != "star":
+            return None
+        n = self.n_elements
+        self.murel_traj_map = np.zeros(n, dtype=int)
+        if len(bodies) == 2:
+            c_type, c_idx = bodies[1]
+            if c_type != "planet":
+                return None
+            comp = getattr(system, "planet", None)
+            mp = "log_q"
+            if comp is not None:
+                mp = comp.config[c_idx].get("mass_parameterization", "log_q")
+            if mp != "log_q":
+                return None
+            self.murel_companion_map = np.full(n, int(c_idx), dtype=int)
+            return {"expr_key": {"from_mulens_thetae_binary": [int(l_idx)]}}
+        return {"expr_key": {"from_mulens_thetae": [int(l_idx)]}}
+
     def register_parameters(self, system):
         """Stage 3: Declare the manifest and push to ConfigManager."""
 
         # 1. Get the stellar parameters we always want.  logmass may carry a
         # power-law-IMF floor (None otherwise, i.e. a plain free parameter).
+        logmass_entry = self._logmass_manifest_entry(system)
+        thetae_entry = self._logmass_thetae_entry(system)
+        if thetae_entry is not None:
+            # Merge the fitthetae expr_key flip into the IMF-floor entry
+            # (both are dicts of disjoint keys; the floor's per-element
+            # "overrides" apply to the still-sampled elements, and a bound
+            # on the derived host element degrades to a soft barrier).
+            logmass_entry = {**(logmass_entry or {}), **thetae_entry}
+
         self.manifest = {
-            "logmass": self._logmass_manifest_entry(system),
+            "logmass": logmass_entry,
             "radius": None,
             "mass": "default",
             "density": "default",

--- a/src/exozippy/ephemeris.py
+++ b/src/exozippy/ephemeris.py
@@ -12,6 +12,7 @@ import contextlib
 import logging
 import os
 import warnings
+import zlib
 from functools import lru_cache
 
 import numpy as np
@@ -212,10 +213,22 @@ def _ephemeris_spline(ephemeris_file, _stamp):
     """Parse one .eph file and fit its CubicSpline, once (review 6.10.1).
 
     Returns `(spline, t_min, t_max)`.  Keyed on the path AND a `_stamp` of
-    `(st_mtime_ns, st_size)` taken by the caller, so an ephemeris
+    `(st_mtime_ns, st_size, crc32)` taken by the caller, so an ephemeris
     regenerated under the same name is re-read rather than served stale --
     a plain path key would outlive a `get_ephemeris.py` re-run inside one
     process (the GUI, a notebook, a test that rewrites its tmp file).
+
+    The crc32 is in the stamp because (mtime_ns, size) alone is not a
+    content fingerprint: a same-size rewrite within one filesystem
+    timestamp tick collides, and that is a REAL case, not a pathology --
+    a GUI-triggered get_ephemeris.py re-run finishes well inside a
+    second, and coarse-mtime filesystems (the cluster scratch the test
+    suite runs on) truncate the tick to that scale.  The suite caught it
+    as a load-dependent flake in test_a_regenerated_ephemeris_is_re_read
+    (ezsuite 15363602: stale spline served exactly when two writes landed
+    in one tick).  The cost is reading the file bytes on every call; the
+    call sites are per-instrument load and plotting grids, not the
+    likelihood, and the parse+fit (the expensive part) stays cached.
 
     What is NOT cached is the extrapolation check: it depends on the
     requested epochs, not on the file, and it has to warn every time.
@@ -255,8 +268,10 @@ def interpolate_ephemeris(time, ephemeris_file):
     # and the mulens plotters, so a multi-draw plotting pass used to re-parse
     # the same .eph dozens of times.
     st = os.stat(ephemeris_file)
+    with open(ephemeris_file, "rb") as fh:
+        crc = zlib.crc32(fh.read())
     cs, t_min, t_max = _ephemeris_spline(
-        ephemeris_file, (st.st_mtime_ns, st.st_size)
+        ephemeris_file, (st.st_mtime_ns, st.st_size, crc)
     )
 
     # Check if we are extrapolating (which is dangerous)

--- a/src/exozippy/introspect.py
+++ b/src/exozippy/introspect.py
@@ -64,6 +64,15 @@ def _expression_info(raw):
 
     Returns (derived, expressions) where ``expressions`` maps each
     expression key (e.g. "default") to {"func_name", "deps"}.
+
+    ``derived`` means derived BY DEFAULT: the block carries a "default"
+    expression, the one a bare-string manifest entry selects.  A block
+    holding only mode-selected expressions (the surgical coordinate
+    swaps' ``from_mulens_*`` blocks on pm_ra/pm_dec/distance/logmass;
+    ``fitvcve``'s alternates) describes a parameter that is SAMPLED
+    unless a flag flips it, and a static schema answers for the default
+    configuration.  The expressions are still reported either way, so a
+    GUI can show what the modes would do.
     """
     expr_block = raw.get("expressions")
     if not isinstance(expr_block, dict) or not expr_block:
@@ -75,7 +84,7 @@ def _expression_info(raw):
             "func_name": cfg.get("func_name"),
             "deps": list(cfg.get("deps", []) or []),
         }
-    return True, out
+    return "default" in out, out
 
 
 def _param_schema(name, raw):
@@ -93,7 +102,7 @@ def _param_schema(name, raw):
         if field in raw:
             entry[field] = raw[field]
 
-    if derived:
+    if expressions:
         entry["expressions"] = expressions
         # Convenience: flatten the "default" dependency list to top level.
         default_expr = expressions.get("default")

--- a/tests/test_fitpirel.py
+++ b/tests/test_fitpirel.py
@@ -1,0 +1,118 @@
+"""
+Tests for `fitpirel: true` (lens block): sample log_pi_rel, derive the
+lens star's distance D_l = 1000/(pi_rel + 1000/D_s).
+
+Swap 2 of the surgical coordinate plan.  Unlike fitmurel this map is
+NONLINEAR, so a Jacobian potential (|dD_l/dlog_pi_rel|) accompanies it;
+the finite-difference test below pins that the potential equals the
+actual stretch of the map the model builds, not a formula transcribed
+beside it.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytensor
+import pytest
+import yaml
+
+from exozippy.system import System
+
+_KMT_DIR = Path(__file__).parent.parent / "examples" / "KMT-2019-BLG-1806"
+
+_WORKDIR = None
+
+
+def _kmt_workdir():
+    global _WORKDIR
+    if _WORKDIR is None:
+        import shutil
+        import tempfile
+
+        _WORKDIR = Path(tempfile.mkdtemp(prefix="kmt_test_")) / "KMT"
+        shutil.copytree(_KMT_DIR, _WORKDIR)
+    return _WORKDIR
+
+
+def _build(fitpirel):
+    import os
+
+    if not _KMT_DIR.is_dir():
+        pytest.skip("KMT-2019-BLG-1806 example not present")
+    cwd = os.getcwd()
+    os.chdir(_kmt_workdir())
+    try:
+        with open("KMT-2019-BLG-1806.yaml") as f:
+            config = yaml.safe_load(f)
+        with open(config["parameter_file"]) as f:
+            user_params = yaml.safe_load(f)
+        for k in ("run", "prefix", "parameter_file", "sampler"):
+            config.pop(k, None)
+        if fitpirel:
+            config["lens"][0]["fitpirel"] = True
+        system = System(config, user_params=user_params)
+        system.prepare()
+        model = system.build_model()
+    finally:
+        os.chdir(cwd)
+    return system, model
+
+
+@pytest.fixture(scope="module")
+def swapped():
+    return _build(fitpirel=True)
+
+
+def _eval(model, node, point):
+    (node,) = model.replace_rvs_by_values([node])
+    f = pytensor.function(model.value_vars, node, on_unused_input="ignore")
+    return f(*[point[v.name] for v in model.value_vars])
+
+
+def test_off_is_the_physical_parameterization():
+    system, model = _build(fitpirel=False)
+    assert "lens.log_pi_rel_raw" not in [v.name for v in model.value_vars]
+    for i in range(system.star.n_elements):
+        assert system.star.distance.element_is_sampled(i)
+    assert not any("fitpirel_jacobian" in p.name for p in model.potentials)
+
+
+def test_swapped_roles_identity_and_jacobian(swapped):
+    system, model = swapped
+    assert "lens.log_pi_rel_raw" in [v.name for v in model.value_vars]
+
+    l_idx = int(system.lens.lens_bodies[0][0][1])
+    s_idx = int(system.lens.source_bodies[0][0][1])
+    assert system.star.distance.element_is_derived(l_idx)
+    assert system.star.distance.element_is_sampled(s_idx)
+
+    point = model.initial_point()
+    d = np.atleast_1d(_eval(model, system.star.distance.value, point))
+    pr = np.atleast_1d(_eval(model, system.lens.pi_rel.value, point))
+    assert np.isclose(
+        d[l_idx], 1000.0 / (pr[0] + 1000.0 / d[s_idx]), rtol=1e-12
+    )
+
+    # The Jacobian potential equals the map's ACTUAL stretch: perturb the
+    # raw log_pi_rel coordinate, measure dD_l/dlog_pi_rel by central
+    # difference on the model graph itself, and compare to exp(potential).
+    jac_pot = [p for p in model.potentials if "fitpirel_jacobian" in p.name]
+    assert len(jac_pot) == 1
+    jac_val = float(np.squeeze(_eval(model, jac_pot[0], point)))
+
+    def at(delta):
+        pt2 = dict(point)
+        pt2["lens.log_pi_rel_raw"] = point["lens.log_pi_rel_raw"] + delta
+        d2 = np.atleast_1d(_eval(model, system.star.distance.value, pt2))
+        import math
+
+        pr2 = np.atleast_1d(_eval(model, system.lens.pi_rel.value, pt2))
+        return float(d2[l_idx]), math.log10(float(pr2[0]))
+
+    eps = 1e-4
+    d_hi, lp_hi = at(eps)
+    d_lo, lp_lo = at(-eps)
+    fd = abs((d_hi - d_lo) / (lp_hi - lp_lo))
+    assert np.isclose(np.exp(jac_val), fd, rtol=1e-4), (np.exp(jac_val), fd)
+
+    assert np.isfinite(float(model.compile_logp()(point)))

--- a/tests/test_fitthetae.py
+++ b/tests/test_fitthetae.py
@@ -1,0 +1,110 @@
+"""
+Tests for `fitthetae: true` (lens block): sample log_theta_E, derive the
+HOST star's logmass from theta_E^2 = kappa * M_tot * pi_rel (with a
+log_q companion, M_host = M_tot/(1+q)).
+
+Swap 3 of the surgical coordinate plan.  In log coordinates the map is
+LINEAR (logM = 2 log theta_E - log kappa pi_rel - log(1+q)), so unlike
+fitpirel there is deliberately NO Jacobian potential -- |J| = 2 is
+constant and cancels in the posterior.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytensor
+import pytest
+import yaml
+
+from exozippy.constants import KAPPA
+from exozippy.system import System
+
+_KMT_DIR = Path(__file__).parent.parent / "examples" / "KMT-2019-BLG-1806"
+
+_WORKDIR = None
+
+
+def _kmt_workdir():
+    global _WORKDIR
+    if _WORKDIR is None:
+        import shutil
+        import tempfile
+
+        _WORKDIR = Path(tempfile.mkdtemp(prefix="kmt_test_")) / "KMT"
+        shutil.copytree(_KMT_DIR, _WORKDIR)
+    return _WORKDIR
+
+
+def _build(fitthetae, planet_linear=False, prepare_only=False):
+    import os
+
+    if not _KMT_DIR.is_dir():
+        pytest.skip("KMT-2019-BLG-1806 example not present")
+    cwd = os.getcwd()
+    os.chdir(_kmt_workdir())
+    try:
+        with open("KMT-2019-BLG-1806.yaml") as f:
+            config = yaml.safe_load(f)
+        with open(config["parameter_file"]) as f:
+            user_params = yaml.safe_load(f)
+        for k in ("run", "prefix", "parameter_file", "sampler"):
+            config.pop(k, None)
+        if fitthetae:
+            config["lens"][0]["fitthetae"] = True
+        if planet_linear:
+            config["planet"][0]["mass_parameterization"] = "linear"
+        system = System(config, user_params=user_params)
+        system.prepare()
+        model = None if prepare_only else system.build_model()
+    finally:
+        os.chdir(cwd)
+    return system, model
+
+
+def _eval(model, node, point):
+    (node,) = model.replace_rvs_by_values([node])
+    f = pytensor.function(model.value_vars, node, on_unused_input="ignore")
+    return f(*[point[v.name] for v in model.value_vars])
+
+
+def test_off_is_the_physical_parameterization():
+    system, _ = _build(fitthetae=False, prepare_only=True)
+    assert "log_theta_E" not in system.lens.manifest
+    entry = system.lens.manifest["theta_E"]
+    assert entry.get("expr_key") == "default"
+
+
+def test_swapped_roles_identity_no_jacobian():
+    system, model = _build(fitthetae=True)
+    assert "lens.log_theta_E_raw" in [v.name for v in model.value_vars]
+
+    l_idx = int(system.lens.lens_bodies[0][0][1])
+    assert system.star.logmass.element_is_derived(l_idx)
+
+    point = model.initial_point()
+    lm = np.atleast_1d(_eval(model, system.star.logmass.value, point))
+    te = np.atleast_1d(_eval(model, system.lens.theta_E.value, point))
+    pr = np.atleast_1d(_eval(model, system.lens.pi_rel.value, point))
+    lq = np.atleast_1d(_eval(model, system.planet.log_q.value, point))
+    expect = np.log10(te[0] ** 2 / (KAPPA * pr[0]) / (1.0 + 10.0 ** lq[0]))
+    assert np.isclose(lm[l_idx], expect, rtol=1e-10)
+
+    # Log-linear map: deliberately no correction potential.
+    assert not any("thetae" in p.name.lower() for p in model.potentials)
+    assert np.isfinite(float(model.compile_logp()(point)))
+
+
+def test_linear_mass_companion_guard(caplog):
+    """A companion sampling a linear mass has no log_q coordinate for the
+    inverse; the flag warns and stands down in BOTH components."""
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        system, _ = _build(
+            fitthetae=True, planet_linear=True, prepare_only=True
+        )
+    assert "log_theta_E" not in system.lens.manifest
+    assert any(
+        "fitthetae" in r.message and "linear mass" in r.message
+        for r in caplog.records
+    )

--- a/tests/test_fitthetae.py
+++ b/tests/test_fitthetae.py
@@ -108,3 +108,44 @@ def test_linear_mass_companion_guard(caplog):
         "fitthetae" in r.message and "linear mass" in r.message
         for r in caplog.records
     )
+
+
+def test_all_three_swaps_compose_into_observable_coordinates():
+    """fitmurel + fitpirel + fitthetae + star_constrains_rho: false is the
+    observable-coordinates parameterization of notes/
+    observable_coordinates.txt: the sampled microlensing coordinates ARE
+    the observable set, the whole lens-star physical state is derived,
+    and every physical prior evaluates on the derived point."""
+    import os
+
+    cwd = os.getcwd()
+    os.chdir(_kmt_workdir())
+    try:
+        with open("KMT-2019-BLG-1806.yaml") as f:
+            config = yaml.safe_load(f)
+        with open(config["parameter_file"]) as f:
+            user_params = yaml.safe_load(f)
+        for k in ("run", "prefix", "parameter_file", "sampler"):
+            config.pop(k, None)
+        for flag in ("fitmurel", "fitpirel", "fitthetae"):
+            config["lens"][0][flag] = True
+        config["lens"][0]["star_constrains_rho"] = False
+        system = System(config, user_params=user_params)
+        system.prepare()
+        model = system.build_model()
+    finally:
+        os.chdir(cwd)
+
+    vv = [v.name for v in model.value_vars]
+    for name in (
+        "lens.mu_ra_rel_raw",
+        "lens.mu_dec_rel_raw",
+        "lens.log_pi_rel_raw",
+        "lens.log_theta_E_raw",
+        "lens.log_rho_raw",
+    ):
+        assert name in vv, name
+    l_idx = int(system.lens.lens_bodies[0][0][1])
+    for param in ("pm_ra", "pm_dec", "distance", "logmass"):
+        assert getattr(system.star, param).element_is_derived(l_idx), param
+    assert np.isfinite(float(model.compile_logp()(model.initial_point())))


### PR DESCRIPTION
## What this branch is

Swaps 2 and 3 of the approved surgical-coordinates plan (notes/observable_coordinates.txt), on the pattern swap 1 (fitmurel, merged in #200) established. Six commits; full suite green (2971 passed, 0 failed, 0 errors).

- **`fitpirel`**: sample the LC-measured relative parallax (as log_pi_rel); the lens star's distance becomes derived, D_l = 1000/(pi_rel + 1000/D_s) -- self-guarding (0 < D_l < D_s). The map is NONLINEAR, so it carries the branch's first explicit Jacobian potential, pinned by a finite-difference test against the model's own map rather than a transcription of the formula. Single-source lenses only.
- **`fitthetae`**: sample the Einstein radius (as log_theta_E); the HOST star's logmass becomes derived, M_host = theta_E^2/(kappa pi_rel)/(1+q). Log-linear map, constant |J| = 2 -- deliberately NO potential, and the test pins its absence. Guards: single source, at most one companion, which must sample log_q.
- **Composition pinned by test**: all three swaps + `star_constrains_rho: false` sample exactly the observable set (mu_rel x2, log_pi_rel, log_theta_E, log_rho) with the whole lens-star physical state derived and every prior evaluating on the derived point -- the observable-coordinates parameterization, reached surgically.
- **`log_pi_rel` physical cap** (pi_rel <= 10 mas): the first fitpirel A/B arm drowned in VBM eval_timeouts because the flat-in-log measure handed hot tempering chains pi_E ~ 10 trajectories the physical-coordinate d^2 volume prior used to suppress implicitly -- a coordinate swap must restate the physics its old measure encoded.
- **introspect: derived means derived BY DEFAULT** (a "default" expression present), so mode-selected `from_mulens_*` expression blocks no longer make statically-sampled parameters report as derived.
- **ephemeris: content-fingerprint the spline cache key** -- (mtime_ns, size) collides on a same-size rewrite within one filesystem tick (a real case: a GUI regeneration finishes inside a second); caught as a 3-of-7-runs suite flake, fixed with a crc32 in the stamp.

A/B arms for both swaps plus the fully-composed observable arm are running on DC2018 event 128 against the same capped baseline as fitmurel's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
