### PR TITLE
fitu0te: sample the signed effective timescale (swap 4)

### DIFF
--- a/src/exozippy/components/mulensing/defaults.yaml
+++ b/src/exozippy/components/mulensing/defaults.yaml
@@ -27,6 +27,35 @@ lens:
     internal_unit: ""
     latex: "u_0"
     description: "impact parameter"
+    expressions:
+      # Selected by `fitu0te: true` (swap 4): the sampled coordinate is
+      # the SIGNED effective timescale u0te = u_0 * t_E (days) -- on
+      # event 128 corr(log u_0, log t_E) = -0.96 and t_eff is measured
+      # 3x tighter than u_0.  Signed and linear because u_0 itself is
+      # signed here (the +/- reflection is sampled); a log coordinate
+      # would amputate half the modes.  |du_0/du0te| = 1/t_E is not
+      # constant: the correction potential lives in
+      # Lens.build_likelihood, like fitpirel's.
+      from_u0te:
+        func_name: "calc_u0_from_u0te"
+        deps: [ "u0te", "t_E" ]
+  u0te:
+    # Sampled ONLY when the lens sets `fitu0te: true`; otherwise absent.
+    # NAMED FOR THE PRODUCT, not the literature symbol: t_eff collides
+    # with the stellar effective temperature in the config namespace
+    # (star.Lens.teff vs lens.Lens.teff differ only in the component,
+    # and a params-file line names the instance first).  The LaTeX
+    # symbol stays t_eff, where lowercase-t vs uppercase-T is the
+    # published convention.  The same rule is reserved for rho*t_E
+    # (rhote, t_*): the literature's t_star collides with thetastar.
+    # NO initval (the mu_rel lesson, 4745cd7e): the engine back-solves
+    # through the u0te = u_0 * t_E relation.
+    lower: -5000.0
+    upper: 5000.0
+    unit: "d"
+    internal_unit: "d"
+    latex: "t_{\\rm eff}"
+    description: "signed eff. timescale"
   # t_E and the pi_E direction live in the light curve's GEOCENTRIC frame
   # (Skowron+2011 t0_par anchor), so they derive from mu_rel_geo, not from
   # the heliocentric pm difference.

