### PR TITLE
examples/ob09020: re-reference to the IOP (version of record) Table 1

### DIFF
--- a/examples/ob09020/README.md
+++ b/examples/ob09020/README.md
@@ -8,7 +8,7 @@
 > geometry reproduces all four published orbital-motion observables in the
 > published `u_0 > 0` labeling (`s_0`, `alpha_0`, `sign(gamma_par)`,
 > `sign(gamma_perp)`); the Yee (Omega, i) -> EXOZIPPy frame mapping is
-> measured (see the params file); and the start logp is finite (+3,276).
+> measured (see the params file); and the start logp is finite (+19,024).
 > The per-instrument flux/`err_scale` seeds still date from the static
 > geometry and are refreshed by the acceptance fit.  Every sign statement
 > below uses the corrected identity `gamma_perp = -dalpha/dt` (Skowron
@@ -23,9 +23,39 @@ measurements.
 * Skowron et al. 2011, ApJ 738, 87 (arXiv:1101.3312) -- the light-curve
   solution and the prediction.  Its Appendix A is also the convention
   EXOZIPPy follows verbatim (`components/mulensing/conventions.md`, C17), so
-  its parameters transfer with no transformation.
+  its parameters transfer with no transformation.  **The arXiv v1 posting
+  and the IOP version of record print different Table 1 values; this
+  example references the IOP version** -- see "Which Table 1" below.
 * Yee et al. 2016, ApJ 821, 121 (arXiv:1506.01441) -- the Keck/HIRES and
   Magellan/MIKE velocities that tested it, and the joint solution.
+
+### Which Table 1
+
+Skowron+2011 exists in two numerically different versions: the arXiv v1
+posting (1101.3312, 2011 January) and the refereed IOP version of record
+(DOI 10.1088/0004-637X/738/1/87, 2011 September).  The refereed version
+evidently re-ran the chains: in the "with priors" column, `t_E` moved from
+76.02 to 76.9 d, `u_0` from +0.06193 to +0.0613, `s_0` from 0.4315 to
+0.4294, `pi_E_N` from -0.025 +/- 0.075 to -0.022 +/- 0.086, `gamma_z` from
++1.7 +/- 0.6 to +1.5 +/- 1.0, several other error bars changed, and a
+`theta_E` row (2.95 mas with priors) exists only in the IOP table.  The
+"2 par. motion" column moved similarly (`t_E` 78.57 -> 78.3, `u_0`
++0.06010 -> +0.0603, `s_0` 0.4261 -> 0.4268).
+
+**This example references the IOP version of record everywhere** -- it is
+the refereed, later version, and it is the one a citation of ApJ 738, 87
+resolves to.  Two side effects worth knowing:
+
+* Any pre-2026-08-27 record in this repo (or a reader checking against the
+  freely downloadable arXiv PDF) will see ~1% "discrepancies" on `t_E`,
+  `u_0` and `s_0`.  They are version skew, not misreads -- both value sets
+  are faithfully printed in their respective versions.
+* Within the IOP with-priors column, the derived block is self-consistent
+  with `t_eff/t_E` (`4.708/0.0613 = 76.80 ~ 76.9`) but its `u_0` is 1% from
+  the fit-parameter product `(u_0/w) * 10**(log w) = 0.06193`; in arXiv v1
+  the derived block matched the product instead.  These are per-parameter
+  MCMC medians, not one self-consistent point -- do not chase the third
+  decimal across rows.
 
 The lens is a 0.89 + 0.24 Msun binary at 0.75 kpc in a 276.6 d, e = 0.27
 orbit; the source is a bulge K giant.  Because the lens is nearby disk,
@@ -179,34 +209,37 @@ default recommendation for events without RVs.
 
 The linear mode's acceptance measurement, re-made 2026-08-27 with the
 shipped machinery (fluxes fit linearly per instrument, all 2837 points, raw
-errors): at Skowron Table 1's **"parallax + 2 par. motion" column** -- the
+errors): at the IOP Table 1's **"parallax + 2 par. motion" column** -- the
 one fitted with EXACTLY this model, so its printed values are the referee
