### PR TITLE
Nested sampling: population slice stepping, survivable checkpoints, role-aware bridge

### DIFF
--- a/examples/DC2018/dc18_fullns_pilot.job
+++ b/examples/DC2018/dc18_fullns_pilot.job
@@ -1,0 +1,27 @@
+# /bin/sh
+#$ -S /bin/sh
+#$ -pe mthread 64
+#$ -q mThC.q
+#$ -cwd
+#$ -j y
+#$ -N fullns
+#$ -o dc18_fullns_pilot.$JOB_ID.log
+
+module purge
+module load tools/python/3.13
+export PATH="$HOME/miniconda3/bin:$PATH:$HOME/.local/bin"
+source $HOME/miniconda3/etc/profile.d/conda.sh
+conda activate exozippy
+export PYTENSOR_FLAGS="base_compiledir=${TMPDIR:-/tmp}/pytensor_$JOB_ID"
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+cd $HOME/python/EXOZIPPy/examples/DC2018
+
+# Full-model (d=27) NS pilot: the d=7 benchmark found the solution blind at
+# ~43 core-hours; this asks whether that survives the real posterior --
+# galactic priors, Hogg mixtures, err_scale, both bands -- at d=27.
+python -u dc18_fullns_pilot.py --backend "${BACKEND:-ultranest}" --nlive 500 --ncpu 60 \
+  --config "${CFG:-DC2018_128.yaml}" \
+  --ckpt "${CKPT:-dc18_fullns_ckpt_$JOB_ID}" \
+  --out "${OUT:-dc18_fullns_pilot.$JOB_ID.json}"