--- a/src/exozippy/components/mulensing/lens.py
+++ b/src/exozippy/components/mulensing/lens.py
@@ -397,6 +397,21 @@ class Lens(Component):
                 ),
             },
             {
+                "key": "fitu0te",
+                "kind": "option",
+                "accepts": None,
+                "required": False,
+                "doc": (
+                    "Sample the SIGNED effective timescale u0te = u_0*t_E "
+                    "(days) and derive u_0 = u0te/t_E. Named for the "
+                    "product because t_eff collides with the stellar "
+                    "effective temperature in the config namespace; the "
+                    "LaTeX symbol stays t_eff. A coordinate choice like "
+                    "fitvcve; the 1/t_E Jacobian potential is added in "
+                    "build_likelihood. Default False."
+                ),
+            },
+            {
                 "key": "star_constrains_rho",
                 "kind": "option",
                 "accepts": None,
@@ -778,6 +793,15 @@ class Lens(Component):
         if fitpirel:
             self.config_manager.add_scale_hint("lens.0.log_pi_rel", 0.1)
 
+        # fitu0te (swap 4): sample the signed effective timescale, derive
+        # u_0 = u0te/t_E (see the defaults.yaml naming note: u0te, not
+        # t_eff -- the stellar teff collision).
+        fitu0te = bool(self.config[0].get("fitu0te", False))
+        self._fitu0te = fitu0te
+        if fitu0te:
+            for j in range(self.n_sources):
+                self.config_manager.add_scale_hint(f"lens.{j}.u0te", 0.05)
+
         # fitthetae (swap 3): sample log_theta_E, derive theta_E from it,
         # and the star component derives the HOST logmass (see star.py).
         # Constraints: single source (theta_E is per-source), and at most
@@ -816,7 +840,7 @@ class Lens(Component):
 
         self.manifest = {
             "t_0": per_source(),
-            "u_0": per_source(),
+            "u_0": per_source("from_u0te" if fitu0te else None),
             "pi_rel": per_source("from_log_pi_rel" if fitpirel else "default"),
             "theta_E": per_source(
                 "from_log_theta_E" if fitthetae else "default"
@@ -824,6 +848,7 @@ class Lens(Component):
             "mu_ra_rel": murel_entry(),
             "mu_dec_rel": murel_entry(),
             **({"log_pi_rel": per_source()} if fitpirel else {}),
+            **({"u0te": per_source()} if fitu0te else {}),
             **({"log_theta_E": per_source()} if fitthetae else {}),
             "mu_rel_mag": per_source("default"),
             "mu_ra_rel_geo": per_source("default"),
@@ -1469,6 +1494,15 @@ class Lens(Component):
         # measure and logit corrections are Parameter.build_pymc's, as for
         # every sampled coordinate; this potential is only the map's own
         # stretch factor.
+        # fitu0te's change of variables: u_0 = u0te/t_E, so
+        # |du_0/du0te| = 1/t_E and the correction is -log(t_E) per source
+        # trajectory.  Same reasoning as fitpirel's potential below.
+        if getattr(self, "_fitu0te", False):
+            pm.Potential(
+                f"{self.prefix}.fitu0te_jacobian",
+                -pt.log(pt.maximum(self.t_E.value[0], 1e-12)),
+            )
+
         if getattr(self, "_fitpirel", False):
             l_idx = int(self.lens_bodies[0][0][1])
             d_l = system.star.distance.value[l_idx]

--- a/src/exozippy/components/mulensing/physics.py
+++ b/src/exozippy/components/mulensing/physics.py
@@ -471,6 +471,14 @@ def calc_theta_E_from_log(log_theta_E):
 
 
 @register_physics
+def calc_u0_from_u0te(u0te, t_E):
+    # fitu0te inverse (swap 4): u_0 = u0te / t_E, both signed.
+    # |du_0/du0te| = 1/t_E is NOT constant; the correction potential
+    # lives in Lens.build_likelihood.
+    return u0te / pt.maximum(t_E, 1e-12)
+
+
+@register_physics
 def calc_rho_from_log(log_rho):
     # Sampled coordinate for `star_constrains_rho: false` lenses: rho spans decades
     # (1e-4 .. 0.5 across published events), so the free coordinate is

--- a/src/exozippy/components/mulensing/symbolic_physics.py
+++ b/src/exozippy/components/mulensing/symbolic_physics.py
@@ -22,6 +22,7 @@ pi_E_N, pi_E_E = sp.symbols("pi_E_N pi_E_E")
 rho, source_radius = sp.symbols("rho source_radius")
 log_rho = sp.symbols("log_rho", real=True)
 log_pi_rel = sp.symbols("log_pi_rel", real=True)
+u0te = sp.symbols("u0te", real=True)
 log_theta_E = sp.symbols("log_theta_E", real=True)
 q_lens, companion_mass = sp.symbols("q_lens companion_mass")
 alpha, xalpha, yalpha = sp.symbols("alpha xalpha yalpha")
@@ -148,6 +149,10 @@ def get_symbol_map(lens_config_list):
         if lens_config_list.get("fitpirel"):
             result["log_pi_rel"] = f"lens.{j}.log_pi_rel"
 
+        # u0te exists only under fitu0te (swap 4).
+        if lens_config_list.get("fitu0te"):
+            result["u0te"] = f"lens.{j}.u0te"
+
         # log_theta_E exists only under fitthetae (swap 3).
         if lens_config_list.get("fitthetae"):
             result["log_theta_E"] = f"lens.{j}.log_theta_E"
@@ -204,6 +209,9 @@ RELATIONS = [
     # (swap 2); inert otherwise.  Lets the distance-derived pi_rel seed
     # back-solve to a log_pi_rel start.
     sp.Eq(pi_rel, 10**log_pi_rel),
+    # signed effective-timescale reparameterization, active only for
+    # `fitu0te: true` (swap 4); inert otherwise.
+    sp.Eq(u0te, u_0 * t_E),
     # theta_E reparameterization, active only for `fitthetae: true` (swap
     # 3); inert otherwise.
     sp.Eq(theta_E, 10**log_theta_E),

--- a/tests/test_fitu0te.py
+++ b/tests/test_fitu0te.py
@@ -1,0 +1,106 @@
+"""
+Tests for `fitu0te: true` (lens block): sample the SIGNED effective
+timescale u0te = u_0 * t_E (days), derive u_0 = u0te / t_E.
+
+Swap 4 of the surgical coordinate plan.  Measured motivation (event 128,
+murel arm): corr(log u_0, log t_E) = -0.96 and t_eff is 3x tighter than
+u_0.  Signed and linear because u_0 itself is signed (the +/- reflection
+is a sampled mode); |du_0/du0te| = 1/t_E is not constant, so a Jacobian
+potential accompanies the swap and is pinned here by finite difference
+against the model's own map.  The config name is u0te, NOT t_eff: the
+stellar effective temperature owns 'teff' in the config namespace
+(star.Lens.teff vs lens.Lens.teff differ only in the component).
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytensor
+import pytest
+import yaml
+
+from exozippy.system import System
+
+_KMT_DIR = Path(__file__).parent.parent / "examples" / "KMT-2019-BLG-1806"
+
+_WORKDIR = None
+
+
+def _kmt_workdir():
+    global _WORKDIR
+    if _WORKDIR is None:
+        import shutil
+        import tempfile
+
+        _WORKDIR = Path(tempfile.mkdtemp(prefix="kmt_test_")) / "KMT"
+        shutil.copytree(_KMT_DIR, _WORKDIR)
+    return _WORKDIR
+
+
+def _build(fitu0te):
+    import os
+
+    if not _KMT_DIR.is_dir():
+        pytest.skip("KMT-2019-BLG-1806 example not present")
+    cwd = os.getcwd()
+    os.chdir(_kmt_workdir())
+    try:
+        with open("KMT-2019-BLG-1806.yaml") as f:
+            config = yaml.safe_load(f)
+        with open(config["parameter_file"]) as f:
+            user_params = yaml.safe_load(f)
+        for k in ("run", "prefix", "parameter_file", "sampler"):
+            config.pop(k, None)
+        if fitu0te:
+            config["lens"][0]["fitu0te"] = True
+        system = System(config, user_params=user_params)
+        system.prepare()
+        model = system.build_model()
+    finally:
+        os.chdir(cwd)
+    return system, model
+
+
+def _eval(model, node, point):
+    (node,) = model.replace_rvs_by_values([node])
+    f = pytensor.function(model.value_vars, node, on_unused_input="ignore")
+    return f(*[point[v.name] for v in model.value_vars])
+
+
+def test_off_is_the_physical_parameterization():
+    system, model = _build(fitu0te=False)
+    vv = [v.name for v in model.value_vars]
+    assert "lens.u0te_raw" not in vv
+    assert "lens.u_0_raw" in vv
+    assert not any("fitu0te" in p.name for p in model.potentials)
+
+
+def test_swapped_identity_and_fd_jacobian():
+    system, model = _build(fitu0te=True)
+    vv = [v.name for v in model.value_vars]
+    assert "lens.u0te_raw" in vv and "lens.u_0_raw" not in vv
+
+    point = model.initial_point()
+    u0 = np.atleast_1d(_eval(model, system.lens.u_0.value, point))
+    ut = np.atleast_1d(_eval(model, system.lens.u0te.value, point))
+    te = np.atleast_1d(_eval(model, system.lens.t_E.value, point))
+    assert np.isclose(u0[0], ut[0] / te[0], rtol=1e-12)
+
+    jac_pot = [p for p in model.potentials if "fitu0te_jacobian" in p.name]
+    assert len(jac_pot) == 1
+    jac_val = float(np.squeeze(_eval(model, jac_pot[0], point)))
+
+    def at(delta):
+        pt2 = dict(point)
+        pt2["lens.u0te_raw"] = point["lens.u0te_raw"] + delta
+        u = float(np.atleast_1d(_eval(model, system.lens.u_0.value, pt2))[0])
+        w = float(np.atleast_1d(_eval(model, system.lens.u0te.value, pt2))[0])
+        return u, w
+
+    eps = 1e-4
+    u_hi, w_hi = at(eps)
+    u_lo, w_lo = at(-eps)
+    fd = abs((u_hi - u_lo) / (w_hi - w_lo))
+    assert np.isclose(np.exp(jac_val), fd, rtol=1e-6), (np.exp(jac_val), fd)
+
+    assert np.isfinite(float(model.compile_logp()(point)))


### PR DESCRIPTION
Swap 4 on the established pattern, measured motivation: on event 128 corr(log u_0, log t_E) = -0.96 and t_eff is 3x tighter than u_0 (eigenanalysis in notes/observable_coordinates.txt). Samples SIGNED u0te = u_0*t_E (u_0 is signed here -- the +/- reflection is a sampled mode, so a log coordinate would amputate half the posterior); u_0 = u0te/t_E derived; the non-constant 1/t_E Jacobian potential is FD-pinned by test. Config key names the product (u0te) because t_eff collides with the stellar effective temperature on the same instance name; LaTeX keeps t_eff. Suite green (2973 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)