-(`u_0 = +0.06010`, `t_E = 78.57`, `s_0 = 0.4261`, `alpha = 189.07`,
+(`u_0 = +0.0603`, `t_E = 78.3`, `s_0 = 0.4268`, `alpha = 189.06`,
 `pi_E_N = -0.11`, `gamma_par = +0.12`, `gamma_perp = +2.78`):
 
 | model | chi2 | chi2/N |
 |---|---|---|
-| static `s`, `alpha` | 81,885 | 28.86 |
-| linear, `dalpha/dt = -2.78 rad/yr` (`gamma_perp = +2.78`, as printed) | **15,388** | **5.42** |
-| linear, `dalpha/dt = +2.78 rad/yr` (wrong sign) | 331,126 | 116.72 |
-| `gamma_par` only | 87,957 | 31.00 |
+| static `s`, `alpha` | 72,485 | 25.55 |
+| linear, `dalpha/dt = -2.78 rad/yr` (`gamma_perp = +2.78`, as printed) | **16,308** | **5.75** |
+| linear, `dalpha/dt = +2.78 rad/yr` (wrong sign) | 306,660 | 108.09 |
+| `gamma_par` only | 78,066 | 27.52 |
 
-A factor 5.3 from the printed rates in the printed labeling, with the wrong
-rotation sense 21x worse -- the sign is decisive, and it agrees with
+A factor 4.4 from the printed rates in the printed labeling, with the wrong
+rotation sense 19x worse -- the sign is decisive, and it agrees with
 `gamma_perp = -dalpha/dt` (Skowron A.4; C24) with no transformation.  Two
 traps this measurement stepped in so the next reader does not have to:
 
 * **Do not mix columns.**  The "full orbit (with priors)" column's
   parameters are a KEPLERIAN solution; through the strong
   `pi_E_N`-`gamma_perp` degeneracy (their Section 4.2) its
-  `pi_E_N = -0.025` pairs with the full-orbit trajectory, and evaluating
-  the LINEAR model at that column's values fits WORSE than static
-  (81k/69k vs 29k over these points).  Each column is self-consistent
+  `pi_E_N = -0.022` pairs with the full-orbit trajectory, and the LINEAR
+  model at that column's values gains almost nothing over static
+  (static 30,932 vs 29,376 with the printed rates -- against the factor
+  4.4 the model earns at its own column).  Each column is self-consistent
   only as a set.
-* An earlier version of this README carried a factor-3.5 table
-  (160,258 -> 45,661) measured at second-hand parameter values ~1% off
-  the printed ones; at the correctly-read values its static baseline is
-  not reproducible and that table is superseded by the one above.
+* Earlier versions of this README carried tables measured first at
+  second-hand parameter values and then at the arXiv v1 Table 1
+  (static 81,885 -> 15,388, factor 5.3); the arXiv-vs-IOP version skew
+  ("Which Table 1" above) is ~1% on the trajectory parameters and moves
+  the chi2 baselines by ~10% here.  The table above, at the IOP values,
+  supersedes both.
 
 The design -- source orbital motion, real `gamma_dot`/`gamma_ddot`, and the
 eventual N-body backend -- is in `notes/orbital_motion_and_nbody.txt`.
@@ -221,9 +254,10 @@ and are recorded there in full:
    tabulates `t_eff = u_0 t_E`, `t_* = rho t_E`, `log q` and `log w`, with
    the impact parameter given as `u_0/w` in units of the central-caustic
    width -- but its "derived" block prints the conversions itself
-   (`s_0 = 0.4315`, `q = 0.272`, `t_E = 76.02`, `u_0 = +0.06193`), and the
-   cross-check is exact: `(u_0/w) * 10**(log w) = 0.42942 * 0.14421 =
-   0.06193`, identical to the printed derived `u_0`.
+   (IOP: `s_0 = 0.4294`, `q = 0.273`, `t_E = 76.9`, `u_0 = +0.0613`,
+   `theta_E = 2.95 mas`).  Cross-check with `t_eff/u_0 = 4.708/0.0613 =
+   76.80 ~ 76.9`, NOT with the fit-parameter product ("Which Table 1"
+   above).
 2. **The blending is not what the EWS page says.**  EWS reports `fbl = 0.987`
    from a PSPL fit to survey data alone; the real source fraction is
    `q_source ~ 0.335` (Skowron: `I_s = 16.43`, `I_b = 15.68`).  Fitting
@@ -239,7 +273,7 @@ and are recorded there in full:
 4. **`u_0` is seeded POSITIVE, as published.**  Table 1's own note reads
    "All parameters represent positive u_0 solutions ... which is slightly
    preferred", and Appendix A is EXOZIPPy's convention verbatim (C17), so
-   the printed `(u_0 = +0.06193, alpha = +189.08)` transfers with no
+   the printed `(u_0 = +0.0613, alpha = +189.08)` transfers with no
    transformation.  The mirror `(u_0, alpha, pi_E_N, gamma_perp) ->
    -(...)` (their Eq. 16) is a distinct, slightly disfavored solution once
    parallax and orbital motion are believed -- a candidate second seed for
@@ -251,7 +285,7 @@ and are recorded there in full:
    orientation (bigomega) and rotation sense (`sign(cos i)`) reach the
    light curve; the orbit component samples both over their full ranges
    (`Orbit._lens_keplerian_orbits`).  The seeds carry the frame-mapped
-   Yee branch (`i = 50.58 = 180 - 129.42`, `bigomega = 337.45`; the
+   Yee branch (`i = 50.58 = 180 - 129.42`, `bigomega = 337.48`; the
    mapping table lives in the params file).  The retired `i180: true`
    hand-holding and the inert commented-out `bigomega` are exactly what
    review 8.6.8 5e said this mode would remove.
@@ -270,19 +304,23 @@ between 0.17 and 0.37 at every site against Skowron's calibrated 0.334, the
 spread being the expected consequence of unfiltered detectors with different
 responses.
 
-Start logp is +3,276 in the full keplerian-mode model (2026-08-27).  For
-the record of the seed lineage: the static model started at +41,458 at the
-published-branch seeds, and +47,309 at the retracted mirror seeds.  The
-keplerian start is lower than the static one NOT because the model is
-worse but because the published point-values do not close as a set: the
-per-instrument flux and `err_scale` seeds still date from the static
-geometry (a linear-flux refit at the keplerian start leaves the caustic
-window healthy -- Bronberg chi2/N = 4.3 on raw errors -- while the OGLE
-wings sit at chi2/N ~ 375, carrying the mismatch between Skowron's
-with-priors trajectory values and the joint solution's unprinted ones),
-and Table 1's own medians are mutually inconsistent at the point-estimate
-level (e.g. its printed |pi_E| = 0.151 against the
-theta_E/(kappa M) = 0.30 implied by its own priors' masses -- marginal
-medians, as the params file notes).  Resolving that tension is precisely
-what the acceptance FIT is for; the per-instrument chi2/N table and the
-flux/`err_scale` seeds are refreshed from its posterior.
+Start logp is +19,024 in the full keplerian-mode model at the IOP-referenced
+seeds (2026-08-27; the same model started at +3,276 at the arXiv v1 values
+-- the ~1% version skew on `t_E`/`u_0`/`rho` is worth ~16k nats through
+this caustic-crossing dataset, which is the concrete argument for pinning
+WHICH version a params file references).  For the record of the seed
+lineage: the static model started at +41,458 at the arXiv published-branch
+seeds, and +47,309 at the retracted mirror seeds.  The keplerian start is
+lower than the static one NOT because the model is worse but because the
+published point-values do not close as a set: the per-instrument flux and
+`err_scale` seeds still date from the static geometry (measured at the
+arXiv-seed start: a linear-flux refit leaves the caustic window healthy --
+Bronberg chi2/N = 4.3 on raw errors -- while the OGLE wings sit at
+chi2/N ~ 375, carrying the mismatch between Skowron's with-priors
+trajectory values and the joint solution's unprinted ones), and Table 1's
+own medians are mutually inconsistent at the point-estimate level (e.g.
+its printed |pi_E| = 0.151 against the theta_E/(kappa M) = 0.30 implied by
+its own priors' masses -- marginal medians, as the params file notes).
+Resolving that tension is precisely what the acceptance FIT is for; the
+per-instrument chi2/N table and the flux/`err_scale` seeds are refreshed
+from its posterior.

--- a/examples/ob09020/ob09020.params.yaml
+++ b/examples/ob09020/ob09020.params.yaml
@@ -30,25 +30,35 @@ star.dec:
 
 # --------------------------------------------------------------------
 # Light curve -- Skowron+2011 Table 1, the "parallax + full orbit (with
-# priors)" column, read off the published table directly (2026-08-27; the
-# earlier version of this file carried second-hand values that drifted by
-# ~1% on t_E and u_0).
+# priors)" column, read off the PUBLISHED (IOP, ApJ 738, 87) table.
+#
+# WHICH TABLE 1: the arXiv v1 posting (1101.3312, 2011-01) and the IOP
+# version of record (2011-09) print DIFFERENT Table 1 values -- the
+# refereed version re-ran the chains (with-priors t_E 76.02 -> 76.9,
+# u_0 0.06193 -> 0.0613, s_0 0.4315 -> 0.4294, several error bars, and a
+# theta_E row that only exists in IOP).  This file references the IOP
+# version of record throughout; the full arXiv-vs-IOP diff and the reason
+# for the choice are documented in README.md.
 #
 # THAT TABLE IS NOT IN THESE UNITS.  Skowron parameterize a high-
 # magnification binary by the quantities the light curve actually measures
 # (t_eff = u_0 t_E, t_* = rho t_E, u_0/w, log w, log q), but its "derived"
 # block prints the conversions itself:
 #
-#     s_0 = 0.4315,  q = 0.272,  t_E = 76.02 d,  u_0 = +0.06193
+#     s_0 = 0.4294,  q = 0.273,  t_E = 76.9 d,  u_0 = +0.0613,
+#     theta_E = 2.95 mas
 #
-# and the cross-check that the two halves of the table agree:
-# u_0 = (u_0/w) * 10**(log w) = 0.42942 * 0.14421 = 0.06193, identical to
-# the printed derived u_0.  rho = t_*/t_E = 0.11595/76.02 = 0.0015252.
+# Cross-checks: t_eff/u_0 = 4.708/0.0613 = 76.80, consistent with the
+# printed t_E = 76.9 to 0.13% -- but (u_0/w) * 10**(log w) =
+# 0.42942 * 0.14421 = 0.06193, 1% from the printed derived u_0 (these are
+# per-parameter MCMC medians, not one self-consistent point; the arXiv v1
+# derived block matched the product instead).
+# rho = t_*/t_E = 0.11595/76.9 = 0.0015078.
 #
 # THE SIGN OF u_0 IS PART OF THE PUBLISHED SOLUTION.  Table 1's note:
 # "All parameters represent positive u_0 solutions ... which is slightly
 # preferred", and Skowron+2011 Appendix A is EXOZIPPy's convention verbatim
-# (C17) -- so the printed (u_0 = +0.06193, alpha = +189.08) drops straight
+# (C17) -- so the printed (u_0 = +0.0613, alpha = +189.08) drops straight
 # in.  The mirror branch (u_0, alpha, pi_E_N, gamma_perp) ->
 # -(u_0, alpha, pi_E_N, gamma_perp) (their Eq. 16; C23's ecliptic
 # degeneracy extended to orbital motion) is a distinct, slightly disfavored
@@ -62,19 +72,19 @@ star.dec:
 # For the orbital-motion work (notes/orbital_motion_and_nbody.txt), the
 # same column's orbital values, in the SAME u_0 > 0 labeling:
 #
-#     gamma_par  = +0.10 +/- 0.06   /yr      (= (ds/dt)/s_0)
+#     gamma_par  = +0.10 +/- 0.11   /yr      (= (ds/dt)/s_0)
 #     gamma_perp = +2.3  +0.5/-0.3  rad/yr   (= -dalpha/dt: Appendix A.4;
 #                                             so dalpha/dt = -2.3 rad/yr)
-#     gamma_z    = +1.7  +/- 0.6    /yr      (+ = toward the observer)
+#     gamma_z    = +1.5  +/- 1.0    /yr      (+ = toward the observer)
 #     s_z        =  0.0  +/- 0.6    r_E
-#     pi_E_N     = -0.025 +/- 0.075          (degenerate with gamma_perp,
+#     pi_E_N     = -0.022 +/- 0.086          (degenerate with gamma_perp,
 #                                             their Section 4.2)
 #
 # DO NOT seed orbital_motion: linear from THIS column: it is a Keplerian
 # solution, and through the pi_E_N <-> gamma_perp degeneracy its values are
 # self-consistent only as a set.  The linear-model-consistent set is the
-# "parallax + 2 par. motion" column (u_0 = +0.06010, t_E = 78.57,
-# s_0 = 0.4261, alpha = 189.07, pi_E_N = -0.11, pi_E_E = 0.1468,
+# "parallax + 2 par. motion" column (u_0 = +0.0603, t_E = 78.3,
+# s_0 = 0.4268, alpha = 189.06, pi_E_N = -0.11, pi_E_E = 0.1468,
 # gamma_par = +0.12, gamma_perp = +2.78) -- see README's measured table.
 #
 # VERIFIED AGAINST THE DATA, not just transcribed: at these values, with
@@ -87,32 +97,32 @@ lens.Source.t_0:
     initval: 2454917.252      # HJD' 4917.252 +0.016/-0.009
 
 lens.Source.u_0:
-    initval: 0.06193          # POSITIVE, as printed (Table 1's derived
+    initval: 0.0613           # POSITIVE, as printed (IOP Table 1's derived
                               # block, and its note quoted above).
 
 lens.Source.t_E:
-    initval: 76.02            # d (Table 1 derived), referenced to the
+    initval: 76.9             # d (IOP Table 1 derived), referenced to the
                               # TOTAL lens mass
 
 lens.Source.rho:
-    initval: 0.0015252        # = t_*/t_E = 0.11595/76.02
+    initval: 0.0015078        # = t_*/t_E = 0.11595/76.9
 
 # s and alpha are NOT seeded: with orbital_motion: keplerian they are
 # DERIVED from orbit L (no sampled log_s/xalpha/yalpha exist -- C24), and
 # their published values are the ACCEPTANCE CHECK, not inputs.  At the
 # orbit/mass/distance seeds below the derived start is s_0 = 0.4263,
-# alpha_0 = 189.08 deg, gamma_par = +0.135/yr, gamma_perp = +3.356 rad/yr
-# (measured 2026-08-27, scratch kep_branch_scan) -- against the published
-# with-priors s_0 = 0.4315, alpha_0 = 189.08 +/- 0.14, gamma_par = +0.10
-# +/- 0.11, gamma_perp = +2.3 +0.5/-0.3.  s_0 agreeing to 1.2% from a fully
-# independent chain (Yee's orbit + masses + distances) is the two-solution
-# consistency check of notes/orbital_motion_and_nbody.txt 0a; the gamma
-# magnitudes differ at the 2-sigma level because Skowron's is a
+# alpha_0 = 189.08 deg, gamma_par = +0.133/yr, gamma_perp = +3.361 rad/yr
+# (measured 2026-08-27, scratch kep_final_probe) -- against the published
+# (IOP) with-priors s_0 = 0.4294, alpha_0 = 189.08 +/- 0.14, gamma_par =
+# +0.10 +/- 0.11, gamma_perp = +2.3 +0.5/-0.3.  s_0 agreeing to 0.7% from
+# a fully independent chain (Yee's orbit + masses + distances) is the
+# two-solution consistency check of notes/orbital_motion_and_nbody.txt 0a;
+# the gamma magnitudes differ at the 2-sigma level because Skowron's is a
 # microlensing-only fit at a different distance.
 
 lens.OB09020.q:
     initval: 0.2748           # = Yee+2016 joint M2/M1 = 0.244/0.888 (Table 1
-                              # with priors prints 0.272).  The engine
+                              # with priors prints 0.273).  The engine
                               # propagates this through
                               # q * m_primary = m_companion to seed
                               # star.L2.mass.
@@ -329,7 +339,7 @@ orbit.L.sesinw:
 # NOT drop into EXOZIPPy's sky frame.  The EXOZIPPy-frame branch below was
 # pinned numerically (scratch kep_branch_scan.py) by requiring the
 # orbit-derived geometry to reproduce ALL FOUR published orbital-motion
-# observables at t0_par in the u_0 > 0 labeling -- s_0 = 0.4315,
+# observables at t0_par in the u_0 > 0 labeling -- s_0 = 0.4294,
 # alpha_0 = 189.08, gamma_par > 0, gamma_perp > 0 -- on top of the
 # RV-verified omega_* = 331.6 and the joint-consistent phi_pi from the
 # pi_E seeds below:
@@ -337,22 +347,30 @@ orbit.L.sesinw:
 #     candidate (bigomega, cosi)          alpha_0     gamma_perp
 #     (352.23, -0.635)  [Yee as-printed]     wrong      -3.36  rad/yr WRONG
 #     (352.23, +0.635)                       wrong      +3.36
-#     (337.45, +0.635)  [SEEDED]            189.080     +3.36  MATCHES
+#     (337.48, +0.635)  [SEEDED]            189.080     +3.36  MATCHES
 #
-# (337.45 rather than the scan's naive 334.45: alpha_0 = phi_pi - PA(axis)
-# uses the ENGINE-RESOLVED parallax direction, and the relaxation engine's
-# reconciliation of the pi_E/pm/distance chain lands phi_pi at 158.76 deg,
-# 3 deg from the seed-implied value -- so bigomega is tuned against the
-# BUILT model (kep_bigom_scan.py), where the derived alpha_0 = 189.080
-# exactly and the start logp is +3276.  A 3 deg alpha error through this
+# The pinned branch obeys ONE closed-form rule, shared with the verified
+# xallarap xi_* mapping (C25): bigomega_EXOZIPPy = PA(frame's first axis)
+# - Omega_frame.  Here the App-B first axis is the binary axis at t_0,kep,
+# whose PA is phi_pi - alpha_0 = 158.79 - 189.08 = 329.71 deg, so
+# bigomega = 329.71 - (-7.767) = 337.48.  (For the xi_* frame the first
+# axis is tau_hat, PA = phi_pi, giving C25's bigomega = phi_pi - xi_Omega.)
+#
+# (337.48 rather than the naive seed-implied value: alpha_0 =
+# phi_pi - PA(axis) uses the ENGINE-RESOLVED parallax direction, and the
+# relaxation engine's reconciliation of the pi_E/pm/distance chain lands
+# phi_pi at 158.79 deg, 3 deg from the seed-implied value -- so bigomega
+# is checked against the BUILT model (kep_bigom_scan.py /
+# kep_final_probe.py), where the derived alpha_0 = 189.080 exactly and
+# the start logp is +19,024.  A 3 deg alpha error through this
 # caustic-crossing dataset costs ~1e7 nats, so this tuning is
 # load-bearing.)
 #
 # i_EXOZIPPy = 180 - 129.42 = 50.58 deg: the toward/away third-axis flip
 # maps i -> 180 - i, exactly as C24/skyframe.md predict.  The derived
-# start then reproduces s_0 = 0.4263 (published 0.4315, 1.2% -- the 0a
-# two-solution consistency check), gamma_par = +0.135 (+0.10 +/- 0.11) and
-# gamma_perp = +3.356 rad/yr (+2.3 +0.5/-0.3; the 2-sigma magnitude
+# start then reproduces s_0 = 0.4263 (published 0.4294, 0.7% -- the 0a
+# two-solution consistency check), gamma_par = +0.133 (+0.10 +/- 0.11) and
+# gamma_perp = +3.361 rad/yr (+2.3 +0.5/-0.3; the 2-sigma magnitude
 # tension is Skowron-vs-Yee, not a convention).
 orbit.L.cosi:
     initval: 0.635054         # i = 50.576 deg in EXOZIPPy's frame
@@ -362,7 +380,7 @@ orbit.L.cosi:
                               # sign(cos i), which is why the config no
                               # longer needs i180.
 orbit.L.bigomega:
-    initval: 337.45           # EXOZIPPy-frame node PA (E of N); see the
+    initval: 337.484          # EXOZIPPy-frame node PA (E of N); see the
                               # mapping table above.  Sampled (not inert)
                               # because the lens keplerian mode consumes
                               # this orbit; measured by the light curve's


### PR DESCRIPTION
Skowron+2011's Table 1 differs between the arXiv v1 posting (1101.3312, 2011-01) and the refereed IOP version of record (DOI 10.1088/0004-637X/738/1/87, 2011-09) -- the refereed version re-ran the chains. With-priors column: t_E 76.02 -> 76.9, u_0 +0.06193 -> +0.0613, s_0 0.4315 -> 0.4294, pi_E_N -0.025+/-0.075 -> -0.022+/-0.086, gamma_z +1.7+/-0.6 -> +1.5+/-1.0, and a theta_E row (2.95 mas) that exists only in IOP; the 2-par-motion column moved similarly.

Per JDE's decision, the IOP version of record is now the reference throughout the example, and README's new **Which Table 1** section documents the diff and the choice (including the version-specific derived-block self-consistency: the arXiv derived block matches (u_0/w)*10^logw exactly, the IOP one matches t_eff/t_E instead -- marginal medians).

Remeasured at the IOP values:

- **Linear-mode acceptance** (2-par-motion column, 2837 points, per-instrument linear fluxes, raw errors): static 72,485 -> 16,308 at the printed rates (factor 4.4); wrong rotation sense 306,660 (19x worse). At the IOP with-priors values the linear rates are ~neutral vs static (30.9k vs 29.4k) rather than actively worse as at the arXiv values -- the do-not-mix-columns trap is restated accordingly.
- **Keplerian start**: bigomega retuned 337.45 -> 337.484 so the derived alpha_0 = 189.080 exactly at the engine-resolved phi_pi = 158.79; derived s_0 = 0.4263 is now 0.7% from the published 0.4294 (was 1.2% vs the arXiv 0.4315); start logp +3,276 -> +19,024 (the ~1% version skew alone is worth ~16k nats through this caustic-crossing dataset).
- The params file now states the closed-form frame rule the numeric pin obeys, shared with the C25 xi_* mapping: bigomega_EXOZIPPy = PA(frame's first axis) - Omega_frame (App-B first axis = binary axis, PA = phi_pi - alpha_0; xi frame first axis = tau_hat, PA = phi_pi).

Docs/example-only change (yaml + md); full suite green in the pre-push hook. Notes-repo record corrected in exozippy-notes b1a8ed0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)