--- a/examples/DC2018/dc18_fullns_pilot.py
+++ b/examples/DC2018/dc18_fullns_pilot.py
@@ -1,0 +1,85 @@
+"""Full-model (d=27) nested sampling pilot on DC2018 event 128.
+
+Drives exozippy.samplers.nested (the `method: nested` machinery) directly on
+the event-128 build, so the pilot and the production path are ONE
+implementation.  See that module's docstring for the bridge and the u-space
+decomposition; this script only adds the event-specific scoring: posterior
+mass near the two known solutions (s = 0.976 and its s <-> 1/s mirror at
+0.863), which the seeded PT runs and the d=7 profile-likelihood benchmark
+established.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+RUN = Path(
+    "/home/jeastman/python/EXOZIPPy/examples/DC2018/events_ladderfix/128"
+)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--backend", default="dynesty")
+    ap.add_argument("--nlive", type=int, default=500)
+    ap.add_argument("--walks", type=int, default=None)
+    ap.add_argument("--dlogz", type=float, default=0.5)
+    ap.add_argument("--ncpu", type=int, default=60)
+    ap.add_argument("--out", default="dc18_fullns_pilot.json")
+    ap.add_argument("--config", default="DC2018_128.yaml")
+    ap.add_argument("--ckpt", default=None)
+    args = ap.parse_args()
+    out_path = Path(args.out).resolve()
+
+    os.chdir(RUN)
+    from exozippy.samplers.nested import nested_sample
+    from exozippy.system import System
+
+    config = yaml.safe_load(open(args.config))
+    pf = config.get("parameter_file", "DC2018_128.params.yaml")
+    for k in ("run", "prefix", "parameter_file", "sampler"):
+        config.pop(k, None)
+    params = yaml.safe_load(open(pf))
+    system = System(config, params)
+    system.prepare()
+    model = system.build_model()
+
+    idata = nested_sample(
+        model,
+        system,
+        backend=args.backend,
+        nlive=args.nlive,
+        walks=args.walks,
+        dlogz=args.dlogz,
+        cores=args.ncpu,
+        seed=11,
+        checkpoint_dir=args.ckpt,
+    )
+
+    a = idata.posterior.attrs
+    log_s = np.asarray(idata.posterior["lens.log_s"]).ravel()
+    lp = np.asarray(idata.sample_stats["lp"]).ravel()
+    best = int(np.argmax(lp))
+    out = {
+        "backend": args.backend,
+        "logz": float(a["nested_logz"]),
+        "logzerr": float(a["nested_logzerr"]),
+        "ncall": int(a["nested_ncall"]),
+        "n_eff": int(a["nested_n_eff"]),
+        "best_lp": float(lp[best]),
+        "best_log_s": float(log_s[best]),
+        "mass_main": float(np.mean(np.abs(log_s - (-0.0104)) < 0.02)),
+        "mass_mirror": float(np.mean(np.abs(log_s - (-0.0640)) < 0.02)),
+    }
+    print(json.dumps(out, indent=2), flush=True)
+    with open(out_path, "w") as f:
+        json.dump(out, f, indent=2)
+    print("done", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/DC2018/dc18_fullns_pilot.py
+++ b/examples/DC2018/dc18_fullns_pilot.py
@@ -35,7 +35,21 @@ def main():
     args = ap.parse_args()
     out_path = Path(args.out).resolve()
 
-    os.chdir(RUN)
+    # Run in the CONFIG's own directory: its data-file and mmexofast
+    # paths are relative to where it lives (configs/ for the persistent
+    # configs).  A bare filename that does not exist relative to the
+    # caller's cwd is looked up in the legacy RUN dir.
+    cfg_path = Path(args.config)
+    if not cfg_path.exists():
+        cfg_path = RUN / cfg_path.name
+    cfg_path = cfg_path.resolve()
+    if not cfg_path.exists():
+        raise SystemExit(f"config not found: {args.config}")
+    args.config = cfg_path.name
+    if args.ckpt:
+        args.ckpt = str(Path(args.ckpt).resolve())
+    out_dir = Path(args.out).resolve().parent
+    os.chdir(cfg_path.parent)
     from exozippy.samplers.nested import nested_sample
     from exozippy.system import System
 

--- a/src/exozippy/run.py
+++ b/src/exozippy/run.py
@@ -58,6 +58,7 @@ KNOWN_SAMPLER_KEYS = {
     "adapt_ladder",
     "de_mode_hop",
     "nested_backend",
+    "checkpoint_dir",
     "nlive",
     "dlogz",
     "walks",
@@ -705,6 +706,13 @@ def _run_fit(config, gui, user_params=None):
                         else None
                     ),
                     cores=cores,
+                    # SIGTERM-survivable by default: ultranest resumes from
+                    # the stored live points; dynesty writes a checkpoint
+                    # file (restore is manual).  The first d=27 pilot
+                    # burned 2.9 unrecoverable days for lack of this.
+                    checkpoint_dir=sampler_cfg.get(
+                        "checkpoint_dir", f"{prefix}_nsckpt"
+                    ),
                 )
             elif method in ("numpyro", "blackjax"):
                 import jax

--- a/src/exozippy/samplers/nested.py
+++ b/src/exozippy/samplers/nested.py
@@ -71,7 +71,7 @@ class NestedBridgeError(RuntimeError):
 class UnitCubeBridge:
     """Numeric unit-cube <-> raw bridge for an EXOZIPPy-built model."""
 
-    def __init__(self, model):
+    def __init__(self, model, sampled_masks=None):
         (
             self._raw_to_phys,
             self.raw_to_phys_batched,
@@ -124,6 +124,20 @@ class UnitCubeBridge:
                     np.asarray(phys_dict(e)[base], dtype=float).ravel() - ref
                 )
                 hits = np.where(moved > 1e-9 * np.maximum(np.abs(ref), 1.0))[0]
+                if hits.size > 1 and sampled_masks and base in sampled_masks:
+                    # Same-parameter derived elements (the surgical swaps:
+                    # pm[lens] = pm[source] + mu_rel) legitimately co-move
+                    # with the sampled element that drives them.  The raw
+                    # coordinate CONTROLS its sampled element; the derived
+                    # movers are reconstructed by the physical graph either
+                    # way, so the map keeps the sampled one.  Role masks
+                    # come from the caller (nested_sample has the System);
+                    # a hand-built model without them keeps the strict
+                    # exactly-one contract below.
+                    mask = np.asarray(sampled_masks[base], dtype=bool).ravel()
+                    sampled_hits = hits[mask[hits]]
+                    if sampled_hits.size == 1:
+                        hits = sampled_hits
                 if hits.size != 1:
                     raise NestedBridgeError(
                         f"raw element {v}[{j}] moves {hits.size} elements "
@@ -325,7 +339,21 @@ def nested_sample(
     integrals.  posterior attrs carry logz/logzerr/ncall/backend.
     """
     t0 = time.time()
-    bridge = UnitCubeBridge(model)
+    sampled_masks = None
+    if system is not None:
+        # Per-parameter sampled-element masks, so the raw->physical probe
+        # can disambiguate same-parameter derived elements (see _col_map).
+        sampled_masks = {}
+        for comp in system.active_components.values():
+            for pname in comp.manifest or {}:
+                param = getattr(comp, pname, None)
+                if param is None or not hasattr(param, "element_is_sampled"):
+                    continue
+                n = param._n_elements()
+                sampled_masks[f"{comp.prefix}.{pname}"] = np.array(
+                    [bool(param.element_is_sampled(i)) for i in range(n)]
+                )
+    bridge = UnitCubeBridge(model, sampled_masks=sampled_masks)
     bridge.verify()
     logp_fn = model.compile_logp()
     _NB.update(bridge=bridge, logp_fn=logp_fn, pool=None)

