### PR TITLE
CI runtime (6.13.1): the gap was worker count, and the compile cache was over budget

### DIFF
--- a/.github/workflows/intel-mac.yml
+++ b/.github/workflows/intel-mac.yml
@@ -239,8 +239,10 @@ jobs:
           python scripts/diag_jax_samplers.py --traceback \
             ${{ inputs.strict_probe && '--strict' || '' }}
 
-      # -n 2 matches tests.yml: this is a 4-CPU runner and each worker peaks
-      # 1-2 GB building a System and compiling graphs.
+      # The worker count comes from the same script tests.yml uses, so the
+      # two workflows cannot drift: each worker peaks 1-2 GB building a
+      # System and compiling graphs, and the script sizes for that from the
+      # runner's own cores and memory.
       #
       # test_gp.py is in the set and is the expensive one, on purpose. Its
       # 10 kernel-building tests carry @needs_celerite2_pymc and SKIP here
@@ -252,7 +254,9 @@ jobs:
       - name: Run the smoke subset
         if: ${{ !inputs.run_full_suite }}
         run: |
-          pytest -q -n 2 \
+          set -euo pipefail
+          workers=$(python scripts/pytest_workers.py --explain)
+          pytest -q -n "$workers" \
             tests/test_limbdark.py \
             tests/test_physics_registry.py \
             tests/test_config_healing.py \
@@ -262,7 +266,10 @@ jobs:
 
       - name: Run the full suite
         if: ${{ inputs.run_full_suite }}
-        run: pytest -q -n 2
+        run: |
+          set -euo pipefail
+          workers=$(python scripts/pytest_workers.py --explain)
+          pytest -q -n "$workers"
 
       # Kept regardless of outcome: when the install fails, the requirement
       # file and whatever pip managed to resolve are the diagnosis.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,14 @@ jobs:
     name: pytest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
+
+    # actions: write is for `gh cache delete` in the housekeeping step at the
+    # end; contents: read is everything else this job does. Scoped to the job
+    # rather than the workflow, so the nightly job below keeps its own narrower
+    # set (issues: write, no actions).
+    permissions:
+      contents: read
+      actions: write
     strategy:
       # Do not cancel the other combinations when one fails. When a new Python
       # breaks something, "3.14 failed and everything else was cancelled" tells
@@ -230,28 +238,42 @@ jobs:
       # test_integration_kelt4, test_gp and test_sed_plot_data across runs,
       # and vanished entirely on others. That is a memory ceiling, not a bug.
       #
-      # The compiledir budget is tighter than the local default (3000). A
-      # developer's cache wants room for several branches' worth of divergent
-      # graphs; a CI job runs one commit, so anything beyond roughly one
-      # suite's 1564 entries is dead weight that only inflates the artifact
-      # this job uploads. 2500 leaves headroom above that measured figure --
-      # a budget BELOW one run's working set would evict entries this very
-      # run still needs.
+      # The compiledir budget is PER COMPILEDIR and there is one per worker
+      # (the root conftest gives each its own, so they never queue on
+      # PyTensor's compile lock). It is tighter than the local default
+      # because a CI job runs one commit: anything beyond roughly one run's
+      # per-worker working set of ~1600 entries is dead weight that only
+      # inflates the artifact this job saves. A budget BELOW that working set
+      # would evict entries this very run still needs.
       - name: Run test suite
         env:
-          EXOZIPPY_TEST_COMPILEDIR_MAX_ENTRIES: "2500"
+          EXOZIPPY_TEST_COMPILEDIR_MAX_ENTRIES: "1800"
         run: poetry run pytest -q -n 2
 
-      # The conftest prunes at session START, so at this point the directory
-      # holds the budget plus everything this run compiled. Trim it again so
-      # the uploaded artifact is a bounded, deterministic size rather than
-      # growing by one run's worth on every merge.
+      # The conftest prunes at session START, so at this point the directories
+      # hold the budget plus everything this run compiled. Trim again so the
+      # saved artifact is a bounded size rather than growing by one run's
+      # worth on every merge.
+      #
+      # --include-worker-dirs is what makes that sentence true, and its
+      # absence is why it was false. Without it this pruned only the
+      # compiledir pytensor.config resolves, which under -n is the
+      # controller's -- the one directory no worker ever writes to. It was
+      # empty, the step reported success having removed nothing, and the
+      # per-worker directories that hold the entire cache were never
+      # considered. The artifact grew every merge: ubuntu 3.14 went 374 ->
+      # 494 -> 606 -> 661 -> 781 MB over five consecutive master runs, and
+      # with the generations below retained on top of that the repository's
+      # pytensor caches reached 8.05 GB of the 10 GB budget -- so GitHub was
+      # evicting least-recently-accessed, which is the scenario the restore
+      # step's comment describes as trading a 5-minute cache for a 250 MB
+      # download.
       - name: Prune the compile cache before saving it
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           export PYTENSOR_FLAGS="base_compiledir=$HOME/.pytensor-pytest"
           poetry run python scripts/pytensor_cache_budget.py \
-            --max-entries 2500 --sweep-other-platforms
+            --max-entries 1800 --sweep-other-platforms --include-worker-dirs
 
       # See the long comment on the restore step for why this is master-only.
       - name: Save the PyTensor compile cache
@@ -260,6 +282,51 @@ jobs:
         with:
           path: ~/.pytensor-pytest
           key: ${{ steps.compiledir-cache.outputs.cache-primary-key }}
+
+      # The restore step's key embeds github.run_id so that each master push
+      # writes a NEW entry instead of hitting an existing one and skipping the
+      # save. That is necessary -- a cache key is immutable once written -- but
+      # it has a consequence the restore-keys prefix hides: nothing ever
+      # supersedes the entry it replaces. Old generations only leave by
+      # eviction, so they accumulate. Measured 2026-08-25: FIVE generations
+      # retained per os+python, 18 entries, 8.05 GB of the repository's 10 GB
+      # budget, total usage 10.43 GB -- i.e. already evicting, and the two
+      # things eviction must not take (the 132 MB Zenodo spectra and the
+      # 115 MB ephemeris kernel) were the smallest entries in there.
+      #
+      # Only the newest is ever restored: the restore-keys prefix matches
+      # most-recent-first. So the older ones buy nothing and cost the budget.
+      # This deletes them, scoped to THIS job's os+python prefix, so the four
+      # matrix combinations running concurrently cannot interfere with each
+      # other.
+      #
+      # The prefix also spans lockfile hashes, which is intended: after a
+      # dependency bump the first master run restores the old-lock entry as a
+      # partial hit, compiles the delta, saves under the new key, and the old
+      # entry is then genuinely superseded.
+      #
+      # continue-on-error, like the issue bookkeeping in the nightly job
+      # below: cache housekeeping must never decide a suite's verdict. A
+      # transient API error here would otherwise turn a green run red.
+      - name: Drop superseded compile caches
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEEP: ${{ steps.compiledir-cache.outputs.cache-primary-key }}
+          PREFIX: pytensor-compiledir-p1-${{ matrix.os }}-${{ matrix.python-version }}-
+        run: |
+          set -euo pipefail
+          keys="$RUNNER_TEMP/superseded-cache-keys.txt"
+          gh cache list --key "$PREFIX" --limit 100 --json key \
+            --jq '.[].key' > "$keys" || true
+          while read -r key; do
+            if [ -z "$key" ] || [ "$key" = "$KEEP" ]; then
+              continue
+            fi
+            echo "deleting superseded cache: $key"
+            gh cache delete "$key" || true
+          done < "$keys"
 
   # Installs WITHOUT poetry.lock, resolving dependencies fresh the way a user's
   # `pip install exozippy` does.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -230,13 +230,25 @@ jobs:
             pytensor-compiledir-p1-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-
             pytensor-compiledir-p1-${{ matrix.os }}-${{ matrix.python-version }}-
 
