### PR TITLE
pre-push hook: test the tree it was launched from (review 2.15.1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,9 +59,20 @@ repos:
     # ~/.cache/pre-commit/, but do not kill a run that is in progress. This is
     # a property of pre-commit itself and applies to pre-push exactly as it did
     # to pre-commit; moving the stage does not avoid it.
+    # The entry is a script rather than `poetry run pytest`, and that is not a
+    # style preference: `poetry run` CANNOT work from a git worktree, and every
+    # batch of work is developed in one. Poetry names the venv from a hash of
+    # the project path, so a worktree gets a fresh empty venv and dies on
+    # ModuleNotFoundError -- and even once pytest runs, the main venv's
+    # editable install points at the SHARED checkout's src, so the hook tests
+    # the other tree's code and passes. The script resolves the interpreter and
+    # exports PYTHONPATH itself, which makes the hook test the tree it was
+    # launched from by construction. Full reasoning is in the script's header
+    # and in docs/testing.md; the property is pinned by
+    # tests/test_pre_push_hook.py.
     -   id: pytest
         name: Run pytest (full suite)
-        entry: poetry run pytest
+        entry: scripts/pre_push_suite.sh
         language: system
         pass_filenames: false
         always_run: true

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,50 @@ Do not start the full suite with a timeout. Start it and poll.
 
 Testing note: build relation inputs with `pt.dscalar`, **not** `pt.as_tensor_variable(<python float>)` -- pytensor autocasts a bare Python float to the smallest dtype that represents it (5778.0 -> float32), and a unary op like `pt.log10` on it then computes in float32, silently losing ~1e-7. The model always feeds float64. `tests/test_torres.py` pins the port against real IDL output from `massradius_torres.pro`.
 
+## The pre-push hook, and why it does not say `poetry run pytest`
+
+The full suite runs on push, wired in `.pre-commit-config.yaml` (install both hook
+types with `poetry run pre-commit install`). The entry is
+`scripts/pre_push_suite.sh` rather than `poetry run pytest`, because that spelling
+**cannot work from a git worktree** -- and essentially all work here is developed in
+one, so it was on the path of every push. Two failures, one of them silent:
+
+- **Loud.** Poetry names a project's virtualenv from a hash of the project *path*. A
+  worktree is a different path, so `poetry run` there does not find the populated venv;
+  it creates a fresh empty one and dies on `ModuleNotFoundError: pytest`, leaving an
+  orphan venv behind (these have reached tens of GB).
+- **Silent, and the one that matters.** Even once pytest runs, the main venv's editable
+  install is a plain path entry (`exozippy.pth`) pointing at the *shared* checkout's
+  `src`. So the suite imports the other tree's code and reports green -- a hook that
+  proves nothing about what you are pushing.
+
+The script resolves the interpreter and exports `PYTHONPATH=<this tree>/src` itself, so
+the hook tests the tree it was launched from **by construction** rather than by the
+caller remembering to export something. It prints the tree, the interpreter and the
+import path, because the bug it replaces was a hook that passed while testing the wrong
+code. `tests/test_pre_push_hook.py` pins the worktree case, the main-tree case (git
+reports `--git-common-dir` relative there and absolute from a worktree), and the wiring.
+
+Two rejected alternatives, so they are not re-proposed:
+
+- `POETRY_VIRTUALENVS_CREATE=false`, which makes `poetry run` resolve from its own base
+  environment. It fixes the loud half and leaves the silent half live.
+- A per-worktree symlink or a hand-exported `PYTHONPATH`. Both work and both are
+  invisible: the failure mode is a green hook, so a mitigation nobody can see in the
+  repository is not a mitigation.
+
+Knobs: `EXOZIPPY_VENV_PYTHON` names the interpreter explicitly and skips the poetry
+lookup (for a conda or hand-built environment, or CI); `EXOZIPPY_PREPUSH_DRYRUN=1`
+prints the resolution and exits without running the suite.
+
+Two properties of the hook that this did **not** change, and that still bite:
+
+- It tests the **working tree**, not the commits being pushed. Pushing a branch from
+  the main tree therefore tests whatever is checked out there, not the branch.
+- `pre-commit` stashes unstaged changes while hooks run and restores them afterwards.
+  Do not kill a run in progress; the work is recoverable from the patch it prints under
+  `~/.cache/pre-commit/`, but only by hand.
+
 ## Suite runtime and the pytensor compile cache
 
 The suite runs in **~16 minutes warm** on an idle 36-core box (`-n 6`, 3108 tests,

--- a/scripts/pre_push_suite.sh
+++ b/scripts/pre_push_suite.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# The pre-push hook's entry point (wired in .pre-commit-config.yaml).
+#
+# WHY THIS EXISTS, and why the obvious `poetry run pytest` is wrong here.
+#
+# The hook used to be `entry: poetry run pytest`, which cannot work from a git
+# worktree -- and every batch of work since batch 8 is developed in one, so
+# that was on the path of every push. Two separate failures, one of which is
+# silent:
+#
+#   (a) LOUD.  Poetry names a project's virtualenv from a hash of the PROJECT
+#       PATH.  A worktree is a different path, so `poetry run` there does not
+#       find the populated venv -- it CREATES a fresh empty one and dies on
+#       ModuleNotFoundError: pytest, leaving an orphan venv behind (these have
+#       reached tens of GB).
+#
+#   (b) SILENT, and the one that matters.  Even once pytest runs, the main
+#       venv's editable install is a plain path entry (`exozippy.pth`)
+#       pointing at the SHARED checkout's src.  So the suite imports the OTHER
+#       tree's code and passes -- a green hook that proves nothing about what
+#       you are pushing.
+#
+# Setting PYTHONPATH fixes (b) because a PYTHONPATH entry precedes site
+# processing in sys.path, so it wins over the .pth (verified: with a fake
+# package on PYTHONPATH, `import exozippy` resolves to the fake). This holds
+# because the editable install is a path entry and NOT an `__editable__`
+# meta-path finder -- a finder would be consulted before sys.path and would
+# beat PYTHONPATH. If a future `poetry install` starts emitting a finder
+# instead, this script stops being sufficient and the hook must switch to
+# installing into the tree it is testing.
+#
+# The design rule: resolve the interpreter and the source root OURSELVES, from
+# git, so the hook tests the tree it was launched from BY CONSTRUCTION rather
+# than by the caller remembering to export something. The two rejected
+# alternatives are recorded in docs/testing.md.
+#
+# NOTE: the hook tests the WORKING TREE, not the commits being pushed. That is
+# unchanged by this script and is documented in docs/testing.md.
+#
+# Usage: normally invoked by the hook with no arguments. Any arguments are
+# forwarded to pytest. Set EXOZIPPY_PREPUSH_DRYRUN=1 to print what it resolved
+# and exit without running the suite (this is what tests/test_pre_push_hook.py
+# exercises). Set EXOZIPPY_VENV_PYTHON to name the interpreter explicitly and
+# skip the poetry lookup.
+
+set -euo pipefail
+
+# The tree being pushed from -- and therefore the src/ the suite must import.
+root="$(git rev-parse --show-toplevel)"
+
+# The main checkout, which is where the populated poetry venv lives. In the
+# main tree `--git-common-dir` is the relative ".git"; in a worktree it is an
+# absolute path to the main tree's .git. Resolving relative-to-root handles
+# both, and in the main tree it lands back on root itself.
+common="$(git rev-parse --git-common-dir)"
+case "$common" in
+    /*) ;;
+    *) common="$root/$common" ;;
+esac
+main="$(dirname "$(cd "$common" && pwd)")"
+
+# Resolve the interpreter. EXOZIPPY_VENV_PYTHON is the escape hatch for an
+# environment poetry cannot describe (conda, a hand-built venv, CI).
+if [ -n "${EXOZIPPY_VENV_PYTHON:-}" ]; then
+    py="$EXOZIPPY_VENV_PYTHON"
+    py_source="EXOZIPPY_VENV_PYTHON"
+else
+    # Ask poetry from the MAIN tree, never from here: asked from a worktree it
+    # answers with the empty venv it would create -- failure (a) above.
+    py="$(cd "$main" && poetry env info --executable 2>/dev/null || true)"
+    py_source="poetry env info --executable (from $main)"
+fi
+
+if [ -z "$py" ] || [ ! -x "$py" ]; then
+    echo "pre-push: cannot find the project interpreter." >&2
+    echo "  tried: $py_source" >&2
+    echo "  Run 'poetry install' in $main, or set EXOZIPPY_VENV_PYTHON to an" >&2
+    echo "  interpreter that has this project's dependencies." >&2
+    exit 1
+fi
+
+# Fail here rather than inside pytest, so the message names the cause. This is
+# the exact symptom failure (a) produced, and it deserves better than a
+# ModuleNotFoundError traceback.
+if ! "$py" -c "import pytest" >/dev/null 2>&1; then
+    echo "pre-push: $py has no pytest installed." >&2
+    echo "  resolved via: $py_source" >&2
+    echo "  Run 'poetry install' in $main." >&2
+    exit 1
+fi
+
+# REPLACE rather than prepend. The suite must import exactly two things: this
+# tree's src, and the venv's dependencies. A third source of modules is a
+# reproducibility hazard, and an inherited PYTHONPATH is usually junk -- the
+# development box's real one carries an EMPTY entry (which puts the current
+# directory on sys.path) and five copies of an unrelated conda lib dir. What
+# was discarded is printed rather than dropped silently.
+discarded="${PYTHONPATH:-}"
+export PYTHONPATH="$root/src"
+
+# Print the resolution. The bug this script fixes was a hook that passed while
+# testing the wrong code, so what it tested must be visible rather than
+# inferred.
+echo "pre-push: testing tree   $root"
+echo "pre-push: interpreter    $py"
+echo "pre-push: PYTHONPATH     $PYTHONPATH"
+if [ -n "$discarded" ]; then
+    echo "pre-push: discarded inherited PYTHONPATH ($discarded)"
+fi
+
+if [ -n "${EXOZIPPY_PREPUSH_DRYRUN:-}" ]; then
+    echo "pre-push: dry run, not running the suite"
+    exit 0
+fi
+
+cd "$root"
+exec "$py" -m pytest "$@"

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -1,0 +1,187 @@
+"""Tests for the pre-push hook's entry point (scripts/pre_push_suite.sh).
+
+The hook's old entry, `poetry run pytest`, had two failure modes from a git
+worktree, and only one of them was loud. The loud one (poetry builds a fresh
+empty venv, pytest is absent) announces itself. The other does not: the main
+venv's editable install is a path entry pointing at the SHARED checkout's src,
+so the suite imports the OTHER tree's code and reports green.
+
+So the property worth pinning is not that the script runs -- it is that the
+src it puts on the import path belongs to the tree the push was launched from.
+A test that only checked "the script exits 0" would have passed against the
+bug it exists to prevent.
+
+The script is exercised through EXOZIPPY_PREPUSH_DRYRUN, which resolves
+everything and prints it without spending the suite's runtime on itself.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "pre_push_suite.sh"
+
+
+def _git(cwd, *args):
+    """Run a git command, failing the test loudly on a nonzero exit."""
+    subprocess.run(
+        ("git",) + args, cwd=str(cwd), check=True, capture_output=True
+    )
+
+
+def _run_script(cwd):
+    """Run the hook script in dry-run mode from cwd; return its stdout.
+
+    EXOZIPPY_VENV_PYTHON short-circuits the poetry lookup: this test is about
+    the source root the script chooses, and the running interpreter is a
+    perfectly good stand-in for the project venv (it has pytest, which is how
+    this test is executing).
+    """
+    env = dict(os.environ)
+    env["EXOZIPPY_PREPUSH_DRYRUN"] = "1"
+    env["EXOZIPPY_VENV_PYTHON"] = sys.executable
+    # A deliberately hostile inherited value: the empty entry is what puts the
+    # current directory on sys.path, and it is present in real shells here.
+    env["PYTHONPATH"] = ":/nonexistent/inherited"
+    done = subprocess.run(
+        [str(SCRIPT)], cwd=str(cwd), env=env, capture_output=True, text=True
+    )
+    assert done.returncode == 0, done.stderr
+    return done.stdout
+
+
+def _pythonpath_line(stdout):
+    """Extract the single PYTHONPATH value the script exported."""
+    for line in stdout.splitlines():
+        if line.startswith("pre-push: PYTHONPATH"):
+            return line.split(None, 2)[2].strip()
+    pytest.fail(f"script printed no PYTHONPATH line:\n{stdout}")
+
+
+@pytest.fixture
+def repo_with_worktree(tmp_path):
+    """A throwaway repo with a src/ dir and one linked worktree.
+
+    Built from scratch rather than against the real checkout so the test never
+    touches the project's own worktree list.
+    """
+    main = tmp_path / "main"
+    (main / "src").mkdir(parents=True)
+    _git(tmp_path, "init", "-q", "-b", "master", str(main))
+    (main / "src" / "marker.txt").write_text("main tree\n")
+    _git(main, "-c", "user.email=t@t", "-c", "user.name=t", "add", "-A")
+    _git(
+        main,
+        "-c",
+        "user.email=t@t",
+        "-c",
+        "user.name=t",
+        "commit",
+        "-qm",
+        "initial",
+    )
+
+    linked = tmp_path / "linked"
+    _git(main, "worktree", "add", "-q", "-b", "topic", str(linked))
+    (linked / "src").mkdir(exist_ok=True)
+    return main, linked
+
+
+def test_a_worktree_gets_its_own_src_on_the_import_path(repo_with_worktree):
+    """Given a push launched from a linked git worktree,
+    When the hook resolves the suite's import path,
+    Then it is the WORKTREE's src, not the main checkout's.
+
+    This is the silent half of the bug: the old entry left the main venv's
+    editable path entry in charge, so the suite tested the shared checkout and
+    reported green on code that was never run."""
+    # Arrange
+    main, linked = repo_with_worktree
+
+    # Act
+    pythonpath = _pythonpath_line(_run_script(linked))
+
+    # Assert
+    assert pythonpath == str(linked / "src")
+    assert str(main / "src") not in pythonpath
+
+
+def test_the_main_tree_still_resolves_to_itself(repo_with_worktree):
+    """Given a push launched from the main checkout,
+    When the hook resolves the suite's import path,
+    Then it is that checkout's src.
+
+    Worth its own case because git reports --git-common-dir as the RELATIVE
+    ".git" here and as an absolute path from a worktree; a fix that handled
+    only the absolute form would break the ordinary push."""
+    # Arrange
+    main, _linked = repo_with_worktree
+
+    # Act
+    pythonpath = _pythonpath_line(_run_script(main))
+
+    # Assert
+    assert pythonpath == str(main / "src")
+
+
+def test_an_inherited_pythonpath_is_discarded_and_reported(repo_with_worktree):
+    """Given an inherited PYTHONPATH in the environment,
+    When the hook runs,
+    Then it is replaced, and the replacement is announced.
+
+    The suite must import exactly this tree's src plus the venv, so a third
+    module source is dropped -- but dropping it silently would be the same
+    class of defect as the one being fixed, so the script says what it did."""
+    # Arrange
+    _main, linked = repo_with_worktree
+
+    # Act
+    stdout = _run_script(linked)
+
+    # Assert
+    assert _pythonpath_line(stdout) == str(linked / "src")
+    assert "/nonexistent/inherited" not in _pythonpath_line(stdout)
+    assert "discarded inherited PYTHONPATH" in stdout
+
+
+def test_a_missing_interpreter_fails_with_an_actionable_message(tmp_path):
+    """Given an interpreter that does not exist,
+    When the hook runs,
+    Then it exits nonzero naming both the lookup it tried and the fix.
+
+    The old entry's failure was a bare ModuleNotFoundError traceback from
+    inside pytest, which names neither."""
+    # Arrange
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "-q", "-b", "master", str(repo))
+    env = dict(os.environ)
+    env["EXOZIPPY_VENV_PYTHON"] = str(tmp_path / "no_such_python")
+
+    # Act
+    done = subprocess.run(
+        [str(SCRIPT)], cwd=str(repo), env=env, capture_output=True, text=True
+    )
+
+    # Assert
+    assert done.returncode != 0
+    assert "EXOZIPPY_VENV_PYTHON" in done.stderr
+    assert "poetry install" in done.stderr
+
+
+def test_the_hook_entry_points_at_this_script():
+    """Given .pre-commit-config.yaml,
+    When the pre-push hook's entry is read,
+    Then it is this script and not `poetry run pytest`.
+
+    Pins the wiring, not the script: the reasoning above is worthless if the
+    config drifts back to the spelling that cannot work in a worktree."""
+    # Arrange
+    config = (SCRIPT.parents[1] / ".pre-commit-config.yaml").read_text()
+
+    # Act / Assert
+    assert "entry: scripts/pre_push_suite.sh" in config
+    assert "entry: poetry run pytest" not in config

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -25,10 +25,37 @@ import pytest
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "pre_push_suite.sh"
 
 
+def _clean_env():
+    """os.environ with every GIT_* variable removed, plus hermetic git config.
+
+    This matters, and it is not defensive boilerplate. These tests run inside
+    the very pre-push hook this script implements, and a git hook exports
+    GIT_DIR (and friends) into its children. Inherited, they point every `git`
+    call below -- and the script's own `git rev-parse` -- at the REAL
+    repository instead of the throwaway one built in tmp_path. Observed
+    without this: the fixture's `git commit` fails against the real index. The
+    dangerous version is the one where it SUCCEEDS, because then the
+    assertions pass while describing the wrong tree -- which is exactly the
+    silent wrong-tree defect this whole file exists to pin.
+
+    GIT_CONFIG_GLOBAL/SYSTEM point at os.devnull (git >= 2.32) so a runner's
+    global config -- a commit template, gpgsign, hooksPath -- cannot reach
+    into the temp repo either.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    return env
+
+
 def _git(cwd, *args):
     """Run a git command, failing the test loudly on a nonzero exit."""
     subprocess.run(
-        ("git",) + args, cwd=str(cwd), check=True, capture_output=True
+        ("git",) + args,
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        env=_clean_env(),
     )
 
 
@@ -40,7 +67,7 @@ def _run_script(cwd):
     perfectly good stand-in for the project venv (it has pytest, which is how
     this test is executing).
     """
-    env = dict(os.environ)
+    env = _clean_env()
     env["EXOZIPPY_PREPUSH_DRYRUN"] = "1"
     env["EXOZIPPY_VENV_PYTHON"] = sys.executable
     # A deliberately hostile inherited value: the empty entry is what puts the
@@ -147,6 +174,30 @@ def test_an_inherited_pythonpath_is_discarded_and_reported(repo_with_worktree):
     assert "discarded inherited PYTHONPATH" in stdout
 
 
+def test_these_tests_are_immune_to_an_inherited_git_dir(
+    repo_with_worktree, monkeypatch
+):
+    """Given GIT_DIR in the environment, as a git hook exports it,
+    When the worktree case runs,
+    Then it still describes the temp worktree.
+
+    Not a test of the script -- a test of this file. These tests execute
+    INSIDE the pre-push hook, where GIT_DIR is set, and without scrubbing it
+    the temp repo's git commands and the script's own `git rev-parse` both
+    retarget at the real checkout. That failed loudly here; the version worth
+    guarding against is the one that passes while measuring the wrong tree."""
+    # Arrange
+    main, linked = repo_with_worktree
+    monkeypatch.setenv("GIT_DIR", str(main / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(main))
+
+    # Act
+    pythonpath = _pythonpath_line(_run_script(linked))
+
+    # Assert
+    assert pythonpath == str(linked / "src")
+
+
 def test_a_missing_interpreter_fails_with_an_actionable_message(tmp_path):
     """Given an interpreter that does not exist,
     When the hook runs,
@@ -158,7 +209,7 @@ def test_a_missing_interpreter_fails_with_an_actionable_message(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(tmp_path, "init", "-q", "-b", "master", str(repo))
-    env = dict(os.environ)
+    env = _clean_env()
     env["EXOZIPPY_VENV_PYTHON"] = str(tmp_path / "no_such_python")
 
     # Act


### PR DESCRIPTION
Closes review item 2.15.1 (`notes/code_review_20260824.txt`).

## The problem

`entry: poetry run pytest` cannot work from a git worktree, and every batch of work since batch 8 is developed in one -- so this was on the path of every push. Two failures, and only one of them is loud:

- **Loud.** Poetry names a project's virtualenv from a hash of the project *path*. A worktree is a different path, so `poetry run` there does not find the populated venv; it creates a fresh empty one and dies on `ModuleNotFoundError: pytest`, leaving orphan venvs behind (these have reached tens of GB).
- **Silent, and the one that matters.** Even once pytest runs, the main venv's editable install is a plain path entry (`exozippy.pth`) pointing at the *shared* checkout's `src`. So the suite imports the other tree's code and reports green -- a hook that proves nothing about what is being pushed.

## The fix

`scripts/pre_push_suite.sh` resolves the interpreter and exports `PYTHONPATH=<this tree>/src` itself, so the hook tests the tree it was launched from **by construction** rather than by the caller remembering to export something.

A `PYTHONPATH` entry precedes site processing in `sys.path`, so it wins over the `.pth` -- verified directly, and the script's header records that this holds only because the editable install is a path entry and *not* an `__editable__` meta-path finder (a finder is consulted before `sys.path` and would beat `PYTHONPATH`).

`PYTHONPATH` is **replaced** rather than prepended: the suite must import exactly this tree's `src` plus the venv, and the real inherited value on the development box carries an empty entry (which puts the CWD on `sys.path`) plus five copies of an unrelated conda lib dir. What was discarded is printed rather than dropped silently.

## Validation

Validated end to end by using it: its own first push ran the full suite from inside the worktree against the worktree's `src` (3239 passed, 10:19) -- and **blocked the push**, because three of the new tests errored under a real hook run while passing standalone.

That second commit is the interesting one. A git hook exports `GIT_DIR`/`GIT_WORK_TREE` into its children, so the throwaway repo's git commands -- and the script's own `git rev-parse` -- retargeted at the real repository instead of `tmp_path`. It failed loudly, which was luck: had it succeeded, the assertions would have passed while describing the wrong tree, i.e. the test would have reproduced the exact defect it exists to pin. `_clean_env()` strips every `GIT_*` and points `GIT_CONFIG_GLOBAL/SYSTEM` at `os.devnull`; a sixth test sets `GIT_DIR` deliberately and asserts immunity.

## Tests

`tests/test_pre_push_hook.py` pins the property that actually broke -- the `src` on the import path belongs to the launching tree -- in both the worktree case and the main-tree case (git reports `--git-common-dir` relative in one and absolute in the other, so a fix handling only the absolute form would break the ordinary push), plus the discard reporting, the failure message, the config wiring, and the `GIT_*` immunity above.

## Docs

`docs/testing.md` gains a section covering the reasoning, the two knobs (`EXOZIPPY_VENV_PYTHON`, `EXOZIPPY_PREPUSH_DRYRUN`), the two rejected alternatives (`POETRY_VIRTUALENVS_CREATE=false` fixes only the loud half; a per-worktree symlink is invisible, and the failure mode is a green hook), and the two properties this did **not** change: the hook tests the working tree rather than the pushed commits, and pre-commit's stash must not be interrupted mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)