### PR TITLE
CI runtime (6.13.1): two shards, and one canonical compiledir instead of one per worker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,11 +83,30 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.12", "3.13", "3.14"]
+        # THE SUITE IS SPLIT ACROSS SHARDS, and this is the lever that
+        # actually reaches the wall-clock target. Worker count is capped by
+        # the runner: measured, ubuntu-latest reports cpus=4/memory=15.6 GB
+        # and macos-latest cpus=3/memory=7.0 GB, so a single job can use at
+        # most 4 and 2 workers respectively. The suite's ~6700 worker-seconds
+        # divided by 4 is still ~22 minutes, so more machines is the only way
+        # further down.
+        #
+        # 2, not more. scripts/pytest_shard.py round-robins the sorted file
+        # list, which measures within 1.04x of a perfectly balanced split at
+        # N=2 against real per-file durations -- and degrades to 1.37x at N=3
+        # and 1.33x at N=4, because the long tail stops averaging out. Going
+        # past 2 means re-measuring, not just editing this list.
+        shard: [1, 2]
         include:
           # CONTRIBUTING documents a macOS setup, and macOS is as fast as Linux
-          # here, so it stays on the pull-request path.
+          # here, so it stays on the pull-request path. Both shards, so the
+          # platform is covered rather than half-covered.
           - os: macos-latest
             python-version: "3.12"
+            shard: 1
+          - os: macos-latest
+            python-version: "3.12"
+            shard: 2
 
     steps:
       - uses: actions/checkout@v7
@@ -257,13 +276,19 @@ jobs:
       # per-worker working set of ~1600 entries is dead weight that only
       # inflates the artifact this job saves. A budget BELOW that working set
       # would evict entries this very run still needs.
+      # --verify is cheap and load-bearing: it asserts the shards partition
+      # the file list exactly. A split that silently DROPS a file leaves every
+      # shard green with the coverage gone, which is the worst way for this to
+      # fail, so the check runs on every job rather than living in a test only.
       - name: Run test suite
         env:
           EXOZIPPY_TEST_COMPILEDIR_MAX_ENTRIES: "1800"
         run: |
           set -euo pipefail
           workers=$(poetry run python scripts/pytest_workers.py --explain)
-          poetry run pytest -q -n "$workers"
+          files=$(poetry run python scripts/pytest_shard.py \
+            --shard ${{ matrix.shard }} --of 2 --verify)
+          poetry run pytest -q -n "$workers" $files
 
       # The conftest prunes at session START, so at this point the directories
       # hold the budget plus everything this run compiled. Trim again so the
@@ -283,16 +308,67 @@ jobs:
       # evicting least-recently-accessed, which is the scenario the restore
       # step's comment describes as trading a 5-minute cache for a 250 MB
       # download.
+      # SHARD 1 ONLY, and the reason is the same property that makes seeding
+      # work: the per-worker compiledirs are ~95% redundant, because most of
+      # what compiles is shared infrastructure every file's model builds
+      # rather than anything specific to a file. So shard 1's tree already
+      # serves shard 2 almost completely, and storing shard 2's as well would
+      # double the cache to buy the last few percent. Shard 2 recompiles that
+      # remainder each run, which is a small bounded cost against a cache
+      # budget that is not.
       - name: Prune the compile cache before saving it
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: >-
+          github.event_name == 'push' && github.ref == 'refs/heads/master'
+          && matrix.shard == 1
         run: |
+          set -euo pipefail
           export PYTENSOR_FLAGS="base_compiledir=$HOME/.pytensor-pytest"
           poetry run python scripts/pytensor_cache_budget.py \
             --max-entries 1800 --sweep-other-platforms --include-worker-dirs
 
+          # SAVE ONE CANONICAL TREE, NOT ONE PER WORKER. The worker
+          # compiledirs are ~95% redundant -- each holds ~1500 of the 1564
+          # entries a whole cold run creates, because most of what compiles is
+          # shared infrastructure every file's model builds. Storing all of
+          # them multiplied the artifact by the worker count, which is what
+          # made the cache unable to absorb more parallelism: 4 workers x 2
+          # shards would have wanted ~12 GB against GitHub's 10 GB
+          # repository-wide budget.
+          #
+          # The next run reconstitutes the others: the root conftest seeds
+          # every missing worker compiledir from the warmest one it finds,
+          # hard-linking the write-once files (.so and .cpp, 98.7% of the
+          # bytes) and copying only key.pkl, which is the single file PyTensor
+          # rewrites in place. Measured on 398 entries: 5.3 s and 7.1 MB of
+          # real disk, against 53.6 s and 218 MB for a full copy.
+          #
+          # gw0 rather than "the warmest": they are within a few percent of
+          # each other, and choose_seed_source() picks the warmest at restore
+          # time anyway, so there is nothing to gain from being clever here.
+          #
+          # The CONTROLLER's compiledir goes too, and it is not a rounding
+          # error. Under -n it is the one directory no worker ever writes to,
+          # so everything in it is stale -- yet it was being saved on every
+          # run: measured on the first master run after the prune fix, the
+          # macOS tree was 5055 entries as controller 1800 + gw0 1578 +
+          # gw1 1677. Dropping it as well as gw1 makes the artifact ~3.2x
+          # smaller rather than ~2x. PyTensor recreates the directory on
+          # import, and the conftest seeds the workers from gw0.
+          before=$(du -sm "$HOME/.pytensor-pytest" | cut -f1)
+          find "$HOME/.pytensor-pytest" -mindepth 1 -maxdepth 1 \
+            -name 'gw*' ! -name 'gw0' -exec rm -rf {} +
+          find "$HOME/.pytensor-pytest" -mindepth 1 -maxdepth 1 \
+            -name 'compiledir_*' -exec rm -rf {} +
+          after=$(du -sm "$HOME/.pytensor-pytest" | cut -f1)
+          echo "compiledir tree trimmed to one canonical worker copy:" \
+            "${before} MB -> ${after} MB"
+          ls -1 "$HOME/.pytensor-pytest"
+
       # See the long comment on the restore step for why this is master-only.
       - name: Save the PyTensor compile cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: >-
+          github.event_name == 'push' && github.ref == 'refs/heads/master'
+          && matrix.shard == 1
         uses: actions/cache/save@v6
         with:
           path: ~/.pytensor-pytest
@@ -324,7 +400,9 @@ jobs:
       # below: cache housekeeping must never decide a suite's verdict. A
       # transient API error here would otherwise turn a green run red.
       - name: Drop superseded compile caches
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: >-
+          github.event_name == 'push' && github.ref == 'refs/heads/master'
+          && matrix.shard == 1
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,11 @@ Other workflow notes:
   because the `-n 2` it replaced was right when a hosted runner had two cores
   and then quietly stopped being right; the job logs the cores and memory it
   saw, so check there rather than assuming a number.