-      # -n 2 overrides the -n 6 in pyproject's addopts. Six workers suit a
-      # workstation but oversubscribe a GitHub runner: each peaks ~1-2 GB
-      # building a System and compiling PyTensor graphs. The symptom was never
-      # an assertion failure but "worker 'gwN' crashed", landing on whichever
-      # heavy test drew the short straw -- it moved between
-      # test_integration_kelt4, test_gp and test_sed_plot_data across runs,
-      # and vanished entirely on others. That is a memory ceiling, not a bug.
+      # The worker count is COMPUTED, not written down here, and the reason
+      # is that the number this replaced went stale without anyone noticing.
+      # `-n 2` was chosen when a hosted Linux runner had two cores; the
+      # runners grew, the suite tripled, and the 2 stayed. Measured on
+      # 2026-08-24 with the compile cache warm on both sides, the four matrix
+      # jobs did the same work PER WORKER as a 36-core workstation -- ubuntu
+      # 3.12 spent 5202 worker-seconds against the workstation's 5682 -- so
+      # the entire 43-minute-vs-15:47 gap was worker count and nothing else.
+      # Replacing one hardcoded number with another would just restart that
+      # clock, so scripts/pytest_workers.py reads the cores and the memory
+      # instead; --explain puts both in the log, which is also how we learn
+      # what a runner actually has rather than inferring it from docs.
+      #
+      # The memory term in that script is the binding one, and the failure it
+      # exists to avoid is specifically "worker 'gwN' crashed" -- a memory
+      # ceiling that presents as a wandering flaky failure, seen on
+      # test_integration_kelt4, test_gp and test_sed_plot_data on different
+      # runs. Do not raise the worker count past what it returns without
+      # raising the memory per worker there too.
       #
       # The compiledir budget is PER COMPILEDIR and there is one per worker
       # (the root conftest gives each its own, so they never queue on
@@ -248,7 +260,10 @@ jobs:
       - name: Run test suite
         env:
           EXOZIPPY_TEST_COMPILEDIR_MAX_ENTRIES: "1800"
-        run: poetry run pytest -q -n 2
+        run: |
+          set -euo pipefail
+          workers=$(poetry run python scripts/pytest_workers.py --explain)
+          poetry run pytest -q -n "$workers"
 
       # The conftest prunes at session START, so at this point the directories
       # hold the budget plus everything this run compiled. Trim again so the
@@ -418,8 +433,15 @@ jobs:
       - name: Record what actually got resolved
         run: pip freeze | tee resolved.txt
 
+      # Same computed worker count as the matrix job -- see the comment
+      # there. No poetry in this job by design, so the script runs on the
+      # bare interpreter; it imports nothing outside the standard library
+      # precisely so it can.
       - name: Run test suite
-        run: pytest -q -n 2
+        run: |
+          set -euo pipefail
+          workers=$(python scripts/pytest_workers.py --explain)
+          pytest -q -n "$workers"
 
       # Email alone is a weak alarm for this job. A nightly that stays broken
       # for a week sends seven identical emails, which is how an alarm becomes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,10 +234,15 @@ Other workflow notes:
   hand off. Don't feel obligated to file one for every change — a good commit
   message already covers most of what a trivial-fix issue would say.
 - Every push and PR against `master` runs the test suite via GitHub Actions
-  (`.github/workflows/tests.yml`). CI runs pytest with `-n 2`, overriding the
-  `-n 6` in pyproject's addopts: six workers suit a workstation but exhaust a
-  GitHub runner's memory, which shows up as "worker 'gwN' crashed" on whichever
-  heavy test drew the short straw rather than as an honest failure.
+  (`.github/workflows/tests.yml`). CI overrides the `-n 6` in pyproject's
+  addopts with a count computed from the runner it landed on --
+  `min(cores, memory_gb // 3)`, via `scripts/pytest_workers.py`. Six workers
+  suit a workstation but exhaust a GitHub runner's memory, which shows up as
+  "worker 'gwN' crashed" on whichever heavy test drew the short straw rather
+  than as an honest failure. The count is computed rather than written down
+  because the `-n 2` it replaced was right when a hosted runner had two cores
+  and then quietly stopped being right; the job logs the cores and memory it
+  saw, so check there rather than assuming a number.
 - Contributing from a fork works the same way, and is the right approach if you
   don't have write access. Note that auto-delete-on-merge cannot reach a fork's
   branches, so clean those up yourself after merge.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ feature:
   at 1-2 GB compiling PyTensor graphs. Measured on that machine, available
   memory bottomed out at **41 MB**: workers were killed (`[gwN] node down`),
   xdist died in its own scheduler, and one run hung for hours. Fix it with a
-  `.wslconfig` (see the runbook) or run `-n 2` as CI does.
+  `.wslconfig` (see the runbook) or lower `-n`;
+  `python scripts/pytest_workers.py --explain` prints what this machine's
+  cores and memory can actually afford, which is what CI runs.
 
 Smaller, setup-time only:
 

--- a/WINDOWS_INSTALL.md
+++ b/WINDOWS_INSTALL.md
@@ -329,7 +329,8 @@ Status: [VERIFIED]
 WSL2 defaults to **50% of host RAM**. On this machine that is 7.6 GiB of
 15.75 GiB -- so a workstation gets handed roughly the memory ceiling of a
 GitHub runner, which is exactly why `.github/workflows/tests.yml` overrides the
-`-n 6` in `pyproject.toml` with `-n 2`.
+`-n 6` in `pyproject.toml` with a count sized to the machine it landed on
+(`scripts/pytest_workers.py`: `min(cores, memory_gb // 3)`).
 
 That ceiling is real here: each worker peaks ~1-2 GB building a `System` and
 compiling PyTensor graphs, and a full `-n 6` run drove **available memory down
@@ -363,9 +364,11 @@ Size `memory` to leave Windows a few GB (12 GB of this machine's 15.75 GB
 leaves ~3.75 GB). It is a ceiling, not a reservation -- WSL reclaims lazily --
 so the cost of setting it too high is Windows swapping, not WSL wasting RAM.
 
