### PR TITLE
CI: measure the shard durations on CI, not on a workstation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -311,7 +311,38 @@ jobs:
           workers=$(poetry run python scripts/pytest_workers.py --explain)
           files=$(poetry run python scripts/pytest_shard.py \
             --shard ${{ matrix.shard }} --of 4 --verify)
-          poetry run pytest -q -n "$workers" $files
+          # --durations=0 into a transcript the step below uploads. This is
+          # the ONLY place per-file cost can be measured on the hardware that
+          # actually runs the suite, and measuring it anywhere else provably
+          # does not transfer: weights taken on a 36-core workstation balanced
+          # the recorded sums to 1301 equal ubuntu-seconds per shard and still
+          # produced 14:19 against 8:38 in real wall clock, because the heavy
+          # files cost relatively more on a runner. See
+          # scripts/gen_durations.py.
+          #
+          # `tee` cannot swallow a failure here: `set -o pipefail` above makes
+          # the pipeline exit non-zero when pytest does. Without it a red suite
+          # would report green, which is the worst possible bug to introduce
+          # in the name of collecting timings.
+          poetry run pytest -q -n "$workers" $files \
+            --durations=0 --durations-min=0 | tee durations.txt
+
+      # Uploaded from EVERY job, including macOS, because which combination to
+      # regenerate from is a decision made when regenerating -- ubuntu today,
+      # since it is the slowest and three of the four legs -- and having only
+      # one platform's transcripts would foreclose it. `if: always()` so a
+      # failing shard still yields the timings that might explain why.
+      #
+      # Each job runs ONE shard, so a whole suite is the union of all four
+      # transcripts for one os+python. gen_durations.py takes several inputs
+      # for that reason.
+      - name: Upload the duration transcript
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: durations-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.shard }}
+          path: durations.txt
+          if-no-files-found: warn
 
       # The conftest prunes at session START, so at this point the directories
       # hold the budget plus everything this run compiled. Trim again so the

--- a/docs/testing-cache.md
+++ b/docs/testing-cache.md
@@ -446,12 +446,51 @@ Measured on the real suite, worst shard as a multiple of ideal:
 | 6 | 1.00x | 1.62x |
 
 So round-robin is fine at two shards and wasteful at four, which is what pays
-for carrying the file. Regenerate it after a big change in the suite's shape:
+for carrying the file.
+
+#### Regenerate it from a CI run, not from a workstation
+
+This is the part that is easy to get wrong, and the first sharded run got it
+wrong. Weights measured on a 36-core box at `-n 6` balance the **recorded
+sums** perfectly -- all four shards inside 1301 equal ubuntu-seconds, and
+`--verify` duly reports `1.00x of ideal` -- and still produced a **1.6x spread
+in real wall clock**:
+
+| shard | sum | heaviest file | predicted | observed (3.13/3.14) |
+|---|---|---|---|---|
+| 1 | 1301s | `test_rm_ltt.py` 263s | 325s | 809 / 859 |
+| 2 | 1301s | `test_orbit_crossing.py` 227s | 325s | 627 / 606 |
+| 3 | 1301s | `test_rossiter.py` 218s | 325s | 585 / 736 |
+| 4 | 1301s | `test_robust_likelihood.py` 194s | 325s | 511 / 518 |
+
+The sums are equal by construction, so the excess can only be the heavy files
+costing *relatively* more on a runner than on the workstation. The packing was
+right; the weights were measured on the wrong machine. **"1.00x of ideal" means
+1.00x of the recorded weights, not of wall clock** -- worth remembering before
+trusting that line.
+
+So every matrix job now uploads its `--durations` transcript as an artifact.
+Each job runs ONE shard, so a whole suite is the union of all four for a single
+os+python, and `gen_durations.py` takes several inputs for that reason:
+
+```bash
+gh run download <run-id> -p 'durations-ubuntu-latest-3.12-*' -D /tmp/dur
+poetry run python scripts/gen_durations.py /tmp/dur/*/durations.txt \
+    --source 'CI run <run-id>, ubuntu-latest 3.12, 4 shards at -n4'
+```
+
+Use the **slowest** combination -- ubuntu, which is also three of the four legs
+-- and do not mix platforms: macOS runs 2 workers instead of 4, clang instead
+of gcc, and skips some tests, so blended weights are worse than either
+platform's own.
+
+A local run still works and is fine for a rough refresh after adding a batch of
+tests:
 
 ```bash
 poetry run pytest -q -n6 --dist loadfile --durations=0 --durations-min=0 \
     > /tmp/durations.txt
-poetry run python scripts/gen_durations.py /tmp/durations.txt tests/durations.json
+poetry run python scripts/gen_durations.py /tmp/durations.txt
 ```
 
 Staleness is reported on every run, and raises a GitHub Actions warning