+- CI also splits the suite across **2 shards**, so `pytest (ubuntu-latest,
+  3.12, 1)` runs half the test files and `... 2)` the other half. The required
+  `test` check aggregates every combination, so nothing about that changes what
+  you wait for. If you are reproducing one shard locally,
+  `python scripts/pytest_shard.py --shard 1 --of 2` prints its file list.
 - Contributing from a fork works the same way, and is the right approach if you
   don't have write access. Note that auto-delete-on-merge cannot reach a fork's
   branches, so clean those up yourself after merge.

--- a/conftest.py
+++ b/conftest.py
@@ -283,6 +283,54 @@ def _prune_compiledir(config):
     return module.summarize_tree(results, budget)
 
 
+def _seed_worker_compiledirs(config):
+    """Give every worker this run will start a warm compiledir.
+
+    Controller only, before any worker exists -- same placement and same
+    reason as _prune_compiledir, and for seeding it is not merely convenient
+    but necessary: a worker cannot seed its own compiledir, because by the
+    time it runs it is already holding the ModuleCache it would be seeding.
+
+    This exists because the per-worker compiledirs are ~95% redundant copies
+    of one another (each holds ~1500 of the 1564 entries a whole cold run
+    creates -- most of what compiles is shared infrastructure every file's
+    model builds). Without it, raising -n makes the NEW workers compile every
+    graph from scratch: measured when CI went from -n2 to -n4, ubuntu 3.12
+    went 43:21 -> 52:24 purely because gw2 and gw3 started empty. It also
+    lets CI store ONE canonical tree instead of one per worker, which is what
+    keeps the saved cache under GitHub's 10 GB repository budget as the worker
+    count and the shard count grow.
+
+    See seed_worker_compiledirs for the hard-link/copy split and the measured
+    costs.
+    """
+    module = _load_budget_module()
+    if module is None:  # pragma: no cover - defensive
+        return None
+    n_workers = int(config.getoption("numprocesses", 0) or 0)
+    if n_workers <= 0:
+        # -n0: this process IS the worker and uses the controller compiledir,
+        # which is the seed source rather than a seed target.
+        return None
+    import pytensor  # noqa: PLC0415 -- must follow the PYTENSOR_FLAGS write above
+
+    stats = module.seed_worker_compiledirs(
+        Path(pytensor.config.base_compiledir),
+        Path(pytensor.config.compiledir),
+        n_workers,
+    )
+    summary = stats.summary()
+    if summary:
+        # stderr rather than pytest_report_header, and CI is the reason: it
+        # runs `pytest -q`, which suppresses the header entirely -- and
+        # seeding is the step most worth seeing there, being where a restored
+        # single-tree cache gets fanned back out, and where a cross-device
+        # hard-link fallback would show up as a sudden multi-minute startup.
+        # It prints only when a seed actually happened, so the steady state is
+        # silent rather than one more line of noise.
+        print(summary, file=sys.stderr, flush=True)
+
+
 def _warm_module_cache():
     """Pay the ModuleCache walk here, where no test can be blamed for it.
 
@@ -319,7 +367,12 @@ def pytest_configure(config):
         _warm_module_cache()
         return
 
+    # PRUNE FIRST, THEN SEED, and the order is load-bearing: pruning picks the
+    # seed source down to the budget, so a freshly seeded worker starts inside
+    # the budget instead of immediately over it. Seeding first would copy
+    # entries that the very next prune would evict.
     _compiledir_summary = _prune_compiledir(config)
+    _seed_worker_compiledirs(config)
     if not _xdist_active(config):
         # -n0: this process runs the tests itself, so it is also the one that
         # needs the cache warm.

--- a/docs/testing-cache.md
+++ b/docs/testing-cache.md
@@ -134,6 +134,46 @@ ahead of the import.
    paid in parallel instead of in a queue -- and duplicated DISK, which is
    why the budget in point 2 is per compiledir and why it has to be walked
    over these directories explicitly. It was not, until 2026-08-25.
+5. **A missing worker compiledir is SEEDED from the warmest one**, on the
+   controller in `pytest_configure`, right after the prune.
+
+   How redundant these directories are is the point. Measured: each of
+   `gw0`-`gw5` held **1455-1562** entries against the **1564** a whole cold
+   run creates -- so a worker's directory holds nearly every graph the suite
+   compiles, because most of what compiles is shared infrastructure that
+   every file's model builds rather than anything specific to the files that
+   worker drew. They are ~95% copies of each other.
+
+   Left alone, that redundancy bills twice. Raising `-n` makes the NEW
+   workers compile everything from scratch: when CI went from `-n 2` to
+   `-n 4`, ubuntu 3.12 went **43:21 -> 52:24** and 3.13 **36:39 -> 39:12**,
+   all green, purely because `gw2` and `gw3` started empty. And it makes the
+   saved CI cache scale with the worker count, so the cache cannot absorb
+   more parallelism.
+
+   Seeding makes both free, and it is cheap because of what an entry is made
+   of. Measured over 148 entries: the `.so` is **85.3%** of the bytes, the
+   `.cpp` **13.4%**, `key.pkl` **1.3%**. Only `key.pkl` is ever rewritten in
+   place -- PyTensor appends to it when a second key maps to one compiled
+   module -- so `key.pkl` is COPIED and everything else is HARD-LINKED.
+   Measured on 398 entries: **5.3 s and 7.1 MB** of real disk, against
+   **53.6 s and 218 MB** for a full copy.
+
+   Two traps, both hit while building this:
+
+   - **Hard links across filesystems silently become copies.** Point
+     `EXOZIPPY_TEST_COMPILEDIR` at a different filesystem from the source and
+     every `os.link` raises `EXDEV`; the first measurement of this code was
+     taken that way by accident and reported *0 hard-linked, 1988 copied*.
+     `SeedStats.link_fallbacks` counts it and the header says so.
+   - **`__init__.py` is not a cache entry.** Counting raw `listdir` names made
+     a brand-new compiledir look warm enough to seed FROM, and a first run
+     printed *"seeded 2 worker compiledir(s) ... 0 entries"*. The seeding path
+     counts directories; `prune_compiledir`'s pre-check still counts names,
+     deliberately, because there it needs an upper bound.
+
+   Do not try hard-linking `key.pkl` to save the last 1.3%: one worker's
+   append would land in every other worker's cache at once.
 
 Escape hatches:
 

--- a/docs/testing-cache.md
+++ b/docs/testing-cache.md
@@ -325,6 +325,46 @@ caches` step now deletes older generations for the job's own os+python.
 Check the total with `gh cache list --limit 200 --json key,sizeInBytes` and
 sum `sizeInBytes`; anything approaching 10 GB means eviction is live.
 
+### One canonical tree, and the sharded matrix
+
+Two changes that only make sense together.
+
+**The saved artifact holds ONE worker tree.** Before saving, the job deletes
+every `gw*` but `gw0` **and the controller's own `compiledir_*`**, so the
+archive no longer multiplies by the worker count. The next run reconstitutes
+the rest by seeding (policy point 5), which is why this is safe rather than
+merely smaller. Without it the cache could not absorb more parallelism: 4
+workers x 2 shards would have wanted ~12 GB against the 10 GB repository
+budget.
+
+The controller's tree is worth deleting on its own account. Under `-n` it is
+the one directory no worker ever writes to, so everything in it is stale --
+and it was being saved every run anyway. Measured on the first master run
+after the prune fix, the macOS tree was **5055 entries**: controller 1800 +
+gw0 1578 + gw1 1677. Dropping the controller as well as gw1 makes the artifact
+about **3.2x** smaller rather than 2x.
+
+**The suite is split across 2 shards**, `scripts/pytest_shard.py`
+round-robining the sorted test-file list. Worker count is capped by the runner
+-- measured, `ubuntu-latest` is `cpus=4, memory=15.6 GB` and `macos-latest` is
+`cpus=3, memory=7.0 GB` -- and ~6700 worker-seconds over 4 workers is still
+~22 minutes, so more machines is the only way further down.
+
+Round-robin rather than a duration-aware pack because it needs no state and
+measures well: **1.04x** of a perfectly balanced split at N=2 against real
+per-file durations. It degrades to **1.37x at N=3** and **1.33x at N=4**, as
+the long tail stops averaging out, so going past 2 shards means re-measuring.
+
+Only **shard 1** prunes, saves, and drops superseded caches. Shard 1's tree
+already serves shard 2 almost completely -- the same ~95% redundancy as above
+-- so storing shard 2's would double the cache to buy a few percent. Shard 2
+recompiles that remainder every run, a small bounded cost against a cache
+budget that is not.
+
+The `--verify` flag on the shard split is load-bearing, not a nicety: a split
+that silently DROPS a file leaves every shard green with the coverage gone. It
+runs on every job.
+
 ## A source change can invalidate the whole cache
 
 A change to the *structure* of a commonly built graph misses every cached

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,7 +39,11 @@ obvious and are wrong:
   still scales nearly linearly -- which is the change CI got.
 
 It is a long tail rather than a few hot spots: the top 30 of 202 files are 67% of the
-total, the worst single file is 5.0%. The heaviest individual tests, for anyone looking
+total, the worst single file is 5.0%. That shape is why CI splits the suite across
+2 shards (`scripts/pytest_shard.py`, round-robin over the sorted file list, measured at
+1.04x of ideal balance): with no dominant file there is nothing to cut, so the remaining
+lever is more machines. See `docs/testing-cache.md` for the sharding and for the
+compiledir seeding that keeps its cache affordable. The heaviest individual tests, for anyone looking
 for something to cut:
 
 | seconds | test |

--- a/scripts/pytensor_cache_budget.py
+++ b/scripts/pytensor_cache_budget.py
@@ -358,6 +358,226 @@ def enforce_budget_tree(
     return results
 
 
+# ---------------------------------------------------------------------------
+# Seeding a cold worker compiledir from a warm one
+# ---------------------------------------------------------------------------
+# The per-worker compiledirs are ~95% redundant copies of each other: measured
+# on this repo, each of gw0-gw5 held 1455-1562 entries against 1564 distinct
+# entries for a whole cold run, because most of what gets compiled is shared
+# infrastructure that every file's model builds rather than anything specific
+# to the files that worker drew.
+#
+# That redundancy bills twice:
+#
+#   1. Changing the worker count makes the NEW workers compile everything from
+#      scratch. Measured on the run that took CI from -n2 to -n4: ubuntu 3.12
+#      went 43:21 -> 52:24 and 3.13 went 36:39 -> 39:12, all green, purely
+#      because gw2 and gw3 started empty.
+#   2. It makes the saved CI cache scale with the worker count, so the cache
+#      cannot absorb more parallelism -- sharding the matrix 2x at -n4 would
+#      want ~8 entries x ~1.5 GB, back over GitHub's 10 GB repository budget.
+#
+# Both dissolve if only ONE tree is stored and the others are derived from it.
+# Deriving is cheap because of what a cache entry is made of. Measured over 148
+# entries: the .so is 85.3% of the bytes, the .cpp 13.4%, and key.pkl 1.3%.
+# Only key.pkl is ever rewritten in place -- PyTensor appends to it when a
+# second key maps to one compiled module -- so only key.pkl has to be a private
+# copy. Everything else can be a hard link.
+#
+# Measured on 398 entries: 5.3 s and 7.1 MB of real disk, against 53.6 s and
+# 218 MB for a full copy. Extrapolated to a 1800-entry tree, ~24 s and ~32 MB
+# per extra worker, instead of a cold compile of every graph.
+_MUTABLE_ENTRY_FILES = frozenset({"key.pkl"})
+
+
+@dataclass
+class SeedStats:
+    """What one seeding pass did."""
+
+    seeded_dirs: list[str] = field(default_factory=list)
+    skipped_dirs: list[str] = field(default_factory=list)
+    entries: int = 0
+    linked: int = 0
+    copied: int = 0
+    # Files that FELL BACK to a copy because os.link refused them. Tracked and
+    # reported because the fallback is silent and turns a 5-second metadata
+    # operation into a multi-minute byte copy. The way it happens in practice
+    # is a cross-device link (EXDEV): point EXOZIPPY_TEST_COMPILEDIR at a
+    # different filesystem from the source tree and every link fails. That is
+    # not hypothetical -- it is how the first measurement of this code was
+    # taken by mistake, reporting 0 hardlinked / 1988 copied.
+    link_fallbacks: int = 0
+
+    def summary(self) -> str:
+        if not self.seeded_dirs:
+            return ""
+        parts = [
+            f"seeded {len(self.seeded_dirs)} worker compiledir(s) from a warm "
+            f"one ({', '.join(self.seeded_dirs)}): {self.entries} entries, "
+            f"{self.linked} hard-linked, {self.copied} copied"
+        ]
+        if self.link_fallbacks:
+            parts.append(
+                f"WARNING: {self.link_fallbacks} hard links fell back to "
+                "copies (cross-device compiledir?), so this was far more "
+                "expensive than it should be"
+            )
+        return "; ".join(parts)
+
+
+def _entry_names(compiledir: Path) -> list[str]:
+    """Real cache entries in ``compiledir``: subdirectories, nothing else.
+
+    Directories only, unlike prune_compiledir's cheap pre-check, which counts
+    raw listdir names deliberately because it needs an UPPER bound. Here an
+    over-count is actively wrong: a compiledir always holds an ``__init__.py``,
+    and counting that as an entry made a brand-new tree look warm enough to be
+    a seed source -- which is how a first run reported "seeded 2 worker
+    compiledir(s) ... 0 entries, 0 hard-linked, 0 copied".
+    """
+    try:
+        return [
+            name
+            for name in os.listdir(compiledir)
+            if name != _LOCK_DIR and (compiledir / name).is_dir()
+        ]
+    except OSError:
+        return []
+
+
+def choose_seed_source(base_compiledir: Path, compiledir: Path) -> Path | None:
+    """The warmest compiledir in the tree, or None if nothing is warm.
+
+    "Warmest" is simply the largest entry count. The controller's own tree is
+    a candidate because that is what a -n0 run populates, and in CI it is the
+    restored one when only a single canonical tree is saved.
+    """
+    candidates = [compiledir]
+    candidates += [
+        d for _, d in worker_compiledirs(base_compiledir, compiledir)
+    ]
+    best, best_count = None, 0
+    for candidate in candidates:
+        count = len(_entry_names(candidate))
+        if count > best_count:
+            best, best_count = candidate, count
+    return best
+
+
+def seed_compiledir(source: Path, target: Path) -> tuple[int, int, int, int]:
+    """Populate ``target`` from ``source``. Returns (entries, linked, copied, fallbacks).
+
+    Hard-links every file in every cache entry except key.pkl, which is copied
+    -- see the module comment above for why that split is exactly right.
+
+    Existing files in ``target`` are left alone, so this is safe to re-run and
+    safe against a partially populated target.
+    """
+    entries = linked = copied = fallbacks = 0
+    try:
+        names = sorted(_entry_names(source))
+    except OSError:  # pragma: no cover - defensive
+        return (0, 0, 0, 0)
+
+    target.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        src_entry = source / name
+        if not src_entry.is_dir():
+            continue
+        entries += 1
+        for root, _dirs, files in os.walk(src_entry):
+            rel = Path(root).relative_to(source)
+            (target / rel).mkdir(parents=True, exist_ok=True)
+            for filename in files:
+                src_file = Path(root) / filename
+                dst_file = target / rel / filename
+                if dst_file.exists():
+                    continue
+                if filename in _MUTABLE_ENTRY_FILES:
+                    try:
+                        shutil.copy2(src_file, dst_file)
+                        copied += 1
+                    except OSError:
+                        pass
+                    continue
+                try:
+                    os.link(src_file, dst_file)
+                    linked += 1
+                except OSError:
+                    # Cross-device, or a filesystem without hard links.
+                    try:
+                        shutil.copy2(src_file, dst_file)
+                        copied += 1
+                        fallbacks += 1
+                    except OSError:
+                        pass
+    return (entries, linked, copied, fallbacks)
+
+
+def seed_worker_compiledirs(
+    base_compiledir: Path,
+    compiledir: Path,
+    n_workers: int,
+    cold_fraction: float = 0.25,
+    dry_run: bool = False,
+) -> SeedStats:
+    """Give every worker this run will start a warm compiledir.
+
+    A worker directory is seeded when it holds less than ``cold_fraction`` of
+    the warmest tree's entry count. That threshold, rather than "is empty", is
+    what makes the pass idempotent AND useful: steady state seeds nothing and
+    costs one listdir per worker, while a worker that was interrupted halfway
+    through populating itself still gets topped up.
+
+    Called from the xdist CONTROLLER before any worker exists -- the same
+    reason the prune lives there. A worker cannot do this for itself: by the
+    time it runs it already holds the ModuleCache it would be seeding.
+    """
+    stats = SeedStats()
+    if n_workers <= 0:
+        return stats
+
+    source = choose_seed_source(base_compiledir, compiledir)
+    if source is None:
+        # Nothing warm anywhere: a genuinely first-ever run. Every worker
+        # compiles from scratch and there is nothing to copy from.
+        return stats
+    source_count = len(_entry_names(source))
+    if source_count == 0:
+        # Nothing warm anywhere. Returning here rather than looping is what
+        # keeps a first-ever run from reporting that it seeded directories it
+        # in fact left empty.
+        return stats
+    threshold = source_count * cold_fraction
+
+    for index in range(n_workers):
+        target = base_compiledir / f"gw{index}" / compiledir.name
+        if target.resolve() == source.resolve():
+            continue
+        count = len(_entry_names(target))
+        if count >= threshold:
+            stats.skipped_dirs.append(f"gw{index}")
+            continue
+        if dry_run:
+            stats.seeded_dirs.append(f"gw{index}")
+            continue
+        entries, linked, copied, fallbacks = seed_compiledir(source, target)
+        if linked + copied == 0:
+            # Claim nothing. The test is on FILES PLACED, not on entry
+            # directories walked: a hollow entry (a directory with no files,
+            # which is a broken cache entry the prune removes anyway) would
+            # otherwise be reported as a successful seed of "1 entries, 0
+            # hard-linked, 0 copied".
+            stats.skipped_dirs.append(f"gw{index}")
+            continue
+        stats.seeded_dirs.append(f"gw{index}")
+        stats.entries += entries
+        stats.linked += linked
+        stats.copied += copied
+        stats.link_fallbacks += fallbacks
+    return stats
+
+
 def summarize_tree(
     results: list[tuple[Path, PruneStats]], max_entries: int
 ) -> str:

--- a/scripts/pytest_shard.py
+++ b/scripts/pytest_shard.py
@@ -1,0 +1,134 @@
+"""Partition the test files into shards, for splitting the suite across CI jobs.
+
+Why shard at all
+----------------
+The suite's cost is ~6700 worker-seconds and it is a LONG TAIL, not a few hot
+spots: the top 30 of 202 files are 67% of it and the worst single file is 5.0%.
+Measured 2026-08-25, `call` (test bodies) is 84.7% of that and `setup` (shared
+`System` builds in fixtures) only 15.3%, so there is no structural cut that
+buys much -- and where several assertions CAN share one fit, a module-scoped
+fixture already does it. What is left is parallelism, and one runner's core
+count caps how much of it a single job can use.
+
+Why a round-robin over the sorted file list
+-------------------------------------------
+Because it needs no state and it measures well. Against the real per-file
+durations, a 2-way round-robin of the alphabetical list lands within **1.04x**
+of a perfectly balanced split (3491 vs 3224 worker-seconds). A duration-aware
+greedy pack does reach 1.00x, but it needs a checked-in durations file that
+goes stale silently, and 4% is not worth that.
+
+The balance is a property of the long tail, not luck: with 202 files and no
+file over 5%, alternating them cannot concentrate much. It degrades at higher
+shard counts -- measured 1.37x at N=3 and 1.33x at N=4 -- so if this ever goes
+past 2 shards, re-measure before assuming it is still fine.
+
+Why the file is the unit
+------------------------
+`--dist loadfile` already pins a file to one worker so module-scoped fixtures
+are shared rather than rebuilt. Splitting at any finer grain would break that,
+and splitting at a coarser one is what this is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# pytest's own default `python_files`, which this repo does not override.
+# BOTH patterns, deliberately: today every test file is `test_*.py`, but a
+# `*_test.py` would be collected by pytest and silently dropped from every
+# shard by a `test_*.py`-only glob. A shard split that loses coverage still
+# reports green, which is the worst way for this to fail.
+_PATTERNS = ("test_*.py", "*_test.py")
+
+
+def discover_test_files(tests_dir: Path) -> list[str]:
+    """Every file pytest would collect under ``tests_dir``, sorted.
+
+    Recursive, for the same reason both patterns are matched: `tests/` has no
+    subpackages today, and a future one must not fall out of the split.
+    """
+    found: set[Path] = set()
+    for pattern in _PATTERNS:
+        found.update(tests_dir.rglob(pattern))
+    # Sorted by POSIX string so the partition is identical on every platform;
+    # a shard that disagrees with its peers about the ordering would double-run
+    # some files and skip others.
+    return sorted(p.as_posix() for p in found)
+
+
+def shard(files: list[str], index: int, total: int) -> list[str]:
+    """The ``index``-of-``total`` slice, 1-based. Round-robin; see the module docstring."""
+    if not 1 <= index <= total:
+        raise ValueError(f"shard {index} is not in 1..{total}")
+    return files[index - 1 :: total]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Print the test files belonging to one shard, space-separated, "
+            "for `pytest $(scripts/pytest_shard.py --shard 1 --of 2)`."
+        )
+    )
+    parser.add_argument(
+        "--shard", type=int, required=True, help="1-based shard index"
+    )
+    parser.add_argument(
+        "--of", type=int, required=True, help="total number of shards"
+    )
+    parser.add_argument(
+        "--tests-dir",
+        default=None,
+        help="defaults to tests/ beside this script's repo root",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help=(
+            "check that the shards partition the file list "
+            "exactly -- every file in one shard, none in two "
+            "-- and report the totals on stderr"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    tests_dir = (
+        Path(args.tests_dir)
+        if args.tests_dir
+        else Path(__file__).resolve().parents[1] / "tests"
+    )
+    files = discover_test_files(tests_dir)
+    if not files:
+        print(f"no test files found under {tests_dir}", file=sys.stderr)
+        return 1
+
+    if args.verify:
+        union: list[str] = []
+        for i in range(1, args.of + 1):
+            union.extend(shard(files, i, args.of))
+        if sorted(union) != files or len(union) != len(files):
+            print(
+                f"shards do not partition {len(files)} files: "
+                f"{len(union)} assigned, {len(set(union))} distinct",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"{len(files)} test files partition cleanly into {args.of} shards",
+            file=sys.stderr,
+        )
+
+    mine = shard(files, args.shard, args.of)
+    print(
+        f"shard {args.shard}/{args.of}: {len(mine)} of {len(files)} test files",
+        file=sys.stderr,
+    )
+    print(" ".join(mine))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pytensor_cache_budget.py
+++ b/tests/test_pytensor_cache_budget.py
@@ -8,7 +8,9 @@ at all under --dry-run.
 
 import importlib.util
 import os
+import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -375,3 +377,321 @@ def test_the_tree_summary_reports_the_total_that_grew_unnoticed(tmp_path):
     # Assert
     assert "3 pruned" in line
     assert "at most 4 entries held in total" in line
+
+
+# ---------------------------------------------------------------------------
+# Seeding a cold worker compiledir from a warm one
+# ---------------------------------------------------------------------------
+
+
+def test_seeding_hardlinks_the_so_and_copies_the_key(tmp_path):
+    """Given a warm compiledir and an empty target,
+    When the target is seeded,
+    Then the module is hard-linked and key.pkl is a private copy.
+
+    The split is the whole design. key.pkl is the only file PyTensor rewrites
+    in place -- it appends to it when a second key maps to one compiled module
+    -- so sharing that inode across workers would let one worker's write land
+    in every other worker's cache. Everything else is write-once, and it is
+    98.7% of the bytes (.so 85.3%, .cpp 13.4%, measured over 148 entries)."""
+    # Arrange
+    warm = tmp_path / "warm"
+    warm.mkdir()
+    _make_entry(warm, "entry0")
+    (warm / "entry0" / "mod.cpp").write_text("int main(){}")
+    target = tmp_path / "gw1" / "compiledir_fake"
+
+    # Act
+    entries, linked, copied, fallbacks = budget.seed_compiledir(warm, target)
+
+    # Assert
+    assert (entries, fallbacks) == (1, 0)
+    assert linked == 2  # mod.so and mod.cpp
+    assert copied == 1  # key.pkl
+    so_src = (warm / "entry0" / "mod.so").stat()
+    so_dst = (target / "entry0" / "mod.so").stat()
+    assert so_dst.st_ino == so_src.st_ino, "the .so must be a hard link"
+    key_src = (warm / "entry0" / "key.pkl").stat()
+    key_dst = (target / "entry0" / "key.pkl").stat()
+    assert key_dst.st_ino != key_src.st_ino, "key.pkl must be a private copy"
+
+
+def test_a_seeded_key_pkl_write_does_not_reach_the_source(tmp_path):
+    """Given a seeded compiledir,
+    When the seeded copy's key.pkl is rewritten,
+    Then the warm source's key.pkl is untouched.
+
+    The consequence of the inode split above, stated as behaviour rather than
+    as st_ino: this is the corruption the design exists to prevent."""
+    # Arrange
+    warm = tmp_path / "warm"
+    warm.mkdir()
+    _make_entry(warm, "entry0")
+    target = tmp_path / "gw1" / "compiledir_fake"
+    budget.seed_compiledir(warm, target)
+
+    # Act -- PyTensor rewrites the whole file, it does not append in place.
+    (target / "entry0" / "key.pkl").write_bytes(b"a second key was added")
+
+    # Assert
+    assert (warm / "entry0" / "key.pkl").read_bytes() == b"fake pickle"
+
+
+def test_seeding_skips_a_worker_that_is_already_warm(tmp_path):
+    """Given one cold worker dir and one already holding the entries,
+    When the tree is seeded,
+    Then only the cold one is touched.
+
+    Idempotence is what lets this run on every single pytest invocation. In
+    steady state it costs one listdir per worker and copies nothing."""
+    # Arrange
+    platform = "compiledir_fake-3.12-64"
+    controller = tmp_path / platform
+    controller.mkdir()
+    for i in range(4):
+        _make_entry(controller, f"entry{i}")
+    warm_worker = tmp_path / "gw0" / platform
+    warm_worker.mkdir(parents=True)
+    for i in range(4):
+        _make_entry(warm_worker, f"entry{i}")
+
+    # Act -- two workers: gw0 is warm, gw1 does not exist yet.
+    stats = budget.seed_worker_compiledirs(tmp_path, controller, n_workers=2)
+
+    # Assert
+    assert stats.seeded_dirs == ["gw1"]
+    assert stats.skipped_dirs == ["gw0"]
+    assert sorted(p.name for p in (tmp_path / "gw1" / platform).iterdir()) == [
+        f"entry{i}" for i in range(4)
+    ]
+
+
+def test_seeding_is_a_no_op_when_nothing_is_warm_yet(tmp_path):
+    """Given a tree with no populated compiledir anywhere,
+    When seeding runs,
+    Then it does nothing and says so.
+
+    The genuinely-first-ever run. There is nothing to copy from, so every
+    worker compiles from scratch, which is correct and unavoidable."""
+    # Arrange
+    controller = tmp_path / "compiledir_fake"
+    controller.mkdir()
+
+    # Act
+    stats = budget.seed_worker_compiledirs(tmp_path, controller, n_workers=4)
+
+    # Assert
+    assert stats.seeded_dirs == []
+    assert stats.summary() == ""
+
+
+def test_a_compiledir_holding_only_init_py_is_not_a_seed_source(tmp_path):
+    """Given compiledirs that contain no cache entries, only an __init__.py,
+    When seeding runs,
+    Then nothing is seeded and nothing is claimed.
+
+    PyTensor puts an ``__init__.py`` in every compiledir, so counting raw
+    listdir names made a brand-new tree look warm enough to seed FROM. The
+    observed symptom was a first run printing "seeded 2 worker compiledir(s)
+    from a warm one (gw0, gw1): 0 entries, 0 hard-linked, 0 copied" -- a
+    header line asserting work that did not happen."""
+    # Arrange
+    platform = "compiledir_fake-3.12-64"
+    controller = tmp_path / platform
+    controller.mkdir()
+    (controller / "__init__.py").touch()
+    for name in ("gw0", "gw1"):
+        worker = tmp_path / name / platform
+        worker.mkdir(parents=True)
+        (worker / "__init__.py").touch()
+
+    # Act
+    stats = budget.seed_worker_compiledirs(tmp_path, controller, n_workers=2)
+
+    # Assert
+    assert stats.seeded_dirs == []
+    assert stats.summary() == ""
+
+
+def test_a_seed_that_copies_nothing_is_not_reported_as_a_seed(tmp_path):
+    """Given a source whose entry count is non-zero but yields no files,
+    When seeding runs,
+    Then the target is reported as skipped rather than seeded.
+
+    Belt to the previous test's braces: the guard is on what was actually
+    copied, not only on how the source looked before starting."""
+    # Arrange -- an entry directory that exists but is empty, so it is counted
+    # by _entry_names and yet contributes no files to copy.
+    platform = "compiledir_fake-3.12-64"
+    controller = tmp_path / platform
+    controller.mkdir()
+    (controller / "hollow_entry").mkdir()
+
+    # Act
+    stats = budget.seed_worker_compiledirs(tmp_path, controller, n_workers=1)
+
+    # Assert -- one entry walked, but zero files, so no claim of a seed.
+    assert stats.seeded_dirs == []
+    assert stats.entries == 0
+
+
+def test_the_seed_source_is_the_warmest_tree_in_the_tree(tmp_path):
+    """Given several compiledirs holding different numbers of entries,
+    When the seed source is chosen,
+    Then it is the one with the most entries."""
+    # Arrange
+    platform = "compiledir_fake"
+    controller = tmp_path / platform
+    controller.mkdir()
+    _make_entry(controller, "entry0")
+    fat = tmp_path / "gw2" / platform
+    fat.mkdir(parents=True)
+    for i in range(5):
+        _make_entry(fat, f"entry{i}")
+
+    # Act
+    source = budget.choose_seed_source(tmp_path, controller)
+
+    # Assert
+    assert source == fat
+
+
+def test_a_cross_device_fallback_is_counted_and_reported(
+    tmp_path, monkeypatch
+):
+    """Given a filesystem where os.link fails,
+    When a compiledir is seeded,
+    Then the copies still happen and the fallback is reported loudly.
+
+    Silence here would be expensive rather than wrong: the fallback turns a
+    5-second metadata operation into a multi-minute byte copy. It is exactly
+    how the first measurement of this code was taken by mistake -- the target
+    was on a different filesystem from the source, every os.link raised EXDEV,
+    and the run reported 0 hard-linked / 1988 copied without complaint."""
+    # Arrange
+    warm = tmp_path / "warm"
+    warm.mkdir()
+    _make_entry(warm, "entry0")
+
+    def no_links(*args, **kwargs):
+        raise OSError(18, "Invalid cross-device link")
+
+    monkeypatch.setattr(budget.os, "link", no_links)
+
+    # Act
+    entries, linked, copied, fallbacks = budget.seed_compiledir(
+        warm, tmp_path / "gw1" / "compiledir_fake"
+    )
+    stats = budget.SeedStats(
+        seeded_dirs=["gw1"],
+        entries=entries,
+        linked=linked,
+        copied=copied,
+        link_fallbacks=fallbacks,
+    )
+
+    # Assert
+    assert linked == 0
+    assert fallbacks == 1  # the .so; key.pkl was always a copy
+    assert (
+        tmp_path / "gw1" / "compiledir_fake" / "entry0" / "mod.so"
+    ).is_file()
+    assert "fell back to copies" in stats.summary()
+
+
+def test_pytensor_really_gets_cache_hits_from_a_seeded_compiledir(tmp_path):
+    """Given a compiledir seeded from a warm one,
+    When PyTensor compiles the same graph against it,
+    Then no new cache entry is created and the result is unchanged.
+
+    The other seeding tests prove the FILE MECHANICS -- hard links, a private
+    key.pkl. They prove nothing about whether PyTensor recognizes the result
+    as its own cache, which is the only claim that matters. A miss would have
+    to write a new entry, so "no new entries" is the assertion.
+
+    Subprocesses because ``base_compiledir`` is declared ``mutable=False``: it
+    can only be set through PYTENSOR_FLAGS before pytensor is imported, so one
+    process cannot exercise two compiledirs.
+
+    ``linker=cvm`` is not incidental. PyTensor 3 made the "auto" linker numba,
+    which caches into ``base/numba/`` and leaves the C compiledir EMPTY --
+    which is exactly how the first version of this check passed while proving
+    nothing: nothing cached, nothing recompiled, "hit". exozippy/__init__.py
+    flips auto to cvm, so cvm is what the suite's cache actually holds and
+    what this has to exercise.
+    """
+    # Arrange
+    pytensor = pytest.importorskip("pytensor")
+    if not pytensor.config.cxx:
+        pytest.skip("no C compiler configured; there is no C cache to seed")
+
+    build = textwrap.dedent(
+        """
+        import numpy as np
+        import pytensor
+        import pytensor.tensor as pt
+
+        x = pt.dvector("x")
+        y = pt.dvector("y")
+        out = pt.log(pt.exp(x) + pt.exp(y)) * pt.sqrt(pt.abs(x - y) + 1.0)
+        f = pytensor.function([x, y], out, mode="FAST_RUN")
+        r = f(np.array([1.0, 2.0]), np.array([0.5, 0.25]))
+        print("RESULT", " ".join(f"{v:.9f}" for v in r))
+        print("COMPILEDIR", pytensor.config.compiledir)
+        """
+    )
+
+    def compile_in(base):
+        env = dict(os.environ)
+        env["PYTENSOR_FLAGS"] = f"base_compiledir={base},linker=cvm"
+        env.pop("EXOZIPPY_TEST_COMPILEDIR", None)
+        done = subprocess.run(
+            [sys.executable, "-c", build],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=900,
+        )
+        assert done.returncode == 0, done.stderr[-2000:]
+        fields = dict(
+            line.split(" ", 1)
+            for line in done.stdout.splitlines()
+            if line.startswith(("RESULT ", "COMPILEDIR "))
+        )
+        return fields["RESULT"].strip(), Path(fields["COMPILEDIR"].strip())
+
+    def entry_names(compiledir):
+        if not compiledir.is_dir():
+            return set()
+        return {
+            name
+            for name in os.listdir(compiledir)
+            if name != "lock_dir" and (compiledir / name).is_dir()
+        }
+
+    src_base, dst_base = tmp_path / "src", tmp_path / "dst"
+    src_base.mkdir()
+    dst_base.mkdir()
+
+    # Act -- compile cold, seed from it, compile the same graph against the seed.
+    cold_result, src_dir = compile_in(src_base)
+    assert entry_names(src_dir), (
+        "the cold compile cached nothing, so this test proves nothing"
+    )
+
+    _, _, _, fallbacks = budget.seed_compiledir(
+        src_dir, dst_base / src_dir.name
+    )
+    assert fallbacks == 0, (
+        "os.link fell back to copying, so tmp_path spans filesystems and this "
+        "run measured a copy rather than the mechanism under test"
+    )
+    seeded = entry_names(dst_base / src_dir.name)
+    warm_result, dst_dir = compile_in(dst_base)
+
+    # Assert
+    assert entry_names(dst_dir) - seeded == set(), (
+        "the seeded compiledir was a MISS: PyTensor recompiled instead of "
+        "reusing the entries hard-linked into place"
+    )
+    assert warm_result == cold_result

--- a/tests/test_pytest_shard.py
+++ b/tests/test_pytest_shard.py
@@ -1,0 +1,143 @@
+"""Tests for the CI shard split (scripts/pytest_shard.py).
+
+The failure mode this guards is specific and quiet: a split that drops a file
+still reports green on every shard, so the coverage is gone and nothing says
+so. Hence the properties pinned here are exhaustiveness and disjointness
+against the REAL tests/ directory, not just against a fixture.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# By path, for the same reason the other scripts/ tests do it: scripts/ is not
+# a package, and putting it on sys.path would make getdata.py / mkparam.py
+# importable as top-level modules.
+_NAME = "_pytest_shard"
+if _NAME in sys.modules:
+    shard_mod = sys.modules[_NAME]
+else:
+    _SPEC = importlib.util.spec_from_file_location(
+        _NAME, _REPO_ROOT / "scripts" / "pytest_shard.py"
+    )
+    shard_mod = importlib.util.module_from_spec(_SPEC)
+    sys.modules[_NAME] = shard_mod
+    _SPEC.loader.exec_module(shard_mod)
+
+
+@pytest.mark.parametrize("total", [1, 2, 3, 4])
+def test_the_real_test_tree_partitions_exactly(total):
+    """Given this repository's own tests/ directory,
+    When it is split into shards,
+    Then every file lands in exactly one shard.
+
+    Against the real directory rather than a fixture, because the thing that
+    breaks this is a real file appearing somewhere the globs do not look --
+    a subpackage, or a `*_test.py`. A fixture would keep passing."""
+    # Arrange
+    files = shard_mod.discover_test_files(_REPO_ROOT / "tests")
+    assert files, "no test files discovered at all"
+
+    # Act
+    shards = [shard_mod.shard(files, i, total) for i in range(1, total + 1)]
+
+    # Assert -- exhaustive and disjoint.
+    union = [f for s in shards for f in s]
+    assert sorted(union) == files
+    assert len(union) == len(set(union)), "a file landed in two shards"
+
+
+def test_this_very_file_is_in_some_shard():
+    """Given the shard split,
+    When it runs over tests/,
+    Then this file is in it.
+
+    A canary for the glob: if someone narrows the patterns or makes the walk
+    non-recursive, the file asserting it is covered stops being covered, and
+    the assertion is what notices."""
+    # Arrange / Act
+    files = shard_mod.discover_test_files(_REPO_ROOT / "tests")
+
+    # Assert
+    assert Path(__file__).resolve().as_posix() in files
+
+
+def test_both_of_pytests_default_patterns_are_collected(tmp_path):
+    """Given a tests dir holding test_*.py and *_test.py and a non-test file,
+    When the files are discovered,
+    Then both test patterns are found and the other file is not.
+
+    `*_test.py` matters even though the repo has none today: pytest's default
+    `python_files` collects it, so a `test_*.py`-only glob would hand pytest a
+    file list that silently omits it."""
+    # Arrange
+    (tmp_path / "test_alpha.py").touch()
+    (tmp_path / "beta_test.py").touch()
+    (tmp_path / "conftest.py").touch()
+    (tmp_path / "helper.py").touch()
+
+    # Act
+    found = {Path(f).name for f in shard_mod.discover_test_files(tmp_path)}
+
+    # Assert
+    assert found == {"test_alpha.py", "beta_test.py"}
+
+
+def test_a_test_file_in_a_subdirectory_is_not_lost(tmp_path):
+    """Given a test file nested in a subpackage,
+    When the files are discovered,
+    Then it is included.
+
+    tests/ is flat today. If it stops being flat, a non-recursive walk would
+    drop the whole subtree out of every shard without failing anything."""
+    # Arrange
+    nested = tmp_path / "sub" / "deeper"
+    nested.mkdir(parents=True)
+    (nested / "test_nested.py").touch()
+    (tmp_path / "test_top.py").touch()
+
+    # Act
+    found = {Path(f).name for f in shard_mod.discover_test_files(tmp_path)}
+
+    # Assert
+    assert found == {"test_top.py", "test_nested.py"}
+
+
+def test_the_split_is_balanced_on_a_long_tail(tmp_path):
+    """Given many files of widely varying cost,
+    When they are round-robined,
+    Then the shards come out close to even.
+
+    This is the property that justifies round-robin over a duration-aware
+    pack. Measured on the real suite: 2 shards land within 1.04x of ideal.
+    Here the same shape is reproduced synthetically -- one 5% file and a long
+    tail -- so the reasoning is pinned rather than just asserted in a comment."""
+    # Arrange -- costs shaped like the measured suite: no file dominant.
+    costs = {f"test_{i:03d}.py": 1.0 / (i + 1) for i in range(200)}
+    files = sorted(costs)
+
+    # Act
+    shards = [shard_mod.shard(files, i, 2) for i in range(1, 3)]
+    loads = [sum(costs[Path(f).name] for f in s) for s in shards]
+
+    # Assert
+    ideal = sum(costs.values()) / 2
+    assert max(loads) / ideal < 1.15
+
+
+@pytest.mark.parametrize("index,total", [(0, 2), (3, 2), (-1, 4)])
+def test_an_out_of_range_shard_index_is_rejected(index, total):
+    """Given a shard index outside 1..total,
+    When a shard is requested,
+    Then it raises rather than silently returning something.
+
+    Shard indices come from a CI matrix, where an off-by-one is easy and would
+    otherwise mean a shard that runs nothing (green, and no coverage) or two
+    shards running the same files."""
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError):
+        shard_mod.shard(["test_a.py", "test_b.py"], index, total)


### PR DESCRIPTION
Follow-up to #206, which measured the problem and fixed the compile cache but
landed ~22 minutes rather than the 20-minute target. This is the two changes
that get under it, and they only work together.

## Why more parallelism, rather than cutting tests

#206's measurement says there is nothing worth cutting. The suite's ~6700
worker-seconds is a **long tail** -- top 30 of 202 files are 67%, worst single
file 5.0% -- and `call` (test bodies) is **84.7%** of it against `setup`
(shared `System` builds) at 15.3%. Where several assertions *can* share one
fit, a module-scoped fixture already does it; where they cannot, the files were
deliberately split apart so `loadfile` runs them concurrently.

So the lever is machines. And the worker count per job is capped by the runner,
now measured rather than inferred from a docs page:

| runner | `--explain` | workers |
|---|---|---|
| ubuntu-latest | `cpus=4, memory=15.6 GB` | 4 |
| macos-latest | `cpus=3, memory=7.0 GB` | 2 |

6700 / 4 is still ~22 minutes. Hence sharding.

## Why the two changes are one PR

Sharding alone would have undone #206. The per-worker compiledirs are ~95%
copies of each other -- measured, gw0-gw5 held 1455-1562 entries against the
1564 a whole cold run creates, because most of what compiles is shared
infrastructure every file's model builds. So the saved cache scales with the
worker count, and 4 workers x 2 shards would have wanted **~12 GB against
GitHub's 10 GB** repository budget: straight back into the eviction #206 just
fixed.

**Commit 1 (seeding)** stops storing the redundancy. The controller seeds any
missing worker compiledir from the warmest one it finds, hard-linking the
write-once files and copying only `key.pkl` -- the single file PyTensor
rewrites in place, when a second key maps to one compiled module.

Composition is what makes that cheap. Measured over 148 entries: `.so`
**85.3%**, `.cpp` **13.4%**, `key.pkl` **1.3%**. So 98.7% of the bytes are
links. Measured on 398 entries: **5.3 s and 7.1 MB** of real disk, against
**53.6 s and 218 MB** for a full copy.

It also fixes a cost #206 made visible: raising `-n` made the NEW workers
compile everything from scratch. ubuntu 3.12 went 43:21 -> 52:24 and 3.13
36:39 -> 39:12 on that PR, all green, purely because gw2 and gw3 started empty.

**Commit 2 (sharding)** splits the suite two ways and trims the saved artifact
to one canonical tree.

## Verification

- Full suite green on this branch: **3138 passed, 6 skipped, 0 failed**.
- **PyTensor really gets cache hits from a seeded compiledir.** A subprocess
  compiles a graph cold, the compiledir is seeded from it, and a second
  subprocess compiling the SAME graph must create no new entry. I sabotaged the
  seeding to confirm it is not a silent pass -- it fails with "the seeded
  compiledir was a MISS: PyTensor recompiled instead of reusing the entries
  hard-linked into place".
- Seeding driven end-to-end through the real conftest: populate two worker
  dirs, delete one, re-run, and the controller reports
  `seeded 1 worker compiledir(s) from a warm one (gw1): 22 entries, 88
  hard-linked, 20 copied` with the directory back to full strength.
- 39 tests over the three CI helper scripts.
- The branch ruleset was read directly: it requires only the aggregating `test`
  check, no bypass actors. The shard dimension renames every matrix check, and
  a stale requirement there would have blocked all future merges including its
  own fix.

## Three traps this hit, all now guarded

Worth reading before touching any of this, because each one produced a
confident wrong answer first.

1. **PyTensor 3's default linker is numba**, which caches into `base/numba/`
   and leaves the C compiledir empty. The first version of the cache-hit test
   passed while proving nothing: nothing cached, nothing recompiled, "hit".
   `exozippy/__init__.py:36` flips `auto` to `cvm`, so the test pins `cvm` --
   which is what the suite's cache actually holds. (Checked separately that the
   suite's tree has no `numba/` directory, so the prune is not missing a second
   unbounded cache.)
2. **`os.link` across filesystems raises EXDEV and silently falls back to
   copying**, turning a 5-second metadata pass into a multi-minute byte copy.
   That is exactly how the first measurement of the seeding was taken by
   mistake: *0 hard-linked, 1988 copied*. `SeedStats.link_fallbacks` counts it
   and the log says so.
3. **`__init__.py` is not a cache entry.** Counting raw `listdir` names made a
   brand-new compiledir look warm enough to seed FROM, and a first run printed
   *"seeded 2 worker compiledir(s) ... 0 entries"* -- asserting work it had not
   done. The seeding path counts directories, and the guard is on files
   actually placed rather than entry directories walked.

## What I have not measured yet, and will report

With a single-tree cache, **every** run seeds the other worker dirs rather than
only the first: ~24 s per tree, so ~72 s at `-n 4`. My expectation is that this
is at worst a wash against downloading and decompressing a ~3.2x larger
archive -- local hard-linking versus network transfer -- but that is an
expectation, not a measurement, and this PR's step timings will settle it.

Note also that **this PR's own run will not exercise the seeding path**: it
restores what master last saved, which is still all five trees, so every worker
dir arrives warm and seeding correctly does nothing. Seeding first runs for real
one master merge later. That is why it is validated locally end-to-end rather
than left to CI.

For the record, #206's fixes are confirmed working in production: the retention
step took macOS from 5 cached generations to 1, the prune reported
`3 pruned to <= 1800 entries each, at most 5055 entries held in total`, and the
repository cache has come down from **10.43 GB to 7.01 GB** with two jobs still
to run their cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