-If you would rather not raise the ceiling, run the suite at `-n 2` like CI
-does. Either way, **always run the suite under a timeout** so a wedged xdist
-cannot silently eat an afternoon:
+If you would rather not raise the ceiling, lower `-n` to what the memory
+allows -- `python scripts/pytest_workers.py --explain` computes it the same
+way CI does, and reports the cores and memory it based that on. Either way,
+**always run the suite under a timeout** so a wedged xdist cannot silently eat
+an afternoon:
 
 ```bash
 timeout 3000 poetry run pytest -q -rf -n 6

--- a/conftest.py
+++ b/conftest.py
@@ -82,14 +82,26 @@ for _var in (
 _COMPILEDIR_ENV = "EXOZIPPY_TEST_COMPILEDIR"
 _BUDGET_ENV = "EXOZIPPY_TEST_COMPILEDIR_MAX_ENTRIES"
 
-# One full cold run of this suite creates 1564 entries (measured, 825 MB), so
-# the budget must clear that comfortably or every run would evict what the
-# next one needs and the cache would never be warm. Note a second run on a
-# different branch does NOT add another 1564: it reuses almost everything and
-# adds only the delta for the graphs that changed, so 3000 covers several
-# worktrees rather than the 1.9 runs the arithmetic suggests -- while keeping
-# the startup walk well under the 4035-entry directory this replaces.
-_DEFAULT_MAX_ENTRIES = 3000
+# PER COMPILEDIR, not a total across the tree -- see the per-worker section
+# below, and enforce_budget_tree's docstring for why that is the right
+# denominator (each worker walks only its own directory, so one directory's
+# entry count is what the startup walk is linear in).
+#
+# The number is sized against ONE run's per-worker working set. A full run
+# creates 1564 distinct entries, and measurement shows a worker's own
+# directory holds very nearly all of them -- 1455 to 1562 across gw0-gw5 --
+# because most of what gets compiled is shared infrastructure that every
+# file's model builds, not something specific to the files that worker drew.
+# So the budget has to clear ~1600 or a run would evict entries it still
+# needs, and there is no point going far above it: the headroom that 3000
+# used to buy ("several worktrees") is not available at this denominator,
+# because with W workers the tree now holds up to (W + 1) x this.
+#
+# 3000 was the old value and it was applied to the CONTROLLER's compiledir,
+# which under -n is the one directory no worker ever reads. It therefore
+# bounded nothing: the controller sat at 2280 entries and never hit 3000,
+# while the six directories that do get read grew without any bound at all.
+_DEFAULT_MAX_ENTRIES = 2000
 
 _raw_compiledir = os.environ.get(_COMPILEDIR_ENV)
 if _raw_compiledir is None:
@@ -168,6 +180,16 @@ if _BASE_COMPILEDIR is not None:
 # common ops across workers, paid in parallel instead of in a queue.
 # Appended as the rightmost flag, so it wins whatever base won above
 # (parse_config_string builds its dict left to right).
+#
+# The OTHER price, which went unpaid for weeks: these directories are not
+# where pytensor.config points in the controller, so the budget below has to
+# be walked over them explicitly. It was not, and they grew without bound --
+# locally to six directories of ~1500 entries each, and in CI to a saved
+# cache artifact that got bigger on every master merge until the
+# repository-wide 10 GB budget started evicting the Zenodo and ephemeris
+# caches that the suite cannot cheaply re-download. _prune_compiledir now
+# covers the whole tree; do not "simplify" it back to pytensor.config's
+# single directory.
 _worker = os.environ.get("PYTEST_XDIST_WORKER")
 if _worker and "pytensor" not in sys.modules:
     _flags = os.environ.get("PYTENSOR_FLAGS", "")
@@ -227,12 +249,21 @@ def _xdist_active(config):
 
 
 def _prune_compiledir(config):
-    """Bound the suite's compiledir. Controller only, before workers exist.
+    """Bound the suite's compiledirs. Controller only, before workers exist.
 
     Doing it here rather than in a fixture is what makes the prune safe
     without taking PyTensor's compile lock: ``pytest_configure`` on the
     controller runs before xdist spawns a single worker, so nothing else is
-    walking the directory yet.
+    walking the directories yet. It is also the only moment at which the
+    per-worker trees can be pruned at all -- a worker cannot prune its own,
+    because by the time it runs it is already holding the ModuleCache it
+    would be deleting under itself.
+
+    EVERY compiledir in the tree, not just the one pytensor.config resolves.
+    That distinction is the whole point: this process is the controller, so
+    what it resolves is ``base/compiledir_<platform>``, and under -n that is
+    the one directory none of the workers ever opens. See
+    enforce_budget_tree.
     """
     budget = int(os.environ.get(_BUDGET_ENV, _DEFAULT_MAX_ENTRIES))
     module = _load_budget_module()
@@ -240,7 +271,7 @@ def _prune_compiledir(config):
         return None
     import pytensor  # noqa: PLC0415 -- must follow the PYTENSOR_FLAGS write above
 
-    stats = module.enforce_budget(
+    results = module.enforce_budget_tree(
         Path(pytensor.config.base_compiledir),
         Path(pytensor.config.compiledir),
         budget,
@@ -249,7 +280,7 @@ def _prune_compiledir(config):
         # Python version that nothing will ever read again.
         sweep_platforms=True,
     )
-    return stats.summary(Path(pytensor.config.compiledir), budget)
+    return module.summarize_tree(results, budget)
 
 
 def _warm_module_cache():

--- a/docs/testing-cache.md
+++ b/docs/testing-cache.md
@@ -123,6 +123,17 @@ ahead of the import.
    worker.** pytest-timeout arms its per-test `SIGALRM` later, so however
    long the walk takes it can no longer fail a test. That is the actual fix
    for the red test; bounding the count is what makes it fast.
+4. **Each xdist worker gets its OWN `base_compiledir`**, `gw0/`, `gw1/`, ...
+   one level below the base, keyed off `PYTEST_XDIST_WORKER`.
+
+   PyTensor serializes ALL compilation behind one lock per compiledir, and
+   `compile__timeout=600` is exactly pytest-timeout's own ceiling -- so on a
+   cold cache a worker queued behind the others died by pytest-timeout
+   without ever failing the lock. The suffix removes the shared lock
+   entirely. The price is duplicated compiles of common ops across workers,
+   paid in parallel instead of in a queue -- and duplicated DISK, which is
+   why the budget in point 2 is per compiledir and why it has to be walked
+   over these directories explicitly. It was not, until 2026-08-25.
 
 Escape hatches:
 
@@ -201,8 +212,9 @@ This is not worth weakening the 300 s cap for. It only bites on a
 genuinely empty compiledir, which is a state you now hit **once**, the
 first time you run the suite after this change. Just re-run -- the second
 run is warm and green -- or make the cold run deliberate with
-`--timeout=1800`. CI never sees it at `-n 2`, where the lock queue is two
-deep instead of six.
+`--timeout=1800`. CI does not see it either, and for a stronger reason than
+the low worker count it used to run at: point 4 above gives every worker its
+own compiledir, so there is no shared compile lock left to queue on.
 
 One full cold run creates **1564 entries / 825 MB**. That is the number the
 budgets are sized against -- a budget below one run's working set would

--- a/docs/testing-cache.md
+++ b/docs/testing-cache.md
@@ -58,12 +58,18 @@ To reclaim space by hand:
 
 ```bash
 # What would go, without touching anything.
-poetry run python scripts/pytensor_cache_budget.py --max-entries 2500 --dry-run
+poetry run python scripts/pytensor_cache_budget.py \
+    --max-entries 2000 --include-worker-dirs --dry-run
 
 # Do it. Defaults to whatever pytensor.config resolves, so PYTENSOR_FLAGS
 # is honoured; --compiledir names one explicitly.