--- a/src/exozippy/samplers/nested.py
+++ b/src/exozippy/samplers/nested.py
@@ -310,6 +310,7 @@ def nested_sample(
     seed=None,
     maxiter=None,
     n_pseudo_chains=4,
+    checkpoint_dir=None,
 ):
     """Run nested sampling and return an arviz.InferenceData.
 
@@ -353,8 +354,19 @@ def nested_sample(
                 pool=pool,
                 queue_size=actual if pool is not None else None,
             )
+            dy_kwargs = {}
+            if checkpoint_dir:
+                import os as _os
+                from pathlib import Path as _Path
+
+                _os.makedirs(str(checkpoint_dir), exist_ok=True)
+                dy_kwargs = {
+                    "checkpoint_file": str(
+                        _Path(checkpoint_dir) / "dynesty.ckpt"
+                    )
+                }
             sampler.run_nested(
-                dlogz=dlogz, maxiter=maxiter, print_progress=False
+                **dy_kwargs, dlogz=dlogz, maxiter=maxiter, print_progress=False
             )
             res = sampler.results
             U = np.asarray(res.samples)
@@ -367,19 +379,38 @@ def nested_sample(
             import ultranest
             import ultranest.stepsampler
 
+            un_kwargs = {}
+            if checkpoint_dir:
+                # log_dir + resume makes SIGTERM survivable: a resubmitted
+                # job continues from the stored live points, and a
+                # truncated run still holds a valid logZ lower bound and
+                # the dead-point record.  The first d=27 pilot predated
+                # this and burned ~2.9 days unrecoverably.
+                un_kwargs = {"log_dir": str(checkpoint_dir), "resume": True}
             sampler = ultranest.ReactiveNestedSampler(
                 bridge.flat_names,
                 _loglike_u_batch,
                 transform=_transform_batch,
                 vectorized=True,
+                **un_kwargs,
             )
             if bridge.ndim >= 15:
-                # Region sampling degrades in high d; slice steps are
-                # ultranest's own recommendation there.
-                sampler.stepsampler = ultranest.stepsampler.SliceSampler(
+                # Region sampling degrades in high d; slice stepping is
+                # ultranest's own recommendation there -- but the plain
+                # SliceSampler is SEQUENTIAL (each step depends on the
+                # previous accept/reject), so it hands the vectorized
+                # likelihood batches of size ~1 and starves the worker
+                # pool: the first d=27 pilot ran at 1/64 = 1.6% CPU on a
+                # 64-slot node for 2.9 days.  The population variant
+                # advances popsize walkers concurrently, producing real
+                # batches sized to keep every pool worker busy.
+                import ultranest.popstepsampler as _pss
+
+                sampler.stepsampler = _pss.PopulationSliceSampler(
+                    popsize=max(2 * actual, 8),
                     nsteps=2 * bridge.ndim,
                     generate_direction=(
-                        ultranest.stepsampler.generate_mixture_random_direction
+                        _pss.generate_mixture_random_direction
                     ),
                 )
             res = sampler.run(


### PR DESCRIPTION
## What this branch is

Operational fixes to `method: nested`, each root-caused on a live run. Three commits; full suite green (2971 passed, 0 failed, 0 errors).

- **Population slice stepping**: the d=27 ultranest pilot ran 2.9 days at 1/64 = 1.6% CPU on a 64-slot node -- the plain `SliceSampler` is sequential (each step depends on the previous accept/reject), handing the vectorized likelihood batches of size ~1 and starving the worker pool the wiring had correctly built. `PopulationSliceSampler` (popsize = 2x pool workers) advances a walker population concurrently: real batches, every worker busy. Relaunched arms run at full parallelism.
- **Survivable checkpoints**: `nested_sample` grows `checkpoint_dir` -- ultranest gets `log_dir` + `resume=True` (SIGTERM survivable; a truncated run still holds a valid logZ lower bound and the dead-point record), dynesty gets a `checkpoint_file`; `run.py` defaults it to `<prefix>_nsckpt`. The killed pilot's 2.9 days were unrecoverable for lack of exactly this.
- **Role-aware bridge map**: the surgical swaps make elements of one parameter derive from its own sampled elements (pm[lens] = pm[source] + mu_rel), so a probe kick legitimately moves two physical elements and the unit-cube bridge's exactly-one contract refused the observable-coordinates model. `nested_sample` now hands the bridge per-parameter sampled-element masks; ambiguous kicks resolve to the sampled mover. Hand-built models without masks keep the strict contract; verified on the observable 128 model (ndim 27, round-trip clean).
- Pilot driver parameterized (`--config`/`--ckpt`, runs in the config's own directory), so one driver serves the physical- and observable-coordinate NS arms now running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