--- a/scripts/gen_durations.py
+++ b/scripts/gen_durations.py
@@ -1,13 +1,33 @@
 """Build tests/durations.json from a ``pytest --durations`` transcript.
 
 The file this writes balances the CI shard split (see
-scripts/pytest_shard.py and docs/testing-cache.md). Regenerate it after a
-change that moves the suite's shape substantially:
+scripts/pytest_shard.py and docs/testing-cache.md).
+
+MEASURE ON CI, NOT ON A WORKSTATION. That is not a style preference, it is the
+lesson from the first sharded runs. Weights taken on a 36-core box at ``-n 6``
+balanced the RECORDED sums perfectly -- all four shards within 1301 equal
+ubuntu-seconds -- and still produced a 1.6x spread in real wall clock, because
+the heavy files cost relatively more on a runner than on the workstation.
+Shard 1 came in at 14:19 against shard 4's 8:38 with identical predicted
+spread. The packing was right; the weights were measured on the wrong machine.
+
+So the source of truth is a CI run, whose jobs upload their ``--durations``
+transcripts as artifacts. Each job runs only ONE shard, so a full set needs
+every shard of one os+python combination -- and this accepts several
+transcripts for exactly that reason:
+
+    gh run download <run-id> -p 'durations-ubuntu-latest-3.12-*' -D /tmp/dur
+    poetry run python scripts/gen_durations.py /tmp/dur/*/durations.txt
+
+Use the SLOWEST combination (ubuntu), not macOS and not a mixture: mixed
+weights are worse than either platform's own, and ubuntu is both the slowest
+and three of the four matrix legs.
+
+A local run still works, and is fine for a rough refresh:
 
     poetry run pytest -q -n6 --dist loadfile --durations=0 --durations-min=0 \\
         > /tmp/durations.txt
-    poetry run python scripts/gen_durations.py /tmp/durations.txt \\
-        tests/durations.json
+    poetry run python scripts/gen_durations.py /tmp/durations.txt
 
 Per FILE, not per test, because ``--dist loadfile`` schedules whole files: a
 per-test breakdown would be more data carrying no more usable signal.
@@ -37,18 +57,26 @@ _LINE = re.compile(r"^([0-9.]+)s\s+(call|setup|teardown)\s+(\S+?)::(\S+)\s*$")
 _LOCAL_ONLY = ("ob09020",)
 
 
-def parse(transcript: str) -> tuple[dict[str, float], dict[str, float]]:
-    """(per-file worker-seconds, per-file seconds excluded as local-only)."""
+def parse(*transcripts: str) -> tuple[dict[str, float], dict[str, float]]:
+    """(per-file worker-seconds, per-file seconds excluded as local-only).
+
+    Accepts several transcripts and SUMS them, which is what makes merging a
+    CI run's per-shard artifacts work: each job reports only the files in its
+    own shard, so the union across shards is one whole suite and no file
+    appears twice. Feeding the same transcript in twice would double its
+    files, so pass each shard exactly once.
+    """
     per_file: collections.Counter[str] = collections.Counter()
     skipped: collections.Counter[str] = collections.Counter()
-    for line in transcript.splitlines():
-        m = _LINE.match(line.strip())
-        if not m:
-            continue
-        if any(tag in m[4] for tag in _LOCAL_ONLY):
-            skipped[m[3]] += float(m[1])
-            continue
-        per_file[m[3]] += float(m[1])
+    for transcript in transcripts:
+        for line in transcript.splitlines():
+            m = _LINE.match(line.strip())
+            if not m:
+                continue
+            if any(tag in m[4] for tag in _LOCAL_ONLY):
+                skipped[m[3]] += float(m[1])
+                continue
+            per_file[m[3]] += float(m[1])
     return dict(per_file), dict(skipped)
 
 
@@ -56,6 +84,7 @@ def build(
     per_file: dict[str, float],
     skipped: dict[str, float],
     measured_on: str = "unknown",
+    source: str = "unknown",
 ) -> dict:
     # Basenames, because the shard split matches on them: an absolute path
     # from whoever generated the file would be useless everywhere else.
@@ -71,7 +100,7 @@ def build(
             "file absent from this map is charged the median cost, so adding "
             "a test does not require updating it."
         ),
-        "_generated_from": "pytest -q -n6 --dist loadfile --durations=0",
+        "_generated_from": source,
         # From the transcript's mtime rather than "now", so regenerating from
         # an old transcript records when it was MEASURED and not when it was
         # converted -- the whole point of the field is judging staleness.
@@ -93,33 +122,52 @@ def main(argv: list[str] | None = None) -> int:
         )
     )
     parser.add_argument(
-        "transcript",
-        help="file holding the output of `pytest --durations=0`",
+        "transcripts",
+        nargs="+",
+        help=(
+            "one or more files holding `pytest --durations=0` output. Pass "
+            "every shard of one CI os+python combination to get a whole "
+            "suite; see the module docstring."
+        ),
     )
     parser.add_argument(
-        "output",
-        nargs="?",
+        "--output",
         default="tests/durations.json",
         help="where to write the JSON (default: %(default)s)",
     )
+    parser.add_argument(
+        "--source",
+        default=None,
+        help=(
+            "free-text note recorded as _generated_from, e.g. "
+            "'CI run 32895346307, ubuntu-latest 3.12, 4 shards at -n4'. "
+            "Defaults to the transcript filenames."
+        ),
+    )
     args = parser.parse_args(argv)
 
-    per_file, skipped = parse(Path(args.transcript).read_text())
+    paths = [Path(t) for t in args.transcripts]
+    per_file, skipped = parse(*(p.read_text() for p in paths))
     if not per_file:
+        listed = ", ".join(str(p) for p in paths)
         print(
-            f"no duration lines found in {args.transcript} -- was pytest run "
-            f"with --durations=0 --durations-min=0?",
+            f"no duration lines found in {listed} -- was pytest run with "
+            f"--durations=0 --durations-min=0?",
             file=sys.stderr,
         )
         return 1
 
+    # The NEWEST transcript's mtime: with a merged set they are all from one
+    # run, and the point of the field is judging staleness.
     stamp = datetime.date.fromtimestamp(
-        Path(args.transcript).stat().st_mtime
+        max(p.stat().st_mtime for p in paths)
     ).isoformat()
-    payload = build(per_file, skipped, measured_on=stamp)
+    source = args.source or " + ".join(p.name for p in paths)
+    payload = build(per_file, skipped, measured_on=stamp, source=source)
     Path(args.output).write_text(json.dumps(payload, indent=2) + "\n")
     print(
-        f"wrote {args.output}: {payload['_file_count']} files, "
+        f"wrote {args.output} from {len(paths)} transcript(s): "
+        f"{payload['_file_count']} files, "
         f"{payload['_total_worker_seconds']:.0f} worker-seconds"
     )
     for name, value in sorted(

--- a/tests/test_pytest_shard.py
+++ b/tests/test_pytest_shard.py
@@ -340,6 +340,7 @@ def test_the_generator_and_the_loader_agree_on_the_file_format(tmp_path):
             sys.executable,
             str(_REPO_ROOT / "scripts" / "gen_durations.py"),
             str(transcript),
+            "--output",
             str(out),
         ],
         capture_output=True,
@@ -351,3 +352,80 @@ def test_the_generator_and_the_loader_agree_on_the_file_format(tmp_path):
 
     # Assert -- summed across call/setup/teardown, keyed by BASENAME.
     assert loaded == {"test_alpha.py": 13.54, "test_beta.py": 5.10}
+
+
+def test_several_transcripts_merge_into_one_whole_suite(tmp_path):
+    """Given one transcript per CI shard, each covering different files,
+    When they are merged,
+    Then the result is the union with each file's cost intact.
+
+    This is the shape a CI run produces: every job runs ONE shard and uploads
+    its own transcript, so a whole suite only exists as the union of all four.
+    If merging silently dropped or double-counted a file the weights would be
+    wrong in a way nothing else would notice -- the split would still
+    partition correctly, just badly."""
+    # Arrange -- two shards, disjoint files, as CI would emit them.
+    shard1 = tmp_path / "s1.txt"
+    shard1.write_text(
+        "10.00s call     tests/test_alpha.py::test_one\n"
+        "2.00s setup    tests/test_alpha.py::test_one\n"
+    )
+    shard2 = tmp_path / "s2.txt"
+    shard2.write_text("5.00s call     tests/test_beta.py::test_two\n")
+    out = tmp_path / "durations.json"
+
+    # Act
+    done = subprocess.run(
+        [
+            sys.executable,
+            str(_REPO_ROOT / "scripts" / "gen_durations.py"),
+            str(shard1),
+            str(shard2),
+            "--output",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert done.returncode == 0, done.stderr
+    loaded = shard_mod.load_durations(tmp_path)
+
+    # Assert
+    assert loaded == {"test_alpha.py": 12.0, "test_beta.py": 5.0}
+
+
+def test_the_recorded_source_says_where_the_weights_came_from(tmp_path):
+    """Given a --source note,
+    When the durations file is written,
+    Then it is recorded in the file.
+
+    Load-bearing metadata rather than decoration: weights measured on a
+    workstation and weights measured on a CI runner produce measurably
+    different balance, so "which machine was this?" has to survive in the
+    file. It is the question anyone debugging a lopsided shard asks first."""
+    # Arrange
+    transcript = tmp_path / "t.txt"
+    transcript.write_text("1.00s call     tests/test_a.py::test_x\n")
+    out = tmp_path / "durations.json"
+    note = "CI run 12345, ubuntu-latest 3.12, 4 shards at -n4"
+
+    # Act
+    done = subprocess.run(
+        [
+            sys.executable,
+            str(_REPO_ROOT / "scripts" / "gen_durations.py"),
+            str(transcript),
+            "--output",
+            str(out),
+            "--source",
+            note,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert done.returncode == 0, done.stderr
+
+    # Assert
+    assert json.loads(out.read_text())["_generated_from"] == note


### PR DESCRIPTION
#208's own run produced the evidence that its durations were measured on the
wrong machine. All four shards carried an identical **1301 ubuntu-seconds**
with an identical 325 s predicted spread, none was file-bound, and `--verify`
reported `1.00x of ideal` -- and yet:

| shard | sum | heaviest file | predicted | observed (3.13/3.14) |
|---|---|---|---|---|
| 1 | 1301s | `test_rm_ltt.py` 263s | 325s | **809 / 859** |
| 2 | 1301s | `test_orbit_crossing.py` 227s | 325s | 627 / 606 |
| 3 | 1301s | `test_rossiter.py` 218s | 325s | 585 / 736 |
| 4 | 1301s | `test_robust_likelihood.py` 194s | 325s | 511 / 518 |

A **1.6x spread in real wall clock**, ordering monotonically by each shard's
heaviest file. The sums are equal by construction, so the excess can only be
the heavy files costing *relatively* more on a runner than on a 36-core box at
`-n 6`. The packing was right; the weights were not.

Worth stating plainly because I had been quoting it as if it meant something
stronger: **"1.00x of ideal" means 1.00x of the recorded weights, not balanced
wall clock.**

## What this does

Every matrix job writes its `--durations=0` output to a transcript and uploads
it. Each job runs one shard, so a whole suite is the union of all four for a
single os+python -- and `gen_durations.py` now takes several transcripts and
sums them for exactly that reason. Regenerating is two commands:

```bash
gh run download <run-id> -p 'durations-ubuntu-latest-3.12-*' -D /tmp/dur
poetry run python scripts/gen_durations.py /tmp/dur/*/durations.txt     --source 'CI run <run-id>, ubuntu-latest 3.12, 4 shards at -n4'
```

Use the slowest combination, and do not mix platforms: macOS runs 2 workers
instead of 4, clang instead of gcc, and skips some tests, so blended weights
are worse than either platform's own.

## Details worth a second look

- **`tee` cannot swallow a failure.** `set -o pipefail` is already in force, so
  the pipeline exits non-zero when pytest does. Collecting timings must not be
  able to turn a red suite green, which would be the worst possible bug to
  introduce in the name of instrumentation.
- **Artifacts from every job, `if: always()`.** Which combination to regenerate
  from is a decision made at regeneration time, and a failing shard's timings
  may be what explains the failure.
- **`--source` is load-bearing, not decoration.** "Which machine measured
  this?" is the first question anyone debugging a lopsided shard asks, and this
  PR exists because the answer mattered.

## Verification

No `src/` change at all -- the touched surface is one script, the workflow, and
the tests covering both. So verification is `tests/test_pytest_shard.py` plus
`tests/test_scripts_smoke.py` (**74 passed**) and CI's own full run, rather
than a local full suite competing for the box with a coverage measurement
that is still running.

Three new tests: several transcripts merge into one whole suite (the CI shape
-- if merging dropped or double-counted a file the split would still partition
correctly, just badly); the `--source` note survives into the file; and the
existing generator/loader contract test, updated for the new CLI.

## What this is expected to buy

Pulling the worst job from ~14:19 toward the ~10:30 mean. The follow-up, once
this has landed and a run has produced artifacts, is to regenerate the file
from them and confirm that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)