-poetry run python scripts/pytensor_cache_budget.py --max-entries 2500
+poetry run python scripts/pytensor_cache_budget.py \
+    --max-entries 2000 --include-worker-dirs
 ```
+
+`--include-worker-dirs` is not optional housekeeping on the suite's own
+cache: without it the command reports success having pruned the one
+directory the workers never read. `--max-entries` is per compiledir.
 
 It evicts least-recently-used on the `atime` of `key.pkl` -- the same stat
 field PyTensor's own `last_access_time()` reads -- and also removes broken
@@ -83,9 +89,36 @@ ahead of the import.
    It lives under `$HOME` rather than in the checkout on purpose: every
    worktree of this repo then shares one **warm** cache, where an in-repo
    path would make each new agent worktree pay a full cold compile.
-2. **It is bounded at 3000 entries**, pruned LRU on the xdist controller in
-   `pytest_configure`, before any worker exists -- which is also what makes
-   the prune safe without taking PyTensor's compile lock.
+2. **Every compiledir in the tree is bounded at 2000 entries**, pruned LRU on
+   the xdist controller in `pytest_configure`, before any worker exists --
+   which is also what makes the prune safe without taking PyTensor's compile
+   lock, and is the only moment at which the per-worker trees below can be
+   pruned at all (a worker cannot prune the ModuleCache it is holding).
+
+   "Every compiledir in the tree", plural, is the correction. Point 4 below
+   gives each xdist worker its own base, so the layout is
+
+   ```
+   ~/.pytensor-pytest/compiledir_<platform>/      <- -n0 runs only
+   ~/.pytensor-pytest/gw0/compiledir_<platform>/  <- worker 0
+   ~/.pytensor-pytest/gw1/compiledir_<platform>/  <- worker 1
+   ```
+
+   and `pytensor.config.compiledir` in the CONTROLLER resolves the first of
+   those -- the one directory no worker ever writes to. The prune ran on that
+   alone until 2026-08-25, so it bounded nothing: measured on this box, the
+   controller's tree sat at 2280 entries against a budget of 3000 and was
+   never touched, while `gw0`-`gw5` held **1455 to 1562 entries each** with
+   no bound of any kind. `enforce_budget_tree` walks all of them.
+
+   The budget is **per compiledir, not a total**, because the walk each
+   worker pays is over its own directory only. The price of that denominator
+   is disk: with W workers the tree holds up to (W + 1) x the budget. That is
+   why the number came DOWN from 3000 when it started applying to seven
+   directories instead of one. It cannot go below ~1600: a worker's own
+   directory holds very nearly the full 1564-entry working set, because most
+   of what gets compiled is shared infrastructure that every file's model
+   builds rather than anything specific to the files that worker drew.
 3. **The `ModuleCache` walk is forced in `pytest_configure`, in every
    worker.** pytest-timeout arms its per-test `SIGALRM` later, so however
    long the walk takes it can no longer fail a test. That is the actual fix
@@ -97,7 +130,7 @@ Escape hatches:
 |---|---|
 | `EXOZIPPY_TEST_COMPILEDIR=/some/path` | put the suite's cache somewhere else |
 | `EXOZIPPY_TEST_COMPILEDIR=` (empty) | opt out; use whatever PyTensor would pick |
-| `EXOZIPPY_TEST_COMPILEDIR_MAX_ENTRIES=N` | change the budget (CI uses 2500) |
+| `EXOZIPPY_TEST_COMPILEDIR_MAX_ENTRIES=N` | change the per-compiledir budget (CI uses 1800) |
 
 The prune itself is guarded by a cheap pre-check, and that is load-bearing
 rather than an optimization: its per-entry pass opens a directory and stats
@@ -207,6 +240,38 @@ That is handled on the pytest side: the conftest prune sweeps stale sibling
 `compiledir_*` trees. This is the same class of bug as the Zenodo cache path
 that went stale in July 2026 and kept reporting "cache hit" while restoring
 132 MB into a directory nothing opened.
+
+### The two ways the saved artifact grew, and the 10 GB wall it hit
+
+Both were found on 2026-08-25 and both are fixed; the shape is worth keeping
+because neither one failed anything, which is why they ran for weeks.
+
+**Each entry grew.** The `Prune the compile cache before saving it` step ran
+`pytensor_cache_budget.py` without `--include-worker-dirs`, so it pruned the
+controller's compiledir -- empty, in a job that runs under `-n` -- reported
+success having removed nothing, and never looked at the `gw*/` trees that
+hold the whole cache. Every merge therefore saved the previous artifact plus
+that run's new entries. Measured across five consecutive master runs, ubuntu
+3.14 went **374 -> 494 -> 606 -> 661 -> 781 MB**.
+
+**Entries were never superseded.** The restore key embeds `github.run_id` so
+each master push writes a NEW entry rather than hitting an existing one and
+skipping the save. That is necessary -- a cache key is immutable once written
+-- but nothing retired the entry it replaced, and only the newest is ever
+restored, because `restore-keys` matches most-recent-first. So old
+generations bought nothing and cost the budget: **five generations retained
+per os+python, 18 entries, 8.05 GB.**
+
+Together those put total repository cache usage at **10.43 GB against a
+10 GB budget**, i.e. GitHub was already evicting least-recently-accessed --
+and the two entries eviction must not take, the 132 MB Zenodo spectra and
+the 115 MB ephemeris kernel, were the smallest things in there. That is the
+exact failure the restore step's comment was written to prevent, arrived at
+from a direction the comment did not consider. The `Drop superseded compile
+caches` step now deletes older generations for the job's own os+python.
+
+Check the total with `gh cache list --limit 200 --json key,sizeInBytes` and
+sum `sizeInBytes`; anything approaching 10 GB means eviction is live.
 
 ## A source change can invalidate the whole cache
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,11 +8,54 @@ Testing note: build relation inputs with `pt.dscalar`, **not** `pt.as_tensor_var
 
 ## Suite runtime and the pytensor compile cache
 
-The suite runs in **~8 minutes warm** and **~25 minutes cold** (`-n 6`, 2473 tests). A cold
-run happens once per fresh checkout or worktree, and on CI until its compiledir cache is
-populated. The runbook -- what the cache is, how it is bounded, how to reclaim space, and
-how to measure a run honestly -- is in `docs/testing-cache.md`. Read that before changing
-anything about the compile cache or the suite's timing.
+The suite runs in **~16 minutes warm** on an idle 36-core box (`-n 6`, 3108 tests,
+measured 2026-08-19 at 2977 tests / 11:37 and 2026-08-25 at 3052 / 15:47). A cold run is
+**~25 minutes** and happens once per fresh checkout or worktree, and on CI until its
+compiledir cache is populated. The runbook -- what the cache is, how it is bounded, how
+to reclaim space, and how to measure a run honestly -- is in `docs/testing-cache.md`.
+Read that before changing anything about the compile cache or the suite's timing.
+
+### Where the time actually goes (measured 2026-08-25, review item 6.13.1)
+
+One `--durations=0` run, 3105 passed / 3 skipped, **6715 worker-seconds** of measured
+test time. The two numbers that decide what is worth optimizing:
+
+| | worker-seconds | share |
+|---|---|---|
+| `call` (test bodies) | 5690 | **84.7%** |
+| `setup` (fixtures, i.e. shared `System` builds) | 1025 | 15.3% |
+| `teardown` | ~0 | 0.0% |
+
+So the cost is in test BODIES, not in fixture construction. Two hypotheses that look
+obvious and are wrong:
+
+- *"Consolidate the files that share a config so a module fixture builds the System
+  once."* The 13 kelt4 files, 8 KMT, 7 DC2018_128 and 5 ob161003 do each build their
+  own -- but all `setup` everywhere totals 15%, so this bounds the whole prize at well
+  under that, and it costs parallelism to collect it.
+- *"The `--dist loadfile` tail serializes the run."* The slowest single file is
+  `test_rm_ltt.py` at 338 s against an ideal `-n 6` wall of 1119 s, and **no file
+  exceeds the ideal wall**. The distribution is not the constraint, and adding workers
+  still scales nearly linearly -- which is the change CI got.
+
+It is a long tail rather than a few hot spots: the top 30 of 202 files are 67% of the
+total, the worst single file is 5.0%. The heaviest individual tests, for anyone looking
+for something to cut:
+
+| seconds | test |
+|---|---|
+| 231.6 | `test_runner.py::test_run_without_flag_writes_no_status` |
+| 175.7 | `test_robust_likelihood.py::test_outlier_prob_at_data_flags_a_planted_outlier` |
+| 171.3 | `test_rm_ltt.py::test_wired_rm_ltt_delay_matches_a_over_c_through_real_accessors` |
+| 167.1 | `test_rm_ltt.py::test_rm_ltt_off_reproduces_pre_ltt_output` |
+| 144.9 | `test_rossiter.py::test_rm_two_instrument_logp_and_gradient_finite_on_both_backends` |
+| 139.6 | `test_mkparam_in_memory.py` (fixture setup) |
+
+Most of that is `build_model()` plus compiling logp/dlogp inside the test body, and the
+`both_backends` cases pay it twice. Compilation is not what a WARM run spends its time
+on, though: the same run added only 15-45 new compiledir entries per worker (~150 total)
+against the 1564 a cold run creates, so the 7:36 -> 15:47 regression since July is added
+work, not a degraded cache.
 
 Two claims that used to live in `CLAUDE.md` are wrong and are recorded here only so nobody
 reintroduces them:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,8 +345,11 @@ norecursedirs = ["exozippy", "src"]
 # same worker so module/session-scoped fixtures (many System builds) are shared,
 # not rebuilt per worker. -n is capped at 6 (not "auto") because each worker
 # peaks ~1-2 GB building a System and compiling graphs; 36 workers would OOM.
-# CI overrides this to -n 2 (see .github/workflows/tests.yml) because a GitHub
-# runner cannot afford six. Override for single-test debugging with `-n0`, e.g.
+# CI overrides this with a count computed from the runner's cores and memory
+# (scripts/pytest_workers.py, called from .github/workflows/tests.yml) rather
+# than a number written down here: a GitHub runner cannot afford six, but the
+# `-n 2` that used to be hardcoded there stayed put while the runners grew.
+# Override for single-test debugging with `-n0`, e.g.
 #   poetry run pytest tests/test_foo.py::test_bar -n0 -x
 addopts = "-n 6 --dist loadfile"
 markers = [

--- a/scripts/pytensor_cache_budget.py
+++ b/scripts/pytensor_cache_budget.py
@@ -74,6 +74,28 @@ _MODULE_SUFFIXES = (".so", ".pyd")
 # compile lock out from under a concurrent process.
 _LOCK_DIR = "lock_dir"
 
+# The root conftest gives every xdist worker its OWN base_compiledir, one
+# level down, named after PYTEST_XDIST_WORKER ("gw0", "gw1", ...). So the
+# tree under the suite's base_compiledir is
+#
+#     ~/.pytensor-pytest/compiledir_<platform>/     <- -n0 runs only
+#     ~/.pytensor-pytest/gw0/compiledir_<platform>/ <- worker 0
+#     ~/.pytensor-pytest/gw1/compiledir_<platform>/ <- worker 1
+#     ...
+#
+# and the ONLY one pytensor.config resolves in the controller is the first.
+# That is why the budget has to be walked explicitly over the rest: pruning
+# what pytensor.config points at bounds the directory no worker ever reads
+# and leaves the six that they do read completely unbounded. Measured on
+# this box before the fix: controller 2280 entries (budget 3000, so never
+# pruned), gw0-gw5 1455-1562 entries EACH, none of them ever considered.
+# In CI the same omission made every saved cache artifact bigger than the
+# last -- ubuntu 3.14 went 374 -> 494 -> 606 -> 661 -> 781 MB over five
+# consecutive master merges -- until the repository-wide 10 GB cache budget
+# went into eviction, which is exactly what the Zenodo-spectra and
+# ephemeris caches cannot afford to lose.
+_WORKER_DIR_GLOB = "gw*"
+
 
 @dataclass
 class PruneStats:
@@ -259,6 +281,124 @@ def enforce_budget(
     return stats
 
 
+def worker_compiledirs(
+    base_compiledir: Path, compiledir: Path
+) -> list[tuple[Path, Path]]:
+    """``(base, compiledir)`` for every per-xdist-worker tree under base.
+
+    ``compiledir`` supplies the platform directory NAME to look for, which
+    is what makes this correct rather than a guess: PyTensor derives that
+    name from the platform, the processor, the Python version and the bit
+    width, and every worker on this machine resolves the same one, because
+    the conftest changes only the base. So the worker's live tree is
+    ``base/gwN/<same name>`` and anything else named ``compiledir_*`` beside
+    it is stranded by a kernel or Python bump, exactly as at the top level.
+
+    Sorted, and worker directories that hold no compiledir at all are still
+    returned: prune_compiledir on a missing directory is a cheap no-op, and
+    reporting the pair keeps the summary honest about what was considered.
+    """
+    if not base_compiledir.is_dir():
+        return []
+    pairs = []
+    for entry in sorted(base_compiledir.glob(_WORKER_DIR_GLOB)):
+        if not entry.is_dir():
+            continue
+        pairs.append((entry, entry / compiledir.name))
+    return pairs
+
+
+def enforce_budget_tree(
+    base_compiledir: Path,
+    compiledir: Path,
+    max_entries: int,
+    sweep_platforms: bool = False,
+    dry_run: bool = False,
+) -> list[tuple[Path, PruneStats]]:
+    """Bound the controller's compiledir AND every per-worker one.
+
+    ``max_entries`` is PER COMPILEDIR, not a total across the tree, because
+    the cost it exists to bound is per compiledir: each worker process
+    builds its own ModuleCache and walks only its own directory, so what
+    determines that walk's length is one directory's entry count. The price
+    of that denominator is disk -- a budget of N with W workers holds up to
+    (W + 1) x N entries -- which is why the default is sized against ONE
+    run's per-worker working set rather than against several.
+
+    Returns one (compiledir, stats) pair per directory considered, the
+    controller's first.
+    """
+    results = [
+        (
+            compiledir,
+            enforce_budget(
+                base_compiledir,
+                compiledir,
+                max_entries,
+                sweep_platforms=sweep_platforms,
+                dry_run=dry_run,
+            ),
+        )
+    ]
+    for worker_base, worker_compiledir in worker_compiledirs(
+        base_compiledir, compiledir
+    ):
+        results.append(
+            (
+                worker_compiledir,
+                enforce_budget(
+                    worker_base,
+                    worker_compiledir,
+                    max_entries,
+                    sweep_platforms=sweep_platforms,
+                    dry_run=dry_run,
+                ),
+            )
+        )
+    return results
+
+
+def summarize_tree(
+    results: list[tuple[Path, PruneStats]], max_entries: int
+) -> str:
+    """One line for the pytest header, however many compiledirs there were.
+
+    The per-directory detail is dropped once everything is within budget --
+    seven identical "not scanned" lines in a test header is noise. What is
+    worth a line every run is the total, because that is the number that
+    grew unnoticed for weeks.
+
+    "at most" when any directory was within budget, and that hedge is not
+    padding: the cheap pre-check proves a directory is under budget from one
+    listdir, whose name count includes lock_dir and any stray file, so it
+    bounds the entry count from above rather than measuring it. PruneStats
+    already refuses to claim otherwise per directory; the total must not
+    launder those bounds into a figure that looks counted.
+    """
+    if not results:
+        return ""
+    touched = [(d, st) for d, st in results if st.removed]
+    total = sum(st.kept for _, st in results)
+    bound = "at most " if any(st.skipped for _, st in results) else ""
+    head = (
+        f"pytensor compiledirs: {len(results)} pruned to <= {max_entries} "
+        f"entries each, {bound}{total} entries held in total"
+    )
+    if not touched:
+        return head
+    detail = "; ".join(
+        f"{d.parent.name}/{d.name}: removed {st.removed}" for d, st in touched
+    )
+    platforms = sorted(
+        name for _, st in results for name in st.removed_platform_dirs
+    )
+    if platforms:
+        detail += "; stale sibling compiledirs removed: " + ", ".join(
+            platforms
+        )
+    return head + " (" + detail + ")"
+
+
 def _resolve_compiledir(args: argparse.Namespace) -> tuple[Path, Path]:
     """Ask PyTensor where its compiledir is, unless told explicitly.
 
@@ -308,6 +448,18 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--include-worker-dirs",
+        action="store_true",
+        help=(
+            "also prune the per-xdist-worker compiledirs (gw*/) that the "
+            "test suite's conftest creates one level below the base. "
+            "pytensor.config resolves only the controller's, which under "
+            "-n is the one directory no worker ever reads -- so without "
+            "this the budget bounds nothing that matters. --max-entries is "
+            "per compiledir, not a total."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="report what would be removed, remove nothing",
@@ -315,6 +467,19 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     base, compiledir = _resolve_compiledir(args)
+    prefix = "[dry run] " if args.dry_run else ""
+    if args.include_worker_dirs:
+        results = enforce_budget_tree(
+            base,
+            compiledir,
+            args.max_entries,
+            sweep_platforms=args.sweep_other_platforms,
+            dry_run=args.dry_run,
+        )
+        print(prefix + summarize_tree(results, args.max_entries))
+        for directory, stats in results:
+            print(prefix + "  " + stats.summary(directory, args.max_entries))
+        return 0
     stats = enforce_budget(
         base,
         compiledir,
@@ -322,7 +487,6 @@ def main(argv: list[str] | None = None) -> int:
         sweep_platforms=args.sweep_other_platforms,
         dry_run=args.dry_run,
     )
-    prefix = "[dry run] " if args.dry_run else ""
     print(prefix + stats.summary(compiledir, args.max_entries))
     return 0
 

--- a/scripts/pytest_workers.py
+++ b/scripts/pytest_workers.py
@@ -1,0 +1,146 @@
+"""Choose how many xdist workers this machine can actually afford.
+
+Why this is computed rather than written down
+---------------------------------------------
+``pyproject.toml`` pins ``-n 6`` for a workstation and CI used to override it
+with a hardcoded ``-n 2``. That 2 was chosen when a GitHub-hosted Linux
+runner had two cores, and it was never revisited: the runners have grown
+since, so the number bought headroom nobody needed while the suite's wall
+clock tripled. Measured on 2026-08-24, the four matrix jobs did the SAME
+amount of work per worker as this 36-core workstation does -- ubuntu 3.12
+spent 5202 worker-seconds against the workstation's 5682 -- so at that point
+CI's whole 43-minute gap over a local 15:47 was worker COUNT, with the
+compile cache warm on both.
+
+The wrong fix is a new hardcoded number, because the reason the old one went
+stale is that it was hardcoded. Both inputs are cheap to read at startup, so
+this reads them.
+
+The rule
+--------
+``min(cpu_count, memory_gb // _GB_PER_WORKER)``, floored at 1.
+
+The memory term is the binding one and it is not conservatism. Each worker
+peaks at roughly 1-2 GB while building a System and compiling PyTensor
+graphs, and the failure when that is exceeded is not an assertion but
+``worker 'gwN' crashed``, landing on whichever heavy test drew the short
+straw -- it moved between test_integration_kelt4, test_gp and
+test_sed_plot_data across runs and vanished on others. A memory ceiling
+presents as a flaky, wandering test failure, so the headroom is worth more
+than the last worker.
+
+``_GB_PER_WORKER = 3`` is that 1-2 GB peak plus room for the interpreter,
+the restored compile cache's page cache, and the fact that the peak is a
+measured typical rather than a bound.
+
+Deliberately NOT used to pick the local default. A developer's box is shared
+with editors, browsers and hours-long interactive fits, and this cannot see
+any of that; ``addopts`` keeps its explicit ``-n 6``, and this script exists
+for the one caller that has a machine to itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# See the module docstring: measured per-worker peak is 1-2 GB, and the
+# failure mode for getting this wrong is a wandering "worker crashed".
+_GB_PER_WORKER = 3
+
+
+def cpu_count() -> int:
+    """Cores this process may actually use, not cores the machine has.
+
+    ``os.process_cpu_count()`` honours the CPU affinity mask, which is what a
+    container-scheduled CI runner sets; ``os.cpu_count()`` reports the host's
+    total and would over-subscribe. The fallback is for pre-3.13.
+    """
+    getter = getattr(os, "process_cpu_count", None)
+    if getter is not None:
+        return getter() or 1
+    return os.cpu_count() or 1
+
+
+def memory_gb() -> float | None:
+    """Total physical memory in GB, or None if it cannot be determined.
+
+    Two probes because the two platforms this runs on report it differently
+    and neither has a portable answer in the standard library. Returning None
+    rather than a guess is deliberate: the caller then falls back to the CPU
+    term alone, which is the behaviour we had before this existed, instead of
+    silently choosing a worker count from a fabricated memory figure.
+    """
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+    except (ValueError, OSError, AttributeError):
+        pass
+    else:
+        if pages > 0 and page_size > 0:
+            return pages * page_size / 1024**3
+
+    # macOS reports SC_PHYS_PAGES on recent versions, but has not always, and
+    # sysctl is the documented interface there.
+    if sys.platform == "darwin":
+        try:
+            import subprocess  # noqa: PLC0415 -- only needed on this path
+
+            out = subprocess.run(
+                ["sysctl", "-n", "hw.memsize"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
+            )
+            return int(out.stdout.strip()) / 1024**3
+        except Exception:
+            return None
+    return None
+
+
+def choose_workers(
+    cpus: int, mem_gb: float | None, gb_per_worker: int = _GB_PER_WORKER
+) -> int:
+    """The rule from the module docstring, floored at 1."""
+    if mem_gb is None:
+        return max(1, cpus)
+    by_memory = int(mem_gb // gb_per_worker)
+    return max(1, min(cpus, by_memory))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Print the number of pytest-xdist workers this machine can "
+            "afford, from its core count and its physical memory."
+        )
+    )
+    parser.add_argument(
+        "--explain",
+        action="store_true",
+        help=(
+            "also print the inputs on stderr. CI uses this so the chosen "
+            "number is recorded in the log rather than inferred later from "
+            "a runner-spec guess."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    cpus = cpu_count()
+    mem = memory_gb()
+    workers = choose_workers(cpus, mem)
+    if args.explain:
+        shown = "unknown" if mem is None else f"{mem:.1f} GB"
+        print(
+            f"pytest workers: {workers} "
+            f"(cpus={cpus}, memory={shown}, {_GB_PER_WORKER} GB/worker)",
+            file=sys.stderr,
+        )
+    print(workers)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pytensor_cache_budget.py
+++ b/tests/test_pytensor_cache_budget.py
@@ -213,3 +213,165 @@ def test_enforce_budget_combines_the_prune_and_the_sweep(tmp_path):
     assert stats.removed_platform_dirs == ["compiledir_stale"]
     assert not (tmp_path / "compiledir_stale").exists()
     assert [p.name for p in live.iterdir()] == ["entry0"]
+
+
+def _worker_tree(base, worker, platform, entries, extra_platform=None):
+    """One gwN/compiledir_<platform>/ tree with `entries` entries in it."""
+    compiledir = base / worker / platform
+    compiledir.mkdir(parents=True)
+    for i in range(entries):
+        _make_entry(compiledir, f"entry{i}", age_seconds=i)
+    if extra_platform is not None:
+        (base / worker / extra_platform).mkdir()
+    return compiledir
+
+
+def test_worker_compiledirs_finds_each_workers_own_platform_tree(tmp_path):
+    """Given the per-worker layout the root conftest creates,
+    When the worker compiledirs are enumerated,
+    Then each gwN contributes its tree named for the LIVE platform."""
+    # Arrange -- every worker on one machine resolves the same platform
+    # directory name, because the conftest changes only the base.
+    platform = "compiledir_Linux-6.1-x86_64-3.12.13-64"
+    controller = tmp_path / platform
+    controller.mkdir()
+    for worker in ("gw0", "gw1", "gw2"):
+        (tmp_path / worker / platform).mkdir(parents=True)
+    # Not a worker directory, and PyTensor keeps other caches beside these.
+    (tmp_path / "numba").mkdir()
+
+    # Act
+    pairs = budget.worker_compiledirs(tmp_path, controller)
+
+    # Assert
+    assert [base.name for base, _ in pairs] == ["gw0", "gw1", "gw2"]
+    assert [d.name for _, d in pairs] == [platform] * 3
+
+
+def test_the_budget_reaches_the_per_worker_compiledirs(tmp_path):
+    """Given per-worker compiledirs over budget and an empty controller one,
+    When the whole tree is bounded,
+    Then every worker's directory is trimmed, not just what pytensor resolves.
+
+    This is the regression. The prune used to run on
+    pytensor.config.compiledir alone, which in the controller process is the
+    top-level tree -- the one directory no worker ever writes to. It was
+    within budget by virtue of being nearly empty, the pass reported success
+    having removed nothing, and the directories holding the entire cache were
+    never looked at. In CI that made every saved cache artifact bigger than
+    the last until the repository's 10 GB budget went into eviction."""
+    # Arrange
+    platform = "compiledir_Linux-6.1-x86_64-3.12.13-64"
+    controller = tmp_path / platform
+    controller.mkdir()
+    workers = [
+        _worker_tree(tmp_path, name, platform, entries=5)
+        for name in ("gw0", "gw1")
+    ]
+
+    # Act
+    results = budget.enforce_budget_tree(tmp_path, controller, max_entries=2)
+
+    # Assert -- the controller's tree first, then one per worker.
+    assert [d for d, _ in results] == [controller, *workers]
+    for worker_dir in workers:
+        assert sorted(p.name for p in worker_dir.iterdir()) == [
+            "entry0",
+            "entry1",
+        ]
+
+
+def test_the_budget_is_per_compiledir_not_a_total_across_the_tree(tmp_path):
+    """Given two workers each holding exactly the budget,
+    When the tree is bounded,
+    Then nothing is evicted.
+
+    The denominator is deliberate: each worker process builds its own
+    ModuleCache and walks only its own directory, so one directory's entry
+    count is what the startup walk is linear in. A total across the tree
+    would evict entries a worker still needs on the very run that made them."""
+    # Arrange
+    platform = "compiledir_fake-3.12-64"
+    controller = tmp_path / platform
+    controller.mkdir()
+    for name in ("gw0", "gw1"):
+        _worker_tree(tmp_path, name, platform, entries=3)
+
+    # Act
+    results = budget.enforce_budget_tree(tmp_path, controller, max_entries=3)
+
+    # Assert
+    assert all(stats.removed == 0 for _, stats in results)
+    for name in ("gw0", "gw1"):
+        assert len(list((tmp_path / name / platform).iterdir())) == 3
+
+
+def test_a_worker_tree_stranded_by_a_platform_bump_is_swept_too(tmp_path):
+    """Given a worker directory carrying a compiledir from an older kernel,
+    When the tree is swept,
+    Then that stranded sibling goes, the same as at the top level.
+
+    Nothing reads a stranded tree and nothing else would ever delete it, so
+    inside a worker directory it rides along in the CI cache forever -- the
+    footgun the restore step's comment describes, one level down."""
+    # Arrange
+    platform = "compiledir_Linux-6.1-x86_64-3.12.13-64"
+    stale = "compiledir_Linux-4.18-x86_64-3.12.13-64"
+    controller = tmp_path / platform
+    controller.mkdir()
+    _worker_tree(tmp_path, "gw0", platform, entries=1, extra_platform=stale)
+
+    # Act
+    results = budget.enforce_budget_tree(
+        tmp_path, controller, max_entries=10, sweep_platforms=True
+    )
+
+    # Assert
+    assert not (tmp_path / "gw0" / stale).exists()
+    assert (tmp_path / "gw0" / platform).is_dir()
+    swept = [n for _, st in results for n in st.removed_platform_dirs]
+    assert swept == [stale]
+
+
+def test_dry_run_reaches_the_worker_dirs_without_deleting_from_them(tmp_path):
+    """Given per-worker compiledirs over budget,
+    When the tree is bounded with dry_run,
+    Then the excess is reported and every entry survives."""
+    # Arrange
+    platform = "compiledir_fake-3.12-64"
+    controller = tmp_path / platform
+    controller.mkdir()
+    worker = _worker_tree(tmp_path, "gw0", platform, entries=4)
+
+    # Act
+    results = budget.enforce_budget_tree(
+        tmp_path, controller, max_entries=1, dry_run=True
+    )
+
+    # Assert
+    assert dict(results)[worker].removed_lru == 3
+    assert len(list(worker.iterdir())) == 4
+
+
+def test_the_tree_summary_reports_the_total_that_grew_unnoticed(tmp_path):
+    """Given a bounded tree,
+    When it is summarized for the pytest header,
+    Then the line carries the number of compiledirs and the total held.
+
+    The total is the point. Seven per-directory lines saying "within budget"
+    is noise nobody reads; one number that would have visibly climbed is the
+    thing whose absence let this go unnoticed for weeks."""
+    # Arrange
+    platform = "compiledir_fake-3.12-64"
+    controller = tmp_path / platform
+    controller.mkdir()
+    for name in ("gw0", "gw1"):
+        _worker_tree(tmp_path, name, platform, entries=2)
+
+    # Act
+    results = budget.enforce_budget_tree(tmp_path, controller, max_entries=5)
+    line = budget.summarize_tree(results, 5)
+
+    # Assert
+    assert "3 pruned" in line
+    assert "at most 4 entries held in total" in line

--- a/tests/test_pytest_workers.py
+++ b/tests/test_pytest_workers.py
@@ -1,0 +1,102 @@
+"""Tests for the CI worker-count rule (scripts/pytest_workers.py).
+
+The rule replaced a hardcoded `-n 2` in the CI workflow, and it exists
+because that 2 went stale unnoticed: it was right when a hosted Linux runner
+had two cores and wrong for years afterwards. So what is worth pinning here
+is not the arithmetic but the two properties that keep it from going stale in
+the other direction -- it never exceeds what the memory allows, and it never
+returns zero.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# By path, for the same reason tests/test_pytensor_cache_budget.py loads its
+# subject by path: scripts/ is not a package, and putting it on sys.path would
+# make getdata.py / mkparam.py importable as top-level modules.
+_NAME = "_pytest_workers"
+if _NAME in sys.modules:
+    workers = sys.modules[_NAME]
+else:
+    _SPEC = importlib.util.spec_from_file_location(
+        _NAME,
+        Path(__file__).resolve().parents[1] / "scripts" / "pytest_workers.py",
+    )
+    workers = importlib.util.module_from_spec(_SPEC)
+    sys.modules[_NAME] = workers
+    _SPEC.loader.exec_module(workers)
+
+
+def test_memory_binds_before_cores_do():
+    """Given more cores than the memory can feed workers for,
+    When the worker count is chosen,
+    Then memory decides it.
+
+    This is the case the number exists for. Overshooting it does not fail an
+    assertion, it produces "worker 'gwN' crashed" on whichever heavy test drew
+    the short straw -- a memory ceiling that presents as a wandering flaky
+    failure rather than as an out-of-memory error."""
+    # Arrange -- a 3-core / 7 GB runner, i.e. the macOS shape.
+    # Act
+    chosen = workers.choose_workers(cpus=3, mem_gb=7.0, gb_per_worker=3)
+
+    # Assert -- 7 // 3 = 2, not the 3 the cores would allow.
+    assert chosen == 2
+
+
+def test_cores_bind_when_memory_is_plentiful():
+    """Given more memory than the cores can use,
+    When the worker count is chosen,
+    Then it never exceeds the core count."""
+    # Arrange / Act -- a 4-core / 16 GB runner, i.e. the Linux shape.
+    chosen = workers.choose_workers(cpus=4, mem_gb=16.0, gb_per_worker=3)
+
+    # Assert -- 16 // 3 = 5, capped at the 4 cores.
+    assert chosen == 4
+
+
+def test_unknown_memory_falls_back_to_the_core_count():
+    """Given a platform whose memory cannot be read,
+    When the worker count is chosen,
+    Then the core count decides it.
+
+    Falling back rather than guessing a size: memory_gb() returns None instead
+    of a fabricated figure, and the resulting behaviour is the CPU-only rule
+    we had before the memory term existed."""
+    # Arrange / Act
+    chosen = workers.choose_workers(cpus=8, mem_gb=None, gb_per_worker=3)
+
+    # Assert
+    assert chosen == 8
+
+
+def test_a_tiny_machine_still_gets_one_worker():
+    """Given less memory than one worker's share,
+    When the worker count is chosen,
+    Then it is 1, never 0.
+
+    `pytest -n 0` is not "one worker", it is xdist disabled -- a different
+    execution mode with different fixture sharing. Returning 0 here would
+    silently change what CI runs."""
+    # Arrange / Act
+    chosen = workers.choose_workers(cpus=2, mem_gb=1.0, gb_per_worker=3)
+
+    # Assert
+    assert chosen == 1
+
+
+def test_this_machine_gets_a_usable_count():
+    """Given the machine actually running the suite,
+    When the probes are read for real,
+    Then they yield at least one worker.
+
+    An end-to-end check on the two probes, because both are platform
+    conditionals: a sysconf key that is absent, or an os attribute that moved,
+    would otherwise only show up as a CI job silently running single-file."""
+    # Arrange / Act
+    chosen = workers.choose_workers(workers.cpu_count(), workers.memory_gb())
+
+    # Assert
+    assert chosen >= 1
+    assert workers.cpu_count() >= 1


### PR DESCRIPTION
Review item 6.13.1, which asked for measurement before any decision about what
to cut. The measurement said the suite's content is not where the cheap wins
are, and turned up a separate live bug on the way, so this is the two
configuration fixes plus the numbers written down.

## What the measurement says

Master push 32712612695, `Run test suite` step only (install/checkout/cache
steps total ~60 s, so this is all pytest). Worker-seconds is the column that
matters:

| job | -n | wall | worker-seconds |
|---|---|---|---|
| ubuntu 3.12 | 2 | 43m21s | 5202 |
| ubuntu 3.13 | 2 | 36m39s | 4398 |
| ubuntu 3.14 | 2 | 37m57s | 4554 |
| macos 3.12 | 2 | 25m06s | 3012 |
| workstation | 6 | 15m47s | 5682 |

ubuntu 3.12 did essentially the same work **per worker** as a 36-core
workstation -- 5202 against 5682 -- and the compiledir restore reported a
578 MB hit, so both sides were warm. **CI's whole gap over local was worker
count.** macOS's 3012 is the same suite on faster cores, which is why it was
the quickest job at the same `-n`.

And one `--durations=0` run locally (3105 passed, 6715 worker-seconds):

| phase | worker-seconds | share |
|---|---|---|
| `call` (test bodies) | 5690 | **84.7%** |
| `setup` (fixtures, i.e. shared `System` builds) | 1025 | 15.3% |
| `teardown` | ~0 | 0.0% |

That rules out the two things one reaches for first:

- **Consolidating files that share a config** so a module fixture builds the
  `System` once. 13 files use kelt4, 8 KMT, 7 DC2018_128, 5 ob161003, and each
  does build its own -- but all `setup` everywhere is 15%, so this bounds the
  whole prize well under that, and it costs parallelism to collect.
- **The `--dist loadfile` tail.** The slowest file is `test_rm_ltt.py` at 338 s
  against an ideal `-n 6` wall of 1119 s, and *no* file exceeds the ideal wall.
  The distribution is not the constraint -- which is exactly why adding workers
  scales.

It is a long tail: top 30 of 202 files are 67%, worst single file 5.0%.
Compilation is not the warm-run cost either -- the run added ~150 new
compiledir entries against the 1564 a cold run creates -- so the 7:36 -> 15:47
regression since July is added work, not a degraded cache.

## The commits

**1. `testing: the compiledir budget reaches the per-worker caches`**

The conftest gives every xdist worker its own `base_compiledir` so workers
never queue on PyTensor's single compile lock, but the prune ran on
`pytensor.config.compiledir` -- which in the *controller* is
`base/compiledir_<platform>`, the one directory no worker ever writes to. So
the budget bounded nothing:

- locally, the controller sat at 2280 entries against a budget of 3000 and was
  never touched, while `gw0`-`gw5` held **1455-1562 each, unbounded**. 11220
  entries in a tree whose policy claimed 3000.
- in CI the prune step ran against an empty controller dir, reported success
  having removed nothing, and every merge saved the previous artifact plus that
  run's entries: ubuntu 3.14 went **374 -> 494 -> 606 -> 661 -> 781 MB** over
  five consecutive master runs.
- compounding it, the restore key embeds `github.run_id` (necessary -- a cache
  key is immutable once written) but nothing retired the entry it superseded,
  even though only the newest is ever restored: **5 generations per os+python,
  18 entries, 8.05 GB.**
- total repository cache usage was **10.43 GB against GitHub's 10 GB budget**,
  i.e. eviction was already live, with the 132 MB Zenodo spectra and 115 MB
  ephemeris kernel the smallest entries in there. That is the exact failure the
  restore step's own comment was written to prevent, reached from a direction it
  did not consider: it guarded against PR runs churning the cache, and the churn
  came from master.

`enforce_budget_tree` + `--include-worker-dirs` walk every compiledir. The
budget is now **per compiledir**, because that is the denominator the cost has
(each worker builds its own `ModuleCache` and walks only its own directory);
the default comes down 3000 -> 2000 to pay for the `(W + 1) x` multiplier, and
cannot go below ~1600 since a worker's own directory holds nearly the whole
1564-entry working set. A `Drop superseded compile caches` step retires older
generations for the job's own os+python, `continue-on-error` because cache
bookkeeping must never decide a suite's verdict.

**2. `CI: size the worker count to the runner, rather than pinning it at 2`**

`-n 2` was right when a hosted Linux runner had two cores; the runners grew,
the suite tripled, and the 2 stayed. Replacing one hardcoded number with
another restarts that clock, so `scripts/pytest_workers.py` reads both inputs:
`min(cores, memory_gb // 3)`, floored at 1. Memory is the binding term and that
is not conservatism -- overshooting produces `worker 'gwN' crashed` on whichever
heavy test drew the short straw, which is how a memory ceiling presents as a
wandering flaky failure. `--explain` logs the cores and memory it saw, so a
runner's real shape becomes recorded rather than inferred from a docs page.

Local `addopts` deliberately keeps its explicit `-n 6`: a developer's box is
shared with editors and hours-long fits, and the script cannot see any of that.

**3. `docs: record where the suite's time actually goes ...`**

The tables above, into `docs/testing.md` (whose headline still said "~8 minutes
warm, 2473 tests"), plus retiring `-n 2` as "CI's number" from the six places
that quoted it. `testing-cache.md` gains the per-worker compiledir as policy
point 4 -- the conftest has done that for a while and the runbook never said
so, which is also why its lock-queue note was stale twice over: there is no
shared compile lock left to queue on.

## Verification

- Full suite green against this tree: **3115 passed, 6 skipped, 0 failed**
  (21:57, on a box concurrently running an unrelated 27-core fit).
- The new prune verified live: during that run the controller's compiledir went
  2280 -> exactly 2000 and the six worker dirs were correctly left alone at
  ~1545, under budget.
- 11 new tests: 6 pinning the tree prune (including the regression itself --
  that per-worker dirs are reached, and that the budget is per directory rather
  than a total) and 5 on the worker-count rule.
- The retention logic dry-run against the live repo: keeps the newest key, would
  drop the 4 stale generations per combo (~5.8 GB), and does not fail under
  `set -e` on an empty result.
- Every workflow `run` block syntax-checked with `bash -n`.

## What this does not cover

- **The master-only steps are not exercised by a PR run.** `Prune before save`,
  `Save`, and `Drop superseded compile caches` are all gated on
  `push` + `refs/heads/master`, so the first real exercise is the merge commit.
  Hence the dry-runs above, and `continue-on-error` on the one that talks to the
  API.
- **The suite's own 5200-5700 worker-seconds is untouched**, and that is the
  remaining lever. The data above is meant to aim it: the heaviest single tests
  are `test_runner.py::test_run_without_flag_writes_no_status` (231.6 s),
  `test_robust_likelihood.py::test_outlier_prob_at_data_flags_a_planted_outlier`
  (175.7 s), the two `test_rm_ltt` cases (171.3 / 167.1 s) and
  `test_rossiter.py::test_rm_two_instrument_logp_and_gradient_finite_on_both_backends`
  (144.9 s, which pays the compile twice by design). That needs a decision about
  what to cut, not a configuration change.
- **Local wall-clock numbers are contended** -- an unrelated fit held 27 of 36
  cores throughout, so absolute local times are inflated (the clean reference is
  15:47). The rankings and the worker-second ratios, which is what the
  conclusions rest on, are not reordered by uniform CPU